### PR TITLE
Added _updated and _error attributes to jobs.

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -17,6 +17,8 @@ var Job = function(queue, jobId, data, opts){
   this.data = data;
   this.opts = opts;
   this._progress = 0;
+  this._updated = Date.now();
+  this._error = '';
 }
 
 Job.create = function(queue, jobId, data, opts){
@@ -40,7 +42,9 @@ Job.prototype.toData = function(){
   return {
     data: JSON.stringify(this.data || {}),
     opts: JSON.stringify(this.opts || {}),
-    progress: this._progress
+    progress: this._progress,
+    updated: this._updated,
+    error: this._error
   }
 }
 
@@ -53,6 +57,11 @@ Job.prototype.progress = function(progress){
   }else{
     return this._progress;
   }
+}
+
+Job.prototype.refreshUpdated = function(){
+  this._updated = Date.now();
+  return this.queue.client.hsetAsync(this.queue.toKey(this.jobId), 'updated', this._updated);
 }
 
 /**
@@ -94,7 +103,7 @@ Job.prototype.releaseLock = function(token){
     'else',
     'return 0',
     'end'].join('\n');
-    
+
   return this.queue.client.evalAsync(script, 1, this.lockKey(), token).then(function(result){
     return result === 1;
   });
@@ -105,7 +114,7 @@ Job.prototype.completed = function(){
 }
 
 Job.prototype.failed = function(err){
-  return this._done('failed');
+  return this._done('failed', err);
 }
 
 Job.prototype.isCompleted = function(){
@@ -131,6 +140,24 @@ Job.prototype.remove = function(){
     .execAsync();
 }
 
+/**
+  Move a job back to the wait queue, effectively retrying it
+*/
+Job.prototype.retry = function(){
+  var queue = this.queue;
+  this._updated = Date.now();
+  this._error = '';
+  return queue.multi()
+    .lrem(queue.toKey('active'), 0, this.jobId)
+    .lrem(queue.toKey('paused'), 0, this.jobId)
+    .srem(queue.toKey('completed'), this.jobId)
+    .srem(queue.toKey('failed'), this.jobId)
+    .lpush(queue.toKey('wait'), this.jobId)
+    .hset(queue.toKey(this.jobId), 'updated', this._updated)
+    .hset(queue.toKey(this.jobId), 'error', this._error)
+    .execAsync();
+}
+
 // -----------------------------------------------------------------------------
 // Private methods
 // -----------------------------------------------------------------------------
@@ -141,14 +168,18 @@ Job.prototype._isDone = function(list){
   });
 }
 
