### PR TITLE
update remove storedprocedure

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -150,12 +150,12 @@ Job.prototype.remove = function(){
   var queue = this.queue;
 
   var script = [
-    'if (redis.call("SISMEMBER", KEYS[4], ARGV[1]) == 0) and (redis.call("SISMEMBER", KEYS[6], ARGV[1]) == 0) then',
+    'if (redis.call("SISMEMBER", KEYS[5], ARGV[1]) == 0) and (redis.call("SISMEMBER", KEYS[6], ARGV[1]) == 0) then',
     '  redis.call("LREM", KEYS[1], 0, ARGV[1])',
     '  redis.call("LREM", KEYS[2], 0, ARGV[1])',
-    '  redis.call("LREM", KEYS[3], 0, ARGV[1])',
+    '  redis.call("ZREM", KEYS[3], ARGV[1])',
+    '  redis.call("LREM", KEYS[4], 0, ARGV[1])',
     'end',
-    'redis.call("ZREM", KEYS[4], ARGV[1])',
     'redis.call("SREM", KEYS[5], ARGV[1])',
     'redis.call("SREM", KEYS[6], ARGV[1])',
     'redis.call("DEL", KEYS[7])'].join('\n');


### PR DESCRIPTION
should remove from "active", "wait", "delayed" and "paused" when it's not on "failed" or "completed". it was always deleting from the ZSET.    And it also used the wrong key. It might be a good idea to add some more unit tests for this function.