### PR TITLE
Move the auto-restart of queue inside process.

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -54,18 +54,10 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
 
   var _this = this;
 
-  var runQueueWhenReady = function(){
-    _this.bclient.once('ready', _this.run.bind(_this));
-  };
-
   // bubble up Redis error events
   [this.client, this.bclient].forEach(function (client) {
     client.on('error', _this.emit.bind(_this, 'error'));
   });
-
-  // attempt to restart the queue when the client throws an error or the connection is dropped by redis
-  this.bclient.on('error', runQueueWhenReady);
-  this.bclient.on('end', runQueueWhenReady);
 
   this.client.select(redisDB, function(err){
     _this.bclient.select(redisDB, function(err){
@@ -99,6 +91,16 @@ Queue.prototype.process = function(handler){
   if(this.handler) throw Error("Cannot define a handler more than once per Queue instance");
 
   this.handler = handler;
+
+  var _this = this;
+
+  var runQueueWhenReady = function(){
+    _this.bclient.once('ready', _this.run.bind(_this));
+  };
+
+  // attempt to restart the queue when the client throws an error or the connection is dropped by redis
+  this.bclient.on('error', runQueueWhenReady);
+  this.bclient.on('end', runQueueWhenReady);
 
   this.run().catch(function(err){
     console.log(err);


### PR DESCRIPTION
Move the auto-restart of queue inside process.
This will prevent calling run() when no handler in case of redis error.
Fix #76 