### PR TITLE
Stop renewing lock for failed jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -270,6 +270,7 @@ Queue.prototype.processJob = function(job){
     var promise = job.failed(err);
     promise.then(function(){
       job.releaseLock(_this.token).then(function(){
+        clearTimeout(lockRenewTimeout);
         _this.processing = false;
         _this.emit('failed', job, err);
       });


### PR DESCRIPTION
When a job fails, the timer keeps spinning infinitely.
