### PR TITLE
FIX: Using Async version of hset when saving the stacktrace

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -129,7 +129,7 @@ Job.prototype.moveToFailed = function(err){
   var _this = this;
   return this._moveToSet('failed').then(function() {
     _this.stacktrace = err.stack;
-    return _this.queue.client.hset(_this.queue.toKey(_this.jobId), 'stacktrace', err.stack);
+    return _this.queue.client.hsetAsync(_this.queue.toKey(_this.jobId), 'stacktrace', err.stack);
   });
 }
 


### PR DESCRIPTION
Fixes using the async/promisified version of hset. Right now, redisClient would emit an error when saving the stacktrace.