### PR TITLE
Add priority queue fonctionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Useful patterns
 Bull can also be used for persistent messsage queues. This is a quite useful
 feature in some usecases. For example, you can have two servers that need to
 communicate with each other. By using a queue the servers do not need to be online
-at the same time, this create a very robust communication channel. You can treat 
+at the same time, this create a very robust communication channel. You can treat
 *add* as *send* and *process* as *receive*:
 
 Server A:
@@ -349,6 +349,32 @@ __Arguments__
 
 ---------------------------------------
 
+
+<a name="priorityQueue"/>
+###PriorityQueue(queueName, redisPort, redisHost, [redisOpts])
+
+This is the Queue constructor of priority queue. It works same a normal queue, with same function and parameters.
+The only difference is that the Queue#add() allow an options opts.priority that could take
+["low", "normal", "medium", "hight", "critical"]. If no options provider, "normal" will be taken.
+
+The priority queue will process more often highter priority jobs than lower.
+
+```javascript
+  var PriorityQueue = require("bull/lib/priority-queue");
+
+  var queue = new PriorityQueue("myPriorityQueues");
+
+  queue.add({todo: "Improve feature"}, {priority: "normal"});
+  queue.add({todo: "Read 9gags"}, {priority: "low"});
+  queue.add({todo: "Fix my test unit"}, {priority: "critical"});
+
+  queue.process(function(job, done) {
+    console.log("I have to: " + job.data.todo);
+    done();
+  });
+```
+
+Warning: Priority queue use 5 times more redis connections than a normal queue.
 
 <a name="job"/>
 ### Job

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -26,11 +26,12 @@ Strategy.exponential = function(n) {
  one for every possible priority.
  */
 var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisOptions) {
-  var _this = this;
-
   if (!(this instanceof PriorityQueue)) {
     return new PriorityQueue(name, redisPort, redisHost, redisOptions);
   }
+
+  var _this = this;
+  this.paused = false;
   this.queues = [];
 
   for (var key in PriorityQueue.priorities) {
@@ -93,6 +94,7 @@ PriorityQueue.prototype.close = function() {
 }
 
 PriorityQueue.prototype.process = function(handler) {
+  this.handler = handler;
   this.queues.forEach(function (queue, key) {
     queue.handler = handler;
   });
@@ -111,14 +113,12 @@ PriorityQueue.prototype.run = function() {
       var i = 0;
 
       var fn = function () {
-        return queue.processStalledJobs().then(function() {
-            queue.getNextJob.bind(queue, {block: false});
-          })
+        return queue.processStalledJobs().then(queue.getNextJob.bind(queue, {block: false}))
           .then(function(job) {
             if (job) {
               emptyLoop = false;
               return queue.processJob(job).then(function() {
-                if (++i < nbJobsToProcess) {
+                if (++i < nbJobsToProcess && !_this.paused) {
                   return fn();
                 }
               })
@@ -129,8 +129,12 @@ PriorityQueue.prototype.run = function() {
       }
 
       return fn();
-    }, {concurrency: 1}).then(function() {
-      setTimeout(loop, (emptyLoop)?_this.waitAfterEmptyLoop:0);
+    }, {concurrency: 1}).finally(function() {
+      if (!_this.paused) {
+        return Promise.delay((emptyLoop) ? _this.waitAfterEmptyLoop : 0).then(loop);
+      }
+    }).catch(function() {
+      console.log(arguments);
     });
   }
 
@@ -151,16 +155,24 @@ PriorityQueue.prototype.empty = function() {
 
 PriorityQueue.prototype.pause = function() {
   var _this = this;
-  return Promise.map(this.queues, function(queue) {
+
+  _this.paused = Promise.map(this.queues, function(queue) {
     return queue.pause();
   }).then(_this.emit.bind(_this, 'paused'));
+
+  return _this.paused;
 }
 
 PriorityQueue.prototype.resume = function() {
   var _this = this;
+  _this.paused = false;
   return Promise.map(this.queues, function(queue) {
     return queue.resume();
-  }).then(_this.emit.bind(_this, 'resumed'));
+  }).then(_this.emit.bind(_this, 'resumed')).then(function() {
+    if (_this.handler) {
+      _this.run();
+    }
+  });
 }
 
 PriorityQueue.genericCount = function(fnName) {
@@ -203,7 +215,7 @@ PriorityQueue.prototype.getFailed = PriorityQueue.genericCount("getFailed");
 
 PriorityQueue.prototype.getQueue = function(priority) {
   if (!PriorityQueue.priorities[priority]) {
-    console.log("Unknown priotity " + priority);
+    //console.log("Unknown priotity " + priority);
     priority = "normal";
   }
 

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -5,26 +5,6 @@ var Promise = require("bluebird");
 var events = require('events');
 var util = require('util');
 
-var Strategy = {};
-
-
-/**
- * This Strategy ensure that a queue Qn will be processing twice faster as all lower queue.
- * @param n
- * @returns {number}
- */
-Strategy.exponential = function(n) {
-  return Math.pow(n, n) * 2;
-};
-
-Strategy.minimum = function(n) {
-  return n;
-};
-
-Strategy.square = function(n) {
-  return Math.pow(n, 2);
-};
-
 /**
  Priority Queue.
 
@@ -42,7 +22,8 @@ var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisO
   this.queues = [];
 
   for (var key in PriorityQueue.priorities) {
-    this.queues.push(Queue(PriorityQueue.getQueueName(name, key), redisPort, redisHost, redisOptions));
+    var queue = Queue(PriorityQueue.getQueueName(name, key), redisPort, redisHost, redisOptions);
+    this.queues[PriorityQueue.priorities[key]] = queue;
   }
 
   Promise.map(this.queues, function(queue) {
@@ -115,7 +96,7 @@ PriorityQueue.prototype.run = function() {
   var loop = function() {
     var emptyLoop = true;
 
-    return Promise.map(_this.queues, function (queue, index) {
+    return Promise.each(_this.queues.reverse(), function (queue, index) {
       var nbJobsToProcess = _this.strategy(index);
       var i = 0;
 
@@ -136,7 +117,7 @@ PriorityQueue.prototype.run = function() {
       }
 
       return fn();
-    }, {concurrency: 1}).finally(function() {
+    }).then(function() {
       if (!_this.paused) {
         return Promise.delay((emptyLoop) ? _this.waitAfterEmptyLoop : 0).then(loop);
       }
@@ -144,6 +125,12 @@ PriorityQueue.prototype.run = function() {
   }
 
   return loop();
+}
+
+PriorityQueue.prototype.setLockRenewTime = function(lockRenewTime) {
+  this.queues.forEach(function(queue) {
+    queue.LOCK_RENEW_TIME = lockRenewTime;
+  })
 }
 
 PriorityQueue.prototype.add = function(data, opts) {
@@ -228,5 +215,31 @@ PriorityQueue.prototype.getQueue = function(priority) {
     priority = "normal";
   }
 
-  return this.queues[PriorityQueue.priorities[priority]];
+  var queue = this.queues[PriorityQueue.priorities[priority]];
+  return queue;
 }
+
+var Strategy = {};
+
+/**
+ * This Strategy ensure that a queue Qn will be processing twice faster as all lower queue.
+ * @param n
+ * @returns {number}
+ */
+Strategy.exponential = function(n) {
+  return Math.pow(n, n) * 2;
+};
+
+/**
+ * This strategy is the minimal acceptable to respect the rule Qn will be processing quicker than Qn-1
+ *
+ * @param n
+ * @returns {*}
+ */
+Strategy.minimum = function(n) {
+  return n + 1;
+};
+
+Strategy.square = function(n) {
+  return Math.pow(n, 2);
+};

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -1,0 +1,85 @@
+"use strict";
+
+var Queue = require('./queue');
+
+
+var Strategy = {};
+
+
+/**
+ * This Strategy ensure that a queue Qn will be processing twice faster as all lower queue.
+ * @param n
+ * @returns {number}
+ */
+Strategy.exponential = function(n) {
+  return 2*Math.exp(n);
+};
+
+
+/**
+ Priority Queue.
+
+ This is a priority queue based on the normal Queue, to provide the same
+ stability and robustness. The priority queue is in fact several Queues,
+ one for every possible priority.
+ */
+var PriorityQueue = function(name, redisPort, redisHost, redisOptions) {
+  if (!(this instanceof PriorityQueue)) {
+    return new PriorityQueue(name, redisPort, redisHost, redisOptions);
+  }
+  var queues = [];
+
+  PriorityQueue.priorities.forEach(function (val, key) {
+    queues.push(Queue(PriorityQueue.getQueueName(name, key), redisPort, redisHost, redisOptions));
+  })
+}
+
+PriorityQueue.priorities = {
+  low: -2,
+  normal: -1,
+  medium: 0,
+  hight: 1,
+  critical: 2
+}
+
+PriorityQueue.getQueueName = function(name, priority){
+  return name + ':prio:' + priority;
+}
+
+PriorityQueue.prototype.close = function() {
+
+}
+
+PriorityQueue.prototype.process = function(handler) {
+
+}
+
+PriorityQueue.prototype.process = function(handler) {
+
+}
+
+PriorityQueue.prototype.add = function(data, opts) {
+
+}
+
+PriorityQueue.prototype.count = function() {
+
+}
+
+PriorityQueue.prototype.empty = function() {
+
+}
+
+PriorityQueue.prototype.pause = function() {
+
+}
+
+PriorityQueue.prototype.resume = function() {
+
+}
+
+PriorityQueue.prototype.run = function() {
+
+}
+
+

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -1,7 +1,9 @@
 "use strict";
 
 var Queue = require('./queue');
-
+var Promise = require("bluebird");
+var events = require('events');
+var util = require('util');
 
 var Strategy = {};
 
@@ -12,7 +14,7 @@ var Strategy = {};
  * @returns {number}
  */
 Strategy.exponential = function(n) {
-  return 2*Math.exp(n);
+  return Math.exp(n) * 2;
 };
 
 
@@ -23,16 +25,45 @@ Strategy.exponential = function(n) {
  stability and robustness. The priority queue is in fact several Queues,
  one for every possible priority.
  */
-var PriorityQueue = function(name, redisPort, redisHost, redisOptions) {
+var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisOptions) {
+  var _this = this;
+
   if (!(this instanceof PriorityQueue)) {
     return new PriorityQueue(name, redisPort, redisHost, redisOptions);
   }
-  var queues = [];
+  this.queues = [];
 
-  PriorityQueue.priorities.forEach(function (val, key) {
-    queues.push(Queue(PriorityQueue.getQueueName(name, key), redisPort, redisHost, redisOptions));
+  for (var key in PriorityQueue.priorities) {
+    this.queues.push(Queue(PriorityQueue.getQueueName(name, key), redisPort, redisHost, redisOptions));
+  }
+
+  Promise.map(this.queues, function(queue) {
+    return new Promise(function(resolve, reject) {
+      queue.once('ready', resolve);
+    });
+  }).then(_this.emit.bind(_this, 'ready'))
+
+  this.queues.forEach(function(queue) {
+      queue.on('error', _this.emit.bind(_this, 'error'));
   })
+
+  this.queues.forEach(function(queue) {
+      queue.on('progress', _this.emit.bind(_this, 'progress'));
+  })
+
+  this.queues.forEach(function(queue) {
+    queue.on('completed', _this.emit.bind(_this, 'completed'));
+  })
+
+  this.queues.forEach(function(queue) {
+    queue.on('failed', _this.emit.bind(_this, 'failed'));
+  })
+
+
+  this.strategy = Strategy.exponential;
 }
+
+util.inherits(PriorityQueue, events.EventEmitter);
 
 PriorityQueue.priorities = {
   low: -2,
@@ -46,40 +77,135 @@ PriorityQueue.getQueueName = function(name, priority){
   return name + ':prio:' + priority;
 }
 
+/**
+ * Priority queue do not use blocking
+ * In order to avoid query redis too much, and to reduce load, we wait a certain time if we loop all queue
+ * without processing any job (ie: all are empty)
+ *
+ * @type {number}
+ */
+PriorityQueue.prototype.waitAfterEmptyLoop = 200;
+
 PriorityQueue.prototype.close = function() {
-
+  return Promise.map(this.queues, function(queue) {
+    return queue.close();
+  })
 }
 
 PriorityQueue.prototype.process = function(handler) {
+  this.queues.forEach(function (queue, key) {
+    queue.handler = handler;
+  });
 
-}
-
-PriorityQueue.prototype.process = function(handler) {
-
-}
-
-PriorityQueue.prototype.add = function(data, opts) {
-
-}
-
-PriorityQueue.prototype.count = function() {
-
-}
-
-PriorityQueue.prototype.empty = function() {
-
-}
-
-PriorityQueue.prototype.pause = function() {
-
-}
-
-PriorityQueue.prototype.resume = function() {
-
+  return this.run();
 }
 
 PriorityQueue.prototype.run = function() {
+  var _this = this;
 
+  var loop = function() {
+    var emptyLoop = true;
+
+    return Promise.map(_this.queues, function (queue, index) {
+      var nbJobsToProcess = _this.strategy(index);
+      var i = 0;
+
+      var fn = function () {
+        return queue.processStalledJobs().then(function() {
+            queue.getNextJob.bind(queue, {block: false});
+          })
+          .then(function(job) {
+            if (job) {
+              emptyLoop = false;
+              return queue.processJob(job).then(function() {
+                if (++i < nbJobsToProcess) {
+                  return fn();
+                }
+              })
+            } else {
+              //nothing It will release loop and call next priority queue even if we have no reach nbJobsToProcess
+            }
+          })
+      }
+
+      return fn();
+    }, {concurrency: 1}).then(function() {
+      setTimeout(loop, (emptyLoop)?_this.waitAfterEmptyLoop:0);
+    });
+  }
+
+  return loop().then(function() {
+
+  });
 }
 
+PriorityQueue.prototype.add = function(data, opts) {
+  return this.getQueue(opts && opts.priority).add(data, opts);
+}
 
+PriorityQueue.prototype.empty = function() {
+  return Promise.map(this.queues, function(queue) {
+    return queue.empty();
+  });
+}
+
+PriorityQueue.prototype.pause = function() {
+  var _this = this;
+  return Promise.map(this.queues, function(queue) {
+    return queue.pause();
+  }).then(_this.emit.bind(_this, 'paused'));
+}
+
+PriorityQueue.prototype.resume = function() {
+  var _this = this;
+  return Promise.map(this.queues, function(queue) {
+    return queue.resume();
+  }).then(_this.emit.bind(_this, 'resumed'));
+}
+
+PriorityQueue.genericCount = function(fnName) {
+  return function() {
+    var args = arguments;
+    return Promise.map(this.queues, function (queue) {
+      return queue[fnName].apply(queue, args);
+    }).then(function (results) {
+      var jobs = [];
+      results.forEach(function (val) {
+        jobs = jobs.concat(val);
+      });
+      return jobs;
+    })
+  }
+}
+
+PriorityQueue.prototype.count = function() {
+  return Promise.map(this.queues, function (queue) {
+    return queue.count();
+  }).then(function (results) {
+    var sum = 0;
+    results.forEach(function (val) {
+      sum += val
+    });
+    return sum;
+  })
+};
+
+PriorityQueue.prototype.getWaiting = PriorityQueue.genericCount("getWaiting");
+PriorityQueue.prototype.getActive = PriorityQueue.genericCount("getActive");
+PriorityQueue.prototype.getDelayed = PriorityQueue.genericCount("getDelayed");
+PriorityQueue.prototype.getCompleted = PriorityQueue.genericCount("getCompleted");
+PriorityQueue.prototype.getFailed = PriorityQueue.genericCount("getFailed");
+
+
+// ---------------------------------------------------------------------
+// Private methods
+// ---------------------------------------------------------------------
+
+PriorityQueue.prototype.getQueue = function(priority) {
+  if (!PriorityQueue.priorities[priority]) {
+    console.log("Unknown priotity " + priority);
+    priority = "normal";
+  }
+
+  return this.queues[PriorityQueue.priorities[priority] + 2];
+}

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -14,9 +14,16 @@ var Strategy = {};
  * @returns {number}
  */
 Strategy.exponential = function(n) {
-  return Math.exp(n) * 2;
+  return Math.pow(n, n) * 2;
 };
 
+Strategy.minimum = function(n) {
+  return n;
+};
+
+Strategy.square = function(n) {
+  return Math.pow(n, 2);
+};
 
 /**
  Priority Queue.
@@ -67,11 +74,11 @@ var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisO
 util.inherits(PriorityQueue, events.EventEmitter);
 
 PriorityQueue.priorities = {
-  low: -2,
-  normal: -1,
-  medium: 0,
-  hight: 1,
-  critical: 2
+  low: 0,
+  normal: 1,
+  medium: 2,
+  hight: 3,
+  critical: 4
 }
 
 PriorityQueue.getQueueName = function(name, priority){
@@ -133,14 +140,10 @@ PriorityQueue.prototype.run = function() {
       if (!_this.paused) {
         return Promise.delay((emptyLoop) ? _this.waitAfterEmptyLoop : 0).then(loop);
       }
-    }).catch(function() {
-      console.log(arguments);
     });
   }
 
-  return loop().then(function() {
-
-  });
+  return loop();
 }
 
 PriorityQueue.prototype.add = function(data, opts) {
@@ -175,7 +178,25 @@ PriorityQueue.prototype.resume = function() {
   });
 }
 
-PriorityQueue.genericCount = function(fnName) {
+PriorityQueue.prototype.count = function() {
+  return Promise.map(this.queues, function (queue) {
+    return queue.count();
+  }).then(function (results) {
+    var sum = 0;
+    results.forEach(function (val) {
+      sum += val
+    });
+    return sum;
+  })
+};
+
+/**
+ * A generic function to get jobs in all queues
+ *
+ * @param fnName
+ * @returns {Function}
+ */
+PriorityQueue.genericGetter = function(fnName) {
   return function() {
     var args = arguments;
     return Promise.map(this.queues, function (queue) {
@@ -190,23 +211,11 @@ PriorityQueue.genericCount = function(fnName) {
   }
 }
 
-PriorityQueue.prototype.count = function() {
-  return Promise.map(this.queues, function (queue) {
-    return queue.count();
-  }).then(function (results) {
-    var sum = 0;
-    results.forEach(function (val) {
-      sum += val
-    });
-    return sum;
-  })
-};
-
-PriorityQueue.prototype.getWaiting = PriorityQueue.genericCount("getWaiting");
-PriorityQueue.prototype.getActive = PriorityQueue.genericCount("getActive");
-PriorityQueue.prototype.getDelayed = PriorityQueue.genericCount("getDelayed");
-PriorityQueue.prototype.getCompleted = PriorityQueue.genericCount("getCompleted");
-PriorityQueue.prototype.getFailed = PriorityQueue.genericCount("getFailed");
+PriorityQueue.prototype.getWaiting = PriorityQueue.genericGetter("getWaiting");
+PriorityQueue.prototype.getActive = PriorityQueue.genericGetter("getActive");
+PriorityQueue.prototype.getDelayed = PriorityQueue.genericGetter("getDelayed");
+PriorityQueue.prototype.getCompleted = PriorityQueue.genericGetter("getCompleted");
+PriorityQueue.prototype.getFailed = PriorityQueue.genericGetter("getFailed");
 
 
 // ---------------------------------------------------------------------
@@ -215,9 +224,9 @@ PriorityQueue.prototype.getFailed = PriorityQueue.genericCount("getFailed");
 
 PriorityQueue.prototype.getQueue = function(priority) {
   if (!PriorityQueue.priorities[priority]) {
-    //console.log("Unknown priotity " + priority);
+    //in case of unknown priority, we use normal
     priority = "normal";
   }
 
-  return this.queues[PriorityQueue.priorities[priority] + 2];
+  return this.queues[PriorityQueue.priorities[priority]];
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -27,12 +27,12 @@ var sequence = require('when/sequence');
 
 /**
   Delayed jobs are jobs that cannot be executed until a certain time in
-  ms has passed since they were added to the queue. 
-  The mechanism is simple, a delayedTimestamp variable holds the next 
+  ms has passed since they were added to the queue.
+  The mechanism is simple, a delayedTimestamp variable holds the next
   known timestamp that is on the delayed set (or MAX_INT if none).
 
   When the current job has finalized the variable is checked, if
-  no delayed job has to be executed yet a setTimeout is set so that a 
+  no delayed job has to be executed yet a setTimeout is set so that a
   delayed job is processed after timing out.
 */
 
@@ -77,7 +77,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
 
   // emit ready when redis connections
   this.client.selectAsync(redisDB).then(function(){
-    return _this.bclient.selectAsync(redisDB); 
+    return _this.bclient.selectAsync(redisDB);
   }).then(function(){
     return _this.dclient.selectAsync(redisDB);
   }).then(function(){
@@ -89,7 +89,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   this.dclient.on('message', function(channel, message){
     if(channel === _this.toKey('delayed')){
       _this.updateDelayTimer(message);
-    }    
+    }
   })
 }
 
@@ -129,7 +129,7 @@ Queue.prototype.process = function(handler){
     _this.bclient.once('ready', _this.run.bind(_this));
   };
 
-  // attempt to restart the queue when the client throws 
+  // attempt to restart the queue when the client throws
   // an error or the connection is dropped by redis
   this.bclient.on('error', runQueueWhenReady);
   this.bclient.on('end', runQueueWhenReady);
@@ -383,7 +383,7 @@ Queue.prototype.processJobs = function(){
 Queue.prototype.processJob = function(job){
   var _this = this;
   var lockRenewTimeout;
-  
+
   //
   // Delay this job if needed.
   //
@@ -441,10 +441,10 @@ Queue.prototype.processJob = function(job){
 /**
   Returns a promise that resolves to the next job in queue.
 */
-Queue.prototype.getNextJob = function(){
+Queue.prototype.getNextJob = function(opts){
   var getJobFromId = Job.fromId.bind(null, this); //should this be a queue method?
 
-  return this.moveJob('wait', 'active').then(getJobFromId);
+  return this.moveJob('wait', 'active', opts).then(getJobFromId);
 }
 
 Queue.prototype.multi = function(){
@@ -458,8 +458,12 @@ Queue.prototype.multi = function(){
 
   @method moveJob
 */
-Queue.prototype.moveJob = function(src, dst){
-  return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst), 0);
+Queue.prototype.moveJob = function(src, dst, opts) {
+  if (opts && opts.block == false) {
+    return this.bclient.rpoplpushAsync(this.toKey(src), this.toKey(dst));
+  } else {
+    return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst), 0);
+  }
 }
 
 Queue.prototype.getJob = function(jobId){

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -420,15 +420,17 @@ describe('Queue', function(){
 
       // Add a job to pend proccessing
       queue.add({'count': 0}).then(function(){
-        queue.pause().then(function(){
-          // Add a series of jobs in a predictable order
-          var fn = function(cb){
-            queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);
-          };
-          fn(fn(fn(fn(function(){
-            queue.resume();
-          }))));
-        });
+        Promise.delay(100).then(function() {
+          queue.pause().then(function(){
+            // Add a series of jobs in a predictable order
+            var fn = function(cb){
+              queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);
+            };
+            fn(fn(fn(fn(function(){
+              queue.resume();
+            }))));
+          });
+        })
       });
     });
   });

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -1,0 +1,538 @@
+"use strict";
+
+var Job = require('../lib/job');
+var Queue = require('../lib/priority-queue');
+var expect = require('expect.js');
+var Promise = require('bluebird');
+var redis = require('redis');
+var sinon = require('sinon');
+var _ = require('lodash');
+
+var STD_QUEUE_NAME = 'test queue';
+
+function buildQueue(name) {
+  var qName = name || STD_QUEUE_NAME;
+  return new Queue(qName, 6379, '127.0.0.1');
+}
+
+function cleanupQueue(queue){
+  return queue.empty().then(queue.close.bind(queue));
+}
+
+describe('Queue', function(){
+  var queue;
+  var sandbox = sinon.sandbox.create();
+
+  afterEach(function(){
+    if(queue){
+      return cleanupQueue(queue).then(function(){
+        queue = undefined;
+      })
+    }
+    sandbox.restore();
+  });
+
+  describe('.close', function () {
+    var testQueue;
+
+    beforeEach(function () {
+        testQueue = buildQueue('test');
+    });
+
+    it('should return a promise', function () {
+      var closePromise = testQueue.close().then(function(){
+        expect(closePromise).to.be.a(Promise);
+      });
+    });
+  });
+
+  it('creates a queue with dots in its name', function(){
+    queue = Queue('using. dots. in.name.');
+
+    return queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok()
+        expect(job.data.foo).to.be('bar')
+      })
+      .then(function(){
+        queue.process(function(job, jobDone){
+          expect(job.data.foo).to.be.equal('bar')
+          jobDone();
+        });
+      });
+  });
+
+  it('process a job', function(done){
+    queue = buildQueue();
+    queue.process(function(job, jobDone){
+      expect(job.data.foo).to.be.equal('bar');
+      jobDone();
+      done();
+    });
+
+    queue.add({foo: 'bar'}).then(function(job){
+      expect(job.jobId).to.be.ok()
+      expect(job.data.foo).to.be('bar')
+    }).catch(done);
+  });
+
+  it('process a job that updates progress', function(done){
+    queue = buildQueue();
+    queue.process(function(job, jobDone){
+      expect(job.data.foo).to.be.equal('bar');
+      job.progress(42);
+      jobDone();
+    });
+
+    queue.add({foo: 'bar'}).then(function(job){
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
+    }).catch(done);
+
+    queue.on('progress', function(job, progress){
+      expect(job).to.be.ok();
+      expect(progress).to.be.eql(42);
+      done();
+    });
+  });
+
+  it('process a job that returns data in the process handler', function(done){
+    queue = buildQueue();
+    queue.process(function(job, jobDone){
+      expect(job.data.foo).to.be.equal('bar');
+      jobDone(null, 37);
+    });
+
+    queue.add({foo: 'bar'}).then(function(job){
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
+    }).catch(done);
+
+    queue.on('completed', function(job, data){
+      expect(job).to.be.ok();
+      expect(data).to.be.eql(37);
+      done();
+    });
+  });
+
+  it('process stalled jobs when starting a queue', function(done){
+    var queueStalled = buildQueue('test queue stalled');
+    queueStalled.LOCK_RENEW_TIME = 10;
+    var jobs = [
+      queueStalled.add({bar: 'baz'}),
+      queueStalled.add({bar1: 'baz1'}),
+      queueStalled.add({bar2: 'baz2'}),
+      queueStalled.add({bar3: 'baz3'})
+    ];
+
+    Promise.all(jobs).then(function(){
+      queueStalled.process(function(job){
+        // instead of completing we just close the queue to simulate a crash.
+        queueStalled.close();
+        setTimeout(function(){
+          var queue2 = buildQueue('test queue stalled');
+          var doneAfterFour = _.after(4, function(){
+            done();
+          });
+          queue2.on('completed', doneAfterFour);
+
+          queue2.process(function(job, jobDone){
+            jobDone();
+          });
+        }, 100);
+      });
+    });
+  });
+
+  it('processes jobs that were added before the queue backend started', function(){
+    var queueStalled = buildQueue('test queue added before');
+    queueStalled.LOCK_RENEW_TIME = 10;
+    var jobs = [
+      queueStalled.add({bar: 'baz'}),
+      queueStalled.add({bar1: 'baz1'}),
+      queueStalled.add({bar2: 'baz2'}),
+      queueStalled.add({bar3: 'baz3'})
+    ];
+
+    return Promise.all(jobs)
+      .then(queueStalled.close.bind(queueStalled))
+      .then(function(){
+        queue = buildQueue('test queue added before');
+        queue.process(function(job, jobDone){
+          jobDone();
+        });
+
+        return new Promise(function(resolve, reject){
+          var resolveAfterAllJobs = _.after(jobs.length, resolve);
+          queue.on('completed', resolveAfterAllJobs);
+        });
+      });
+  });
+
+  it('processes several stalled jobs when starting several queues', function(done){
+    var NUM_QUEUES = 10;
+    var NUM_JOBS_PER_QUEUE = 20;
+    var stalledQueues = [];
+    var jobs = [];
+
+    for(var i=0; i<NUM_QUEUES; i++){
+      var queue = buildQueue('test queue stalled 2');
+      stalledQueues.push(queue);
+      queue.LOCK_RENEW_TIME = 10;
+
+      for(var j=0; j<NUM_JOBS_PER_QUEUE; j++){
+        jobs.push(queue.add({job: j}));
+      }
+    }
+
+    Promise.all(jobs).then(function(){
+      var processed = 0;
+      for(var k=0; k<stalledQueues.length; k++){
+        stalledQueues[k].process(function(job){
+          // instead of completing we just close the queue to simulate a crash.
+          this.close();
+
+          processed ++;
+          if(processed === stalledQueues.length){
+            setTimeout(function(){
+              var queue2 = buildQueue('test queue stalled 2');
+              queue2.process(function(job, jobDone){
+                jobDone();
+              });
+
+              var counter = 0;
+              queue2.on('completed', function(job){
+                counter ++;
+                if(counter === NUM_QUEUES * NUM_JOBS_PER_QUEUE) {
+                  queue2.close().then(function(){
+                      done();
+                  });
+                }
+              });
+            }, 100);
+          }
+        });
+      }
+    });
+  });
+
+  it('does not process a job that is being processed when a new queue starts', function(done){
+    this.timeout(5000)
+    var err = null;
+    var anotherQueue;
+
+    queue = buildQueue();
+
+    queue.add({foo: 'bar'}).then(function(addedJob){
+      queue.process(function(job, jobDone){
+        expect(job.data.foo).to.be.equal('bar');
+
+        if(addedJob.jobId !== job.jobId){
+          err = new Error('Processed job id does not match that of added job');
+        }
+        setTimeout(jobDone, 100);
+      });
+
+      anotherQueue = buildQueue();
+      anotherQueue.process(function(job, jobDone){
+        err = new Error('The second queue should not have received a job to process');
+        jobDone();
+      });
+
+      queue.on('completed', function(){
+        cleanupQueue(anotherQueue).then(done.bind(null, err));
+      });
+    });
+  });
+
+  it.skip('process stalled jobs without requiring a queue restart');
+
+  it('process a job that fails', function(done){
+    var jobError = Error("Job Failed");
+    queue = buildQueue();
+
+    queue.process(function(job, jobDone){
+      expect(job.data.foo).to.be.equal('bar');
+      jobDone(jobError);
+    });
+
+    queue.add({foo: 'bar'}).then(function(job){
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
+    }, function(err){
+      done(err);
+    });
+
+    queue.once('failed', function(job, err){
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
+      expect(err).to.be.eql(jobError);
+      done();
+    });
+  });
+
+  it('process a job that throws an exception', function(done){
+    var jobError = new Error("Job Failed");
+
+    queue = buildQueue();
+
+    queue.process(function(job, jobDone){
+      expect(job.data.foo).to.be.equal('bar');
+      throw jobError;
+    });
+
+    queue.add({foo: 'bar'}).then(function(job){
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
+    }, function(err){
+      done(err);
+    });
+
+    queue.once('failed', function(job, err){
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
+      expect(err).to.be.eql(jobError);
+      done();
+    });
+  });
+
+  it('process several jobs serially', function(done){
+    var counter = 1;
+    var maxJobs = 100;
+
+    queue = buildQueue();
+
+    queue.process(function(job, jobDone){
+      expect(job.data.num).to.be.equal(counter);
+      expect(job.data.foo).to.be.equal('bar');
+      jobDone();
+      if(counter == maxJobs) done();
+      counter++;
+    });
+
+    for(var i=1; i<=maxJobs; i++){
+      queue.add({foo: 'bar', num: i});
+    }
+  });
+
+  it('count added, unprocessed jobs', function(){
+    var counter = 1;
+    var maxJobs = 100;
+    var added = [];
+
+    queue = buildQueue();
+
+    for(var i=1; i<=maxJobs; i++){
+      added.push(queue.add({foo: 'bar', num: i}));
+    }
+
+    return Promise.all(added)
+      .then(queue.count.bind(queue))
+      .then(function(count){
+        expect(count).to.be(100);
+      })
+      .then(queue.empty.bind(queue))
+      .then(queue.count.bind(queue))
+      .then(function(count){
+        expect(count).to.be(0);
+      });
+  });
+
+  it('add jobs to a paused queue', function(done){
+    var ispaused = false, counter = 2;
+
+    queue = buildQueue();
+
+    queue.process(function(job, jobDone){
+      expect(ispaused).to.be(false);
+      expect(job.data.foo).to.be.equal('paused');
+      jobDone();
+      counter--;
+      if(counter === 0) done();
+    });
+
+    queue.pause();
+
+    ispaused = true;
+
+    queue.add({foo: 'paused'});
+    queue.add({foo: 'paused'});
+
+    setTimeout(function(){
+      ispaused = false;
+      queue.resume();
+    }, 100); // We hope that this was enough to trigger a process if
+    // we were not paused.
+  });
+
+  it('paused a running queue', function(done){
+    var ispaused = false, isresumed = true, first = true;
+
+    queue = buildQueue();
+
+    queue.process(function(job, jobDone){
+      expect(ispaused).to.be(false);
+      expect(job.data.foo).to.be.equal('paused');
+      jobDone();
+
+      if(first){
+        first = false;
+        queue.pause();
+        ispaused = true;
+      }else{
+        expect(isresumed).to.be(true);
+        done();
+      }
+    });
+
+    queue.add({foo: 'paused'});
+    queue.add({foo: 'paused'});
+
+    queue.on('paused', function(){
+      setTimeout(function(){
+        ispaused = false;
+        queue.resume();
+      }, 100); // We hope that this was enough to trigger a process if
+    });
+
+    queue.on('resumed', function(){
+      isresumed = true;
+    });
+  });
+
+  it('process a lifo queue', function(done){
+    var currentValue = 0, first = true;
+    queue = Queue('test lifo');
+
+    queue.once('ready', function(){
+      queue.process(function(job, jobDone){
+        // Catching the job before the pause
+        if(first){
+          expect(job.data.count).to.be.equal(0);
+          first = false;
+          return jobDone();
+        }
+        expect(job.data.count).to.be.equal(currentValue--);
+        jobDone();
+        if(currentValue === 0){
+          done();
+        }
+      });
+
+      // Add a job to pend proccessing
+      queue.add({'count': 0}).then(function(){
+        queue.pause().then(function(){
+          // Add a series of jobs in a predictable order
+          var fn = function(cb){
+            queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);
+          };
+          fn(fn(fn(fn(function(){
+            queue.resume();
+          }))));
+        });
+      });
+    });
+  });
+
+  describe("Jobs getters", function(){
+    it('should get waitting jobs', function(done){
+      queue = buildQueue();
+      Promise.join(queue.add({foo: 'bar'}), queue.add({baz: 'qux'})).then(function(){
+        queue.getWaiting().then(function(jobs){
+          expect(jobs).to.be.a('array');
+          expect(jobs.length).to.be.equal(2);
+          expect(jobs[1].data.foo).to.be.equal('bar');
+          expect(jobs[0].data.baz).to.be.equal('qux');
+          done();
+        });
+      });
+    });
+
+    it('should get active jobs', function(done){
+      var counter = 2;
+
+      queue = buildQueue();
+      queue.process(function(job, jobDone){
+        queue.getActive().then(function(jobs){
+          expect(jobs).to.be.a('array');
+          expect(jobs.length).to.be.equal(1);
+          expect(jobs[0].data.foo).to.be.equal('bar');
+          done();
+        });
+        jobDone();
+      });
+
+      queue.add({foo: 'bar'});
+    });
+
+    it('should get completed jobs', function(){
+      var counter = 2;
+
+      queue = buildQueue();
+      queue.process(function(job, jobDone){
+        jobDone();
+      });
+
+      queue.on('completed', function(){
+        counter --;
+
+        if(counter === 0){
+          queue.getCompleted().then(function(jobs){
+            expect(jobs).to.be.a('array');
+            // We need a "empty completed" kind of function.
+            //expect(jobs.length).to.be.equal(2);
+            done();
+          });
+        }
+      });
+
+      queue.add({foo: 'bar'});
+      queue.add({baz: 'qux'});
+    });
+
+    it('should get failed jobs', function(done){
+      var counter = 2;
+
+      queue = buildQueue();
+
+      queue.process(function(job, jobDone){
+        jobDone(Error("Forced error"));
+      });
+
+      queue.on('failed', function(){
+        counter --;
+
+        if(counter === 0){
+          queue.getFailed().then(function(jobs){
+            expect(jobs).to.be.a('array');
+            done();
+          });
+        }
+      });
+
+      queue.add({foo: 'bar'});
+      queue.add({baz: 'qux'});
+    });
+
+    it('fails jobs that exceed their specified timeout', function(done){
+      queue = buildQueue();
+
+      queue.process(function(job, jobDone){
+        setTimeout(jobDone, 150);
+      });
+
+      queue.on('failed', function(job, error){
+        expect(error).to.be.a(Promise.TimeoutError);
+        done();
+      });
+
+      queue.on('completed', function(){
+        var error = new Error('The job should have timed out');
+        done(error);
+      });
+
+      queue.add({some: 'data'}, {
+        timeout: 100
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adding priority queue functionality to Bull.

Priority have been design to process job of higher priority more often than lower priority. It will not process all critical before all hight before all normal... This design choice allow us to save many check and Redis request. But it work like a charm and job with hight priority will be processing significantly faster than other.

It's works like normal queue, except that the ```add``` function allow an ```opts.priority``` options with one of following value: ```[low, normal, medium, hight, critical]```.

Due to current design of Redis connection, this priority queue will increase Redis connection by 5.