-Job.prototype._done = function(list){
+Job.prototype._done = function(list, err){
   var queue = this.queue;
   var activeList = queue.toKey('active');
   var completedList = queue.toKey(list);
-  
+
   var multi = queue.multi();
-    
+  this._updated = Date.now();
+  this._error = err ? err.message : '';
+
   return multi
+    .hset(queue.toKey(this.jobId), 'updated', this._updated)
+    .hset(queue.toKey(this.jobId), 'error', this._error)
     .lrem(activeList, 0, this.jobId)
     .sadd(completedList, this.jobId)
     .execAsync();
@@ -158,7 +189,9 @@ Job.prototype._done = function(list){
 */
 Job.fromData = function(queue, jobId, data){
   var job = new Job(queue, jobId, JSON.parse(data.data), data.opts);
-  job._progress = parseInt(data.progress);
+  job._progress = parseInt(data.progress, 10);
+  job._updated = parseInt(data.updated, 10);
+  job._error = data.error;
   return job;
 }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -10,7 +10,7 @@ var sequence = require('when/sequence');
 
 /**
   Gets or creates a new Queue with the given name.
-  
+
   The Queue keeps 4 data structures:
     - wait (list)
     - active (list)
@@ -18,7 +18,7 @@ var sequence = require('when/sequence');
     - failed (a set)
                            - >completed
                           /
-    job -> wait -> active 
+    job -> wait -> active
                           \
                            - > failed
 */
@@ -29,7 +29,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   if(!this){
     return new Queue(name, redisPort, redisHost, redisOptions);
   }
-  
+
   var redisDB = 0;
   if(_.isObject(redisPort)){
     var opts = redisPort;
@@ -37,27 +37,28 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisPort = redisOpts.port || 6379;
     redisHost = redisOpts.host || '127.0.0.1';
     redisOptions = redisOpts.opts || {};
-    redisDB = redisOpts.DB;    
+    redisDB = redisOpts.DB;
   }
-  
+
   this.name = name;
   this.client = redis.createClient(redisPort, redisHost, redisOptions);
   this.bclient = redis.createClient(redisPort, redisHost, redisOptions);
-    
+
   this.paused = false;
-  
+
   this.token = uuid();
   this.LOCK_RENEW_TIME = LOCK_RENEW_TIME;
-  
+
   // Promisify some redis client methods
   var _this = this;
   var methods = [
-    'lrange', 
+    'lrange',
     'sismember',
     'set',
     'eval',
     'incr',
     'lpush',
+    'rpush',
     'hset',
     'hmset',
     'smembers',
@@ -67,9 +68,9 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   methods.forEach(function(method){
     _this.client[method+'Async'] = Promise.promisify(_this.client[method]);
   });
-  
+
   this.bclient.brpoplpushAsync = Promise.promisify(this.bclient.BRPOPLPUSH);
-  
+
   this.client.select(redisDB, function(err){
     _this.bclient.select(redisDB, function(err){
       _this.emit('ready');
@@ -87,7 +88,7 @@ Queue.prototype.close = function(){
 /**
   Processes a job from the queue. The callback is called for every job that
   is dequeued.
-  
+
   @method process
 */
 Queue.prototype.process = function(handler){
@@ -96,7 +97,7 @@ Queue.prototype.process = function(handler){
   this.run().catch(function(err){
     console.log(err);
   });
-  
+
   this.handler = handler;
 };
 
@@ -115,13 +116,15 @@ interface JobOptions
 */
 Queue.prototype.add = function(data, opts){
   var _this = this;
-  
+  opts = opts || {};
+
   // If we fail after incrementing the job id we may end having an unused
   // id, but this should not be so harmful
   return _this.client.incrAsync(this.toKey('id')).then(function(jobId){
     return Job.create(_this, jobId, data, opts).then(function(job){
       var key = _this.toKey('wait');
-      return _this.client.lpushAsync(key, jobId).then(function(){
+      // if queue is LIFO use rpushAsync
+      return _this.client[(opts.lifo ? 'r' : 'l') + 'pushAsync'](key, jobId).then(function(){
         return job;
       });
     });
@@ -144,26 +147,26 @@ Queue.prototype.count = function(){
 
 /**
   Empties the queue.
-  
+
   Returns a promise that is resolved after the operation has been completed.
   Note that if some other process is adding jobs at the same time as emptying,
   the queues may not be really empty after this method has executed completely.
   Also, if the method does error between emptying the lists and removing all the
   jobs, there will be zombie jobs left in redis.
-  
+
   TODO: Use EVAL to make this operation fully atomic.
 */
 Queue.prototype.empty = function(){
   var _this = this;
-  
+
   // Get all jobids and empty all lists atomically.
   var multi = this.multi();
-  
+
   multi.lrange(this.toKey('wait'), 0, -1);
   multi.lrange(this.toKey('paused'), 0, -1);
   multi.del(this.toKey('wait'));
   multi.del(this.toKey('paused'));
-  
+
   return multi.execAsync().then(function(res){
     var waiting = res[0];
     var paused = res[1];
@@ -171,24 +174,24 @@ Queue.prototype.empty = function(){
     var jobKeys = _.map(waiting, function(jobId){
       return _this.toKey(jobId);
     });
-    
+
     jobKeys = jobKeys.concat(_.map(paused, function(jobId){
       return _this.toKey(jobId);
     }));
 
     if(jobKeys.length){
       var multi = _this.multi();
-  
+
       multi.del.apply(multi, jobKeys);
       return multi.execAsync();
-    }  
+    }
   });
 }
 
 /**
   Pauses the processing of this queue.
   TODO: This pause only pauses the current queue instance, it is not
-  good enough, we need to pause all instances. It should be great if RENAME can 
+  good enough, we need to pause all instances. It should be great if RENAME can
   be used for this. So when pausing we just rename the wait queue to paused.
   BRPOPLPUSH still blocks even when a key does not exist, so it will block
   until the paused key is renamed to wait. The problem is when adding
@@ -198,7 +201,7 @@ Queue.prototype.empty = function(){
 */
 Queue.prototype.pause = function(){
   if(this.paused) return this.paused;
-  
+
   var _this = this;
 
   this.paused = new Promise(function(resolve, reject){
@@ -212,7 +215,7 @@ Queue.prototype.pause = function(){
       resolve();
     }
   });
-  
+
   return this.paused;
 }
 
@@ -272,7 +275,7 @@ Queue.prototype.processStalledJob = function(job){
 
 Queue.prototype.processJobs = function(){
   var _this = this;
-  
+
   return this.getNextJob().then(function(job){
     return _this.processJob(job);
   }).then(function(){
@@ -294,6 +297,10 @@ Queue.prototype.processJob = function(job){
 
   if(!this.paused){
     this.processing = true;
+
+    // updated tracks the last time the job moved to a different state
+    job.refreshUpdated();
+
     try{
       lockRenewer();
       _this.handler(job, function(err, data){
@@ -353,7 +360,7 @@ Queue.prototype.multi = function(){
 
 /**
   Atomically moves a job from one list to another.
-  
+
   @method moveJob
 */
 Queue.prototype.moveJob = function(src, dst){
@@ -361,31 +368,39 @@ Queue.prototype.moveJob = function(src, dst){
 }
 
 Queue.prototype.getWaiting = function(start, end){
-  return this.getJobs('wait');
+  return this.getJobs('wait', true);
 }
 
 Queue.prototype.getActive = function(start, end){
-  return this.getJobs('active');
+  return this.getJobs('active', true);
 }
 
-Queue.prototype.getCompleted = function(start, end){
+Queue.prototype.getCompleted = function(){
   return this.getJobs('completed');
 }
 
-Queue.prototype.getFailed = function(start, end){
+Queue.prototype.getFailed = function(){
   return this.getJobs('failed');
 }
 
-Queue.prototype.getJobs = function(queueType, start, end){
+Queue.prototype.getJobs = function(queueType, isList, start, end){
   var _this = this;
-  
+
   start = _.isUndefined(start) ? 0 : start;
   end = _.isUndefined(end) ? -1 : end;
-  
-  var key = this.toKey(queueType);
-  //this.client.lrange(key, start, end, function(err, jobIds){
 
-  return this.client.smembersAsync(key).then(function(jobIds){
+  var key = this.toKey(queueType);
+  var jobs;
+  if(isList){
+    start = _.isUndefined(start) ? 0 : start;
+    end = _.isUndefined(end) ? -1 : end;
+
+    jobs = this.client.lrangeAsync(key, start, end);
+  }else{
+    jobs = this.client.smembersAsync(key);
+  }
+
+  return jobs.then(function(jobIds){
     if(jobIds.length){
       return Promise.all(_.map(jobIds, function(jobId){
         return Job.fromId(_this, jobId);
@@ -399,3 +414,4 @@ Queue.prototype.toKey = function(queueType){
 }
 
 module.exports = Queue;
+Queue.Job = Job;


### PR DESCRIPTION
Hey Manuel,

We're working on a small web interface to admin bull jobs (like kue). It will be a totally independent module so bull code can stay minimal. We just need a few more things in bull:
- `job._updated`: last time the job was moved to a different state.
- `job._error`: error message of failed jobs
- `job.retry()`: move the job back to the "wait" queue.
