### PR TITLE
Emit an event when a job is removed

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -190,6 +190,7 @@ Job.prototype.remove = function(){
       return queue.toKey(name);
   });
 
+  var job = this;
   return this.queue.client.evalAsync(
     script,
     keys.length,
@@ -200,7 +201,9 @@ Job.prototype.remove = function(){
     keys[4],
     keys[5],
     keys[6],
-    this.jobId);
+    this.jobId).then(function () {
+      queue.emit('removed', job);
+    });
 }
 
 // -----------------------------------------------------------------------------

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -64,6 +64,16 @@ describe('Job', function(){
             expect(storedJob).to.be(null);
           });
       })
+
+      it('emits removed event', function (cb) {
+        queue.once('removed', function (job) {
+          expect(job.data.foo).to.be.equal('bar');
+          cb();
+        });
+        Job.create(queue, 1, {foo: 'bar'}).then(function(job){
+          job.remove();
+        });
+      });
   });
 
   describe('Locking', function(){


### PR DESCRIPTION
I'm building a wrapper for bull that allows consuming status with an [EventSource](http://dev.w3.org/html5/eventsource/). Having this event would make it possible to detect when a job is removed.