### PR TITLE
Implement getJob(jobId) helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,24 @@ __Arguments__
 
 ---------------------------------------
 
+<a name="getJob"/>
+#### Queue##getJob(jobId)
+
+Returns a promise that will return the job instance associated with the `jobId`
+parameter. If the specified job cannot be located, the promise callback parameter
+will be set to `null`.
+
+__Arguments__
+
+```javascript
+  jobId {String} A string identifying the ID of the to look up.
+  returns {Promise} A promise that resolves with the job instance when the job
+  has been retrieved to the queue, or null otherwise.
+```
+
+---------------------------------------
+
+
 <a name="job"/>
 ### Job
 
@@ -354,4 +372,3 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -381,6 +381,10 @@ Queue.prototype.moveJob = function(src, dst){
   return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst), 0);
 }
 
+Queue.prototype.getJob = function(jobId){
+  return Job.fromId(this, jobId);
+}
+
 Queue.prototype.getWaiting = function(start, end){
   return this.getJobs('wait', true);
 }
@@ -408,12 +412,12 @@ Queue.prototype.getJobs = function(queueType, isList, start, end){
   if(isList){
     start = _.isUndefined(start) ? 0 : start;
     end = _.isUndefined(end) ? -1 : end;
-    
+
     jobs = this.client.lrangeAsync(key, start, end);
   }else{
     jobs = this.client.smembersAsync(key);
-  }  
-  
+  }
+
   return jobs.then(function(jobIds){
     if(jobIds.length){
       return Promise.all(_.map(jobIds, function(jobId){

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -70,7 +70,7 @@ describe('Queue', function(){
       done(err);
     });
   });
-  
+
   it('should recover from a connection loss', function(done){
     queue = Queue('test connection loss');
     queue.on('error', function(err){
@@ -153,7 +153,7 @@ describe('Queue', function(){
       queueStalled.add({bar1: 'baz1'}),
       queueStalled.add({bar2: 'baz2'}),
       queueStalled.add({bar3: 'baz3'})];
-      
+
     Promise.all(jobs).then(function(){
       queueStalled.process(function(job){
         // instead of completing we just close the queue to simulate a crash.
@@ -350,7 +350,7 @@ describe('Queue', function(){
     for(var i=1; i<=maxJobs; i++){
       added.push(queue.add({foo: 'bar', num: i}));
     }
-    
+
     Promise.all(added).then(function(){
       queue.count().then(function(count){
         expect(count).to.be(100);
@@ -422,7 +422,7 @@ describe('Queue', function(){
       isresumed = true;
     });
   });
-  
+
   it('process a lifo queue', function(done){
     var currentValue = 0, first = true;
     queue = Queue('test lifo');
@@ -456,7 +456,7 @@ describe('Queue', function(){
       });
     });
   });
-    
+
   describe("Jobs getters", function(){
     it('should get waitting jobs', function(done){
       Promise.join(queue.add({foo: 'bar'}), queue.add({baz: 'qux'})).then(function(){
@@ -469,10 +469,10 @@ describe('Queue', function(){
         })
       });
     });
-    
+
     it('should get active jobs', function(done){
       var counter = 2;
-      
+
       queue.process(function(job, jobDone){
         queue.getActive().then(function(jobs){
           expect(jobs).to.be.a('array');
@@ -482,20 +482,32 @@ describe('Queue', function(){
         });
         jobDone();
       });
-      
+
       queue.add({foo: 'bar'});
     });
-    
+
+    it('should get a specific job', function(done){
+      var data = {foo: 'sup!'}
+
+      queue.add(data).then(function(job) {
+        queue.getJob(job.jobId).then(function(returnedJob) {
+          expect(returnedJob.data).to.eql(data);
+          expect(returnedJob.jobId).to.be(job.jobId);
+          done();
+        })
+      })
+    });
+
     it('should get completed jobs', function(){
       var counter = 2;
-      
+
       queue.process(function(job, jobDone){
         jobDone();
       });
-      
+
       queue.on('completed', function(){
         counter --;
-        
+
         if(counter === 0){
           queue.getCompleted().then(function(jobs){
             expect(jobs).to.be.a('array');
@@ -505,21 +517,21 @@ describe('Queue', function(){
           });
         }
       });
-      
+
       queue.add({foo: 'bar'});
       queue.add({baz: 'qux'});
     });
-    
+
     it('should get failed jobs', function(done){
       var counter = 2;
-      
+
       queue.process(function(job, jobDone){
         jobDone(Error("Forced error"));
       });
-      
+
       queue.on('failed', function(){
         counter --;
-        
+
         if(counter === 0){
           queue.getFailed().then(function(jobs){
             expect(jobs).to.be.a('array');
@@ -527,9 +539,12 @@ describe('Queue', function(){
           });
         }
       });
-      
+
       queue.add({foo: 'bar'});
       queue.add({baz: 'qux'});
     });
+
+
+
   });
 });


### PR DESCRIPTION
- Provide a convenient helper to retrieve a job by ID
  - `queue.getJob(jobId).then(function(job) {});`
- Added unit test and documentation for new helper.
