### PR TITLE
Add timeout option to queue.add

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ __Arguments__
     to the job processing function in job.opts
   opts.lifo {Boolean} A boolean which, if true, adds the job to the right
     of the queue instead of the left (default false)
+  opts.timeout {Number} The number of milliseconds after which the job
+    should be fail with a timeout error [optional]
   returns {Promise} A promise that resolves when the job has been succesfully
     added to the queue (or rejects if some error occured).
 ```

--- a/lib/job.js
+++ b/lib/job.js
@@ -16,7 +16,7 @@ var Job = function(queue, jobId, data, opts){
   this.queue = queue;
   this.jobId = jobId;
   this.data = data;
-  this.opts = opts;
+  this.opts = opts || {};
   this._progress = 0;
 }
 
@@ -181,7 +181,7 @@ Job.prototype._moveToSet = function(set){
 /**
 */
 Job.fromData = function(queue, jobId, data){
-  var job = new Job(queue, jobId, JSON.parse(data.data), data.opts);
+  var job = new Job(queue, jobId, JSON.parse(data.data), JSON.parse(data.opts));
   job._progress = parseInt(data.progress);
   return job;
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -285,6 +285,7 @@ Queue.prototype.processJob = function(job){
     lockRenewTimeout = setTimeout(lockRenewer, _this.LOCK_RENEW_TIME/2);
   };
   var runHandler = Promise.promisify(this.handler.bind(this));
+  var timeoutMs = job.opts.timeout;
 
   function finishProcessing(){
     clearTimeout(lockRenewTimeout);
@@ -313,10 +314,16 @@ Queue.prototype.processJob = function(job){
     _this.processing = true;
 
     lockRenewer();
-    return runHandler(job)
-        .then(handleCompleted, handleFailed)
-        .then(finishProcessing)
-        .then(resolve, reject);
+    var jobPromise = runHandler(job);
+
+    if(timeoutMs){
+      jobPromise = jobPromise.timeout(timeoutMs);
+    }
+
+    return jobPromise
+      .then(handleCompleted, handleFailed)
+      .then(finishProcessing)
+      .then(resolve, reject);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "when": "~2.1.1"
   },
   "devDependencies": {
-    "mocha": "~1.12",
+    "mocha": "~1.21.4",
     "expect.js": "~0.2.0"
   },
   "scripts": {

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -45,6 +45,8 @@ describe('Job', function(){
         expect(storedJob).to.have.property('data');
 
         expect(storedJob.data.foo).to.be.equal('bar');
+        expect(storedJob.opts).to.be.a(Object);
+        expect(storedJob.opts.testOpt).to.be('enabled');
       });
     });
   });

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -19,180 +19,146 @@ describe('Job', function(){
     });
   });
 
-  it('create', function(done){
-    Job.create(queue, 1, {foo: 'bar'}).then(function(job){
+  describe('.create', function () {
+    var job;
+    var data;
+    var opts;
+
+    beforeEach(function () {
+      data = {foo: 'bar'};
+      opts = {testOpt: 'enabled'};
+
+      return Job.create(queue, 1, data, opts)
+        .then(function(createdJob){
+          job = createdJob
+        });
+    });
+
+    it('returns a promise for the job', function () {
       expect(job).to.have.property('jobId');
       expect(job).to.have.property('data');
+    });
 
-      expect(job.data.foo).to.be.equal('bar');
-
-      Job.fromId(queue, job.jobId).then(function(storedJob){
+    it('saves the job in redis', function () {
+      return Job.fromId(queue, job.jobId).then(function(storedJob){
         expect(storedJob).to.have.property('jobId');
         expect(storedJob).to.have.property('data');
 
         expect(storedJob.data.foo).to.be.equal('bar');
-        done();
-      }, function(err){
-        console.log(err);
-        done(err);
-      })
-    }, function(err){
-      console.log(err);
-      done(err);
+      });
     });
   });
 
-  it('remove', function(done){
-    Job.create(queue, 1, {foo: 'bar'}).then(function(job){
-      expect(job).to.have.property('jobId');
-      expect(job).to.have.property('data');
-
-      expect(job.data.foo).to.be.equal('bar');
-
-      job.remove().then(function(){
-        Job.fromId(queue, job.jobId).then(function(storedJob){
-          expect(storedJob).to.be(null);
-          done();
-        }, function(err){
-          done(err);
-        });
-      }, function(err){
-        done(err);
-      });
-    }, function(err){
-      done(err);
-    });
-  })
-
+  describe('.remove', function () {
+      it('removes the job from redis', function(){
+        return Job.create(queue, 1, {foo: 'bar'})
+          .tap(function(job){
+            return job.remove();
+          })
+          .then(function(job){
+            return Job.fromId(queue, job.jobId)
+          })
+          .then(function(storedJob){
+            expect(storedJob).to.be(null);
+          });
+      })
+  });
 
   describe('Locking', function(){
-    it('take a lock', function(done){
-      Job.create(queue, 1, {foo: 'bar'}).then(function(job){
-        expect(job).to.have.property('jobId');
-        expect(job).to.have.property('data');
+    var id = 0;
+    var job;
 
-        return job.takeLock('123').then(function(lockTaken){
-          expect(lockTaken).to.be(true);
+    beforeEach(function () {
+      id++;
+      return Job.create(queue, id, {foo: 'bar'})
+        .then(function(createdJob){
+          job = createdJob;
         });
-      }).then(done, function(err){
-        console.log(err);
-        done(err);
+    });
+
+    it('can take a lock', function(){
+      return job.takeLock('123').then(function(lockTaken){
+        expect(lockTaken).to.be(true);
       });
     });
 
-    it('take an already taken lock', function(done){
-      Job.create(queue, 2, {foo: 'bar'}).then(function(job){
-        expect(job).to.have.property('jobId');
-        expect(job).to.have.property('data');
-
+    it('cannot take an already taken lock', function(){
+      return job.takeLock('123').then(function(lockTaken){
+        expect(lockTaken).to.be(true);
+      }).then(function(){
         return job.takeLock('123').then(function(lockTaken){
-          expect(lockTaken).to.be(true);
-        }).then(function(){
-          return job.takeLock('123').then(function(lockTaken){
-            expect(lockTaken).to.be(false);
-          });
-        })
-      }).then(done, function(err){
-        console.log(err);
-        done(err);
+          expect(lockTaken).to.be(false);
+        });
       });
     });
 
-    it('renew a taken lock', function(done){
-      Job.create(queue, 3, {foo: 'bar'}).then(function(job){
-        expect(job).to.have.property('jobId');
-        expect(job).to.have.property('data');
-
-        return job.takeLock('123').then(function(lockTaken){
-          expect(lockTaken).to.be(true);
-        }).then(function(){
-          return job.renewLock('123').then(function(lockRenewed){
-            expect(lockRenewed).to.be(true);
-          });
+    it('can renew a previously taken lock', function(){
+      return job.takeLock('123').then(function(lockTaken){
+        expect(lockTaken).to.be(true);
+      }).then(function(){
+        return job.renewLock('123').then(function(lockRenewed){
+          expect(lockRenewed).to.be(true);
         });
-      }).then(done, function(err){
-        console.log(err);
-        done(err);
       });
     });
 
-    it('release a lock', function(done){
-      Job.create(queue, 4, {foo: 'bar'}).then(function(job){
-        expect(job).to.have.property('jobId');
-        expect(job).to.have.property('data');
-
-        return job.takeLock('123').then(function(lockTaken){
-          expect(lockTaken).to.be(true);
-        }).then(function(){
-          return job.releaseLock('321').then(function(lockReleased){
-            expect(lockReleased).to.be(false);
-          });
-        }).then(function(){
-          return job.releaseLock('123').then(function(lockReleased){
-            expect(lockReleased).to.be(true);
-          });
+    it('can release a lock', function(){
+      return job.takeLock('123').then(function(lockTaken){
+        expect(lockTaken).to.be(true);
+      }).then(function(){
+        return job.releaseLock('321').then(function(lockReleased){
+          expect(lockReleased).to.be(false);
         });
-      }).then(done, function(err){
-        console.log(err);
-        done(err);
-      });
-    });
-  })
-
-
-  it('report progress', function(done){
-    Job.create(queue, 2, {foo: 'bar'}).then(function(job){
-      expect(job).to.have.property('jobId');
-      expect(job).to.have.property('data');
-
-      expect(job.data.foo).to.be.equal('bar');
-      expect(job.progress()).to.be(0);
-
-      return job.progress(42).then(function(){
-        return Job.fromId(queue, job.jobId).then(function(storedJob){
-          expect(storedJob.progress()).to.be(42);
-          done();
+      }).then(function(){
+        return job.releaseLock('123').then(function(lockReleased){
+          expect(lockReleased).to.be(true);
         });
       });
-    }, function(err){
-      console.log(err);
-      done(err);
     });
   });
 
-  it('moveToCompleted', function(done){
-    Job.create(queue, 3, {foo: 'bar'}).then(function(job){
-      return job.isCompleted().then(function(isCompleted){
-        expect(isCompleted).to.be(false);
-      }).then(function(){
-        return job.moveToCompleted();
-      }).then(function(){
-        return job.isCompleted().then(function(isCompleted){
-          expect(isCompleted).to.be(true);
-          done();
+  describe('.progress', function () {
+    it('can set and get progress', function () {
+        return Job.create(queue, 2, {foo: 'bar'}).then(function(job){
+          return job.progress(42).then(function(){
+            return Job.fromId(queue, job.jobId).then(function(storedJob){
+              expect(storedJob.progress()).to.be(42);
+            });
+          });
         });
-      });
-    }, function(err){
-      done(err);
     });
   });
 
-  it('moveToFailed', function(done){
-    Job.create(queue, 4, {foo: 'bar'}).then(function(job){
-      return job.isFailed().then(function(isFailed){
-        expect(isFailed).to.be(false);
-      }).then(function(){
-        return job.moveToFailed(Error("test error"));
-      }).then(function(){
-        return job.isFailed().then(function(isFailed){
-          expect(isFailed).to.be(true);
-          done();
+  describe('.moveToCompleted', function () {
+      it('marks the job as completed', function(){
+        return Job.create(queue, 3, {foo: 'bar'}).then(function(job){
+          return job.isCompleted().then(function(isCompleted){
+            expect(isCompleted).to.be(false);
+          }).then(function(){
+            return job.moveToCompleted();
+          }).then(function(){
+            return job.isCompleted().then(function(isCompleted){
+              expect(isCompleted).to.be(true);
+            });
+          });
         });
       });
-    }, function(err){
-      done(err);
-    });
-
   });
+
+  describe('.moveToFailed', function () {
+      it('marks the job as failed', function(){
+        return Job.create(queue, 4, {foo: 'bar'}).then(function(job){
+          return job.isFailed().then(function(isFailed){
+            expect(isFailed).to.be(false);
+          }).then(function(){
+            return job.moveToFailed(Error("test error"));
+          }).then(function(){
+            return job.isFailed().then(function(isFailed){
+              expect(isFailed).to.be(true);
+            });
+          });
+        });
+      });
+  });
+
 });
-

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2,6 +2,7 @@ var Job = require('../lib/job');
 var Queue = require('../');
 var expect = require('expect.js');
 var Promise = require('bluebird');
+var _ = require('lodash');
 
 var STD_QUEUE_NAME = 'test queue';
 
@@ -35,8 +36,8 @@ describe('Queue', function(){
     });
   });
 
-  it('create a queue with standard redis opts', function(done){
-    var queue = Queue('standard');
+  it('creates a queue with standard redis opts', function(done){
+    queue = Queue('standard');
 
     queue.once('ready', function(){
       expect(queue.client.host).to.be('127.0.0.1');
@@ -52,8 +53,8 @@ describe('Queue', function(){
     });
   });
 
-  it('create a queue using custom redis paramters', function(done){
-    var queue = Queue('custom', {redis: {DB: 1}});
+  it('creates a queue using the supplied redis DB', function(done){
+    queue = Queue('custom', {redis: {DB: 1}});
 
     queue.once('ready', function(){
       expect(queue.client.host).to.be('127.0.0.1');
@@ -67,10 +68,10 @@ describe('Queue', function(){
 
       done();
     });
-  })
+  });
 
-  it('create a queue using custom redis paramters 2', function(done){
-    var queue = Queue('custom', {redis: {host: 'localhost'}});
+  it('creates a queue using custom the supplied redis host', function(done){
+    queue = Queue('custom', {redis: {host: 'localhost'}});
 
     queue.once('ready', function(){
       expect(queue.client.host).to.be('localhost');
@@ -78,26 +79,23 @@ describe('Queue', function(){
 
       expect(queue.client.selected_db).to.be(0);
       expect(queue.bclient.selected_db).to.be(0);
-
       done();
     });
-  })
+  });
 
-  it('create a queue with dots in its name', function(done){
-    var queue = Queue('using. dots. in.name.');
+  it('creates a queue with dots in its name', function(){
+    queue = Queue('using. dots. in.name.');
 
-    queue.process(function(job, jobDone){
-      expect(job.data.foo).to.be.equal('bar')
-      jobDone();
-      done();
-    })
-
-    queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok()
-      expect(job.data.foo).to.be('bar')
-    }, function(err){
-      done(err);
-    });
+    return queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok()
+        expect(job.data.foo).to.be('bar')
+      })
+      .then(function(){
+        queue.process(function(job, jobDone){
+          expect(job.data.foo).to.be.equal('bar')
+          jobDone();
+        });
+      });
   });
 
   it('should recover from a connection loss', function(done){
@@ -124,14 +122,12 @@ describe('Queue', function(){
       expect(job.data.foo).to.be.equal('bar')
       jobDone();
       done();
-    })
+    });
 
     queue.add({foo: 'bar'}).then(function(job){
       expect(job.jobId).to.be.ok()
       expect(job.data.foo).to.be('bar')
-    }, function(err){
-      done(err);
-    });
+    }).catch(done);
   });
 
   it('process a job that updates progress', function(done){
@@ -145,9 +141,7 @@ describe('Queue', function(){
     queue.add({foo: 'bar'}).then(function(job){
       expect(job.jobId).to.be.ok()
       expect(job.data.foo).to.be('bar');
-    }, function(err){
-      done(err);
-    });
+    }).catch(done);
 
     queue.on('progress', function(job, progress){
       expect(job).to.be.ok();
@@ -166,9 +160,7 @@ describe('Queue', function(){
     queue.add({foo: 'bar'}).then(function(job){
       expect(job.jobId).to.be.ok()
       expect(job.data.foo).to.be('bar');
-    }, function(err){
-      done(err);
-    });
+    }).catch(done);
 
     queue.on('completed', function(job, data){
       expect(job).to.be.ok();
@@ -184,63 +176,59 @@ describe('Queue', function(){
       queueStalled.add({bar: 'baz'}),
       queueStalled.add({bar1: 'baz1'}),
       queueStalled.add({bar2: 'baz2'}),
-      queueStalled.add({bar3: 'baz3'})];
+      queueStalled.add({bar3: 'baz3'})
+    ];
 
     Promise.all(jobs).then(function(){
       queueStalled.process(function(job){
         // instead of completing we just close the queue to simulate a crash.
         queueStalled.close();
-
         setTimeout(function(){
           var queue2 = Queue('test queue stalled', 6379, '127.0.0.1');
+          var doneAfterFour = _.after(4, function(){
+            done();
+          });
+          queue2.on('completed', doneAfterFour);
+
           queue2.process(function(job, jobDone){
             jobDone();
-          })
-
-          var counter = 0;
-          queue2.on('completed', function(job){
-            counter ++;
-            if(counter === 4) {
-              done();
-            }
           });
         }, 100);
       });
-    })
+    });
   });
 
-  it('process jobs added that were added before queue backend started', function(done){
+  it('processes jobs that were added before the queue backend started', function(){
     var queueStalled = Queue('test queue added before', 6379, '127.0.0.1');
     queueStalled.LOCK_RENEW_TIME = 10;
     var jobs = [
       queueStalled.add({bar: 'baz'}),
       queueStalled.add({bar1: 'baz1'}),
       queueStalled.add({bar2: 'baz2'}),
-      queueStalled.add({bar3: 'baz3'})];
+      queueStalled.add({bar3: 'baz3'})
+    ];
 
-    Promise.all(jobs).then(function(){
-      return queueStalled.close();
-    }).then(function(){
-      var queue = Queue('test queue added before', 6379, '127.0.0.1');
-      queue.process(function(job, jobDone){
-        jobDone();
-      });
+    return Promise.all(jobs)
+      .then(queueStalled.close.bind(queueStalled))
+      .then(function(){
+        queue = Queue('test queue added before', 6379, '127.0.0.1');
+        queue.process(function(job, jobDone){
+          jobDone();
+        });
 
-      var counter = 0;
-      queue.on('completed', function(job){
-        counter ++;
-        if(counter === 4) {
-          done();
-        }
+        return new Promise(function(resolve, reject){
+          var resolveAfterAllJobs = _.after(jobs.length, resolve);
+          queue.on('completed', resolveAfterAllJobs);
+        });
       });
-    })
   });
 
-  it('process several stalled jobs when starting several queues', function(done){
+  it('processes several stalled jobs when starting several queues', function(done){
     var NUM_QUEUES = 10;
     var NUM_JOBS_PER_QUEUE = 20;
     var stalledQueues = [];
     var jobs = [];
+
     for(var i=0; i<NUM_QUEUES; i++){
       var queue = Queue('test queue stalled 2', 6379, '127.0.0.1');
       stalledQueues.push(queue);
@@ -270,7 +258,9 @@ describe('Queue', function(){
               queue2.on('completed', function(job){
                 counter ++;
                 if(counter === NUM_QUEUES * NUM_JOBS_PER_QUEUE) {
-                  done();
+                  queue2.close().then(function(){
+                      done();
+                  });
                 }
               });
             }, 100);
@@ -401,7 +391,7 @@ describe('Queue', function(){
     }
   });
 
-  it('count added, unprocessed jobs', function(done){
+  it('count added, unprocessed jobs', function(){
     var counter = 1;
     var maxJobs = 100;
     var added = [];
@@ -412,18 +402,16 @@ describe('Queue', function(){
       added.push(queue.add({foo: 'bar', num: i}));
     }
 
-    Promise.all(added).then(function(){
-      queue.count().then(function(count){
+    return Promise.all(added)
+      .then(queue.count.bind(queue))
+      .then(function(count){
         expect(count).to.be(100);
-
-        queue.empty().then(function(){
-          queue.count().then(function(count){
-            expect(count).to.be(0);
-            done();
-          });
-        });
+      })
+      .then(queue.empty.bind(queue))
+      .then(queue.count.bind(queue))
+      .then(function(count){
+        expect(count).to.be(0);
       });
-    });
   });
 
   it('add jobs to a paused queue', function(done){

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -550,7 +550,7 @@ describe('Queue', function(){
           expect(returnedJob.data).to.eql(data);
           expect(returnedJob.jobId).to.be(job.jobId);
           done();
-        })
+        });
       })
     });
 
@@ -603,5 +603,26 @@ describe('Queue', function(){
       queue.add({baz: 'qux'});
     });
 
+    it('fails jobs that exceed their specified timeout', function(done){
+      queue = buildQueue();
+
+      queue.process(function(job, jobDone){
+        setTimeout(jobDone, 150);
+      });
+
+      queue.on('failed', function(job, error){
+        expect(error).to.be.a(Promise.TimeoutError);
+        done();
+      });
+
+      queue.on('completed', function(){
+        var error = new Error('The job should have timed out');
+        done(error);
+      });
+
+      queue.add({some: 'data'}, {
+        timeout: 100
+      });
+    });
   });
 });


### PR DESCRIPTION
It lets the user specify a timeout in ms, after which the job should be failed.
Example:
```javascript
queue.add({some: 'data'}, {
    timeout: 100 //if the job takes longer than 100ms, it is failed
});
```
The semantics are as such: if for any reason the job takes too long (e.g. unresponsive API), it is forced into the `failed` set and the queue will process the next job. This should be an anomalous case and more of a safeguard to keep the queue from getting stuck. Users of the queue should know to handle the resulting `'failed'` event - as any event listeners and timeouts set by the job cannot be removed and may eventually be called.
Example
```javascript
function handler(job, done){
    setTimeout(function(){
        bus.emit('ready');
    }, 150);
}
```
In this case, once the job is failed after 100ms, users of the queue may want to remove any listener to a `ready` event or otherwise the application may end up in an inconsistent state. Exactly what needs to be done would depend on the mechanics of the job and possibly on the progress reported.
This may be preferable over the queue being stuck.

This PR also contains an upgrade to mocha, which after version 1.18 supports promises. This is preferable over async (`function(done)`) tests because if an assertion in the test fails, the promise is rejected with the error thrown by the assertion and mocha displays the rejection value as the reason for the failed test. With async tests, the test simply times out because `done()` is never reached and one cannot see why in the console.

Any thoughts on this @manast?
Cheers