### PR TITLE
Emit an event when a job becomes active

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -500,6 +500,7 @@ Queue.prototype.processJob = function(job){
 
   if(!_this.paused){
     this.processing++;
+    this.emit('active', job);
 
     lockRenewer();
     var jobPromise = runHandler(job);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -622,6 +622,19 @@ describe('Queue', function(){
     });
   });
 
+  it("should emit an event when a job becomes active", function (done) {
+    queue = buildQueue();
+    queue.process(function(job, jobDone){
+      jobDone();
+    });
+    queue.add({});
+    queue.once('active', function (job) {
+      queue.once('completed', function (job) {
+        done();
+      });
+    });
+  });
+
   describe("Delayed jobs", function(){
     it("should process a delayed job only after delayed time", function(done){
       var delay = 500;


### PR DESCRIPTION
I'm building a wrapper for bull that allows consuming status with an [EventSource](http://dev.w3.org/html5/eventsource/). Having this event would make it possible to detect when a job becomes active.