### PR TITLE
add a password parameter to the redisOpt hash so we can use heroku addons

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -31,6 +31,8 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   }
 
   var redisDB = 0;
+  var redisPassword = null;
+
   if(_.isObject(redisPort)){
     var opts = redisPort;
     var redisOpts = opts.redis || {};
@@ -38,11 +40,17 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisHost = redisOpts.host || '127.0.0.1';
     redisOptions = redisOpts.opts || {};
     redisDB = redisOpts.DB;
+    redisPassword = redisOpts.password;
   }
 
   this.name = name;
   this.client = redis.createClient(redisPort, redisHost, redisOptions);
   this.bclient = redis.createClient(redisPort, redisHost, redisOptions);
+
+  if(redisPassword) {
+    this.client.auth(redisPassword);
+    this.bclient.auth(redisPassword);
+  }
 
   this.paused = false;
 


### PR DESCRIPTION
This is a simple change so that authenticated redis URLs, like what is used in heroku addons, can be used by bull. I thought about having a factory function but decided an additional value in the hash is better.

BTW it seems that there is no documentation that a hash can be passed as the second parameter in Queue(...), I can also make that change.

I'm not sure the easiest way to add a test for this, either. Open to thoughts.
