### PR TITLE
Ability to retry failed jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -25,9 +25,13 @@ var sequence = require('when/sequence');
 
 var LOCK_RENEW_TIME = 5000; // 5 seconds is the renew time.
 
-var Queue = function Queue(name, redisPort, redisHost, redisOptions){
+var Queue = function Queue(name, redisPort, redisHost, redisOptions, queueOptions){
+  if(_.isPlainObject(name)){
+    return new Queue(name.name, name.redisPort, name.redisHost, name.redisOptions, name);
+  }
+
   if(!this){
-    return new Queue(name, redisPort, redisHost, redisOptions);
+    return new Queue(name, redisPort, redisHost, redisOptions, queueOptions);
   }
 
   var redisDB = 0;
@@ -43,6 +47,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   this.name = name;
   this.client = redis.createClient(redisPort, redisHost, redisOptions);
   this.bclient = redis.createClient(redisPort, redisHost, redisOptions);
+  this.options = queueOptions || {};
 
   this.paused = false;
 
@@ -253,8 +258,28 @@ Queue.prototype.resume = function(){
 
 Queue.prototype.run = function(){
   var _this = this;
-  return this.processStalledJobs().then(function(){
+
+  var chain = this.processStalledJobs();
+
+  if(this.options.runFailedOnStart){
+    var failed = _.bind(this.processFailedJobs, _this);
+
+    chain = chain.then(failed);
+  }
+
+  return chain.then(function(){
     return _this.processJobs();
+  });
+}
+
+Queue.prototype.processFailedJobs = function(){
+  var _this = this;
+
+  return this.getFailed().then(function(jobs){
+    var tasks = _.map(jobs, function(job){
+      return _.bind(_this.processStalledJob, _this, job);
+    });
+    return sequence(tasks);
   });
 }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -25,13 +25,9 @@ var sequence = require('when/sequence');
 
 var LOCK_RENEW_TIME = 5000; // 5 seconds is the renew time.
 
-var Queue = function Queue(name, redisPort, redisHost, redisOptions, queueOptions){
-  if(_.isPlainObject(name)){
-    return new Queue(name.name, name.redisPort, name.redisHost, name.redisOptions, name);
-  }
-
+var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   if(!this){
-    return new Queue(name, redisPort, redisHost, redisOptions, queueOptions);
+    return new Queue(name, redisPort, redisHost, redisOptions);
   }
 
   var redisDB = 0;
@@ -42,12 +38,13 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions, queueOption
     redisHost = redisOpts.host || '127.0.0.1';
     redisOptions = redisOpts.opts || {};
     redisDB = redisOpts.DB;
+    this.options = opts;
   }
 
   this.name = name;
   this.client = redis.createClient(redisPort, redisHost, redisOptions);
   this.bclient = redis.createClient(redisPort, redisHost, redisOptions);
-  this.options = queueOptions || {};
+  this.options = this.options || {};
 
   this.paused = false;
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1,7 +1,18 @@
 var Job = require('../lib/job');
-var Queue = require('../');
+var realQueue = require('../');
 var expect = require('expect.js');
 var Promise = require('bluebird');
+
+var ts = Date.now();
+
+var Queue = function(name){
+  // use fresh queue each test run
+  var name = name + ts;
+
+  arguments[0] = name;
+
+  return realQueue.apply(null, arguments);
+};
 
 var STD_QUEUE_NAME = 'test queue';
 
@@ -167,7 +178,9 @@ describe('Queue', function(){
           })
 
           queue2.on('completed', function(job){
-            done();
+            queue2.getFailed().then(function(jobs){
+              expect(jobs.length).to.be.equal(0);
+            });
           });
         }, 200);
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -173,13 +173,18 @@ describe('Queue', function(){
       queueFailed.process(function(job, jobDone){
         setTimeout(function(){
           var queue2 = Queue('test queue failed', conf);
-          queue2.process(function(job, jobDone){
-            jobDone();
-          })
+          queue2.getFailed().then(function(jobs){
+           expect(jobs.length).to.be.equal(1);
 
-          queue2.on('completed', function(job){
-            queue2.getFailed().then(function(jobs){
-              expect(jobs.length).to.be.equal(0);
+            queue2.process(function(job, jobDone){
+              jobDone();
+            })
+
+            queue2.on('completed', function(job){
+              queue2.getFailed().then(function(jobs){
+                expect(jobs == null).to.be.true;
+                done();
+              });
             });
           });
         }, 200);
@@ -210,15 +215,18 @@ describe('Queue', function(){
         setTimeout(function(){
           var queue2 = Queue('test queue failed 2', conf);
 
-          queue2.process(function(job, jobDone){
-            jobDone();
-          });
+          queue2.getFailed().then(function(jobs){
+             expect(jobs.length).to.be.equal(1);
+              queue2.process(function(job, jobDone){
+                jobDone();
+              });
 
-          queue2.on('completed', function(job){
-            done();
-          });
+              queue2.on('completed', function(job){
+                done();
+              });
 
-          queue2.processFailedJobs();
+              queue2.processFailedJobs();
+          });
         }, 100);
       });
     })

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -147,20 +147,21 @@ describe('Queue', function(){
 
   it('process failed jobs when starting a queue', function(done){
     var conf = {
-      name: 'test queue failed',
-      redisPort: 6379,
-      redisHost: '127.0.0.1',
+      redis: {
+        port: 6379,
+        host: '127.0.0.1'
+      },
       runFailedOnStart: true
     };
 
-    var queueFailed = Queue(conf);
+    var queueFailed = Queue('test queue failed', conf);
     queueFailed.LOCK_RENEW_TIME = 10;
     var jobs = [queueFailed.add({bar: 'baz'})];
 
     Promise.all(jobs).then(function(){
       queueFailed.process(function(job, jobDone){
         setTimeout(function(){
-          var queue2 = Queue(conf);
+          var queue2 = Queue('test queue failed', conf);
           queue2.process(function(job, jobDone){
             jobDone();
           })
@@ -178,12 +179,13 @@ describe('Queue', function(){
 
   it('process failed jobs manually', function(done){
     var conf = {
-      name: 'test queue failed 2',
-      redisPort: 6379,
-      redisHost: '127.0.0.1'
+      redis: {
+        port: 6379,
+        host: '127.0.0.1'
+      }
     };
 
-    var queueFailed = Queue(conf);
+    var queueFailed = Queue('test queue failed 2', conf);
     queueFailed.LOCK_RENEW_TIME = 10;
     var jobs = [queueFailed.add({bar: 'baz'})];
 
@@ -193,7 +195,7 @@ describe('Queue', function(){
         queueFailed.close();
 
         setTimeout(function(){
-          var queue2 = Queue(conf);
+          var queue2 = Queue('test queue failed 2', conf);
 
           queue2.process(function(job, jobDone){
             jobDone();


### PR DESCRIPTION
Introduce object based configuration for queue (optional), which allows you to enable/disable processing failed jobs on start. processFailedJobs() can also be called based on some type of timer/scheduling. Maybe in future bull can handle retry/delay, just not sure of performance/memory implications of bull hanging onto scheduled jobs if problems occur and the list grows.
