### PR TITLE
Implementation of tags to jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -24,6 +24,8 @@ var Job = function(queue, jobId, data, opts){
   this.delay = this.opts.delay;
   this.timestamp = opts.timestamp || Date.now();
   this.stacktrace = null;
+  var tags = opts.tags;
+  this.tags = Array.isArray(tags)?tags:[tags] || [];
 };
 
 Job.create = function(queue, jobId, data, opts){
@@ -49,7 +51,8 @@ Job.prototype.toData = function(){
     opts: JSON.stringify(this.opts || {}),
     progress: this._progress,
     delay: this.delay,
-    timestamp: this.timestamp
+    timestamp: this.timestamp,
+    tags: this.tags
   };
 };
 
@@ -272,7 +275,6 @@ Job.fromData = function(queue, jobId, data){
   job._progress = parseInt(data.progress);
   job.delay = parseInt(data.delay);
   job.timestamp = parseInt(data.timestamp);
-
   return job;
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -593,6 +593,23 @@ Queue.prototype.getJobs = function(queueType, type, start, end){
   });
 };
 
+/**
+  Return jobs by tag with type [wait, active, delayed, completed, failed]
+*/
+Queue.prototype.getByTag = function(type, tag){
+  var mapper = {wait:'LIST', active:'LIST', delayed: 'ZSET', completed: 'SET', failed: 'SET'};
+  if(!(type in mapper))
+    return Promise.all([]);
+  return this.getJobs(type, mapper[type]).then(function(jobId){
+    var value = jobId.filter(function(x){ return x.tags.indexOf(tag) != -1;});
+    return Promise.all(value);
+  }).catch(function(err){
+    _this.emit('error', err);
+  });
+
+};
+
+
 Queue.prototype.retryJob = function(job) {
   return job.retry();
 };

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -938,4 +938,47 @@ describe('Queue', function(){
       });
     });
   });
+
+  describe("tags", function(){
+    it("should return one job with tag bar", function(done) {
+        queue = buildQueue();
+        queue.add({first:'second'}, {tags:['foo', 'bar']});
+        queue.process(function(job, done){
+          queue.getByTag('active', 'bar', function(jobs){
+            expect(jobs.length).to.be(1);
+          });
+          job.progress(42);
+          done();
+        });
+    });
+
+    it("should return zero jobs cause wrong tag", function(done) {
+      queue = buildQueue();
+      queue.add({first:'second'}, {tags:['foo', 'bar']});
+      queue.process(function(job, done) {
+          job.progress(42);
+          done();
+      });
+      queue.on('completed', function(job) {
+        queue.getByTag('completed', 'bar42', function(jobs){
+          expect(jobs.length).to.be(0);
+        });
+      });
+    });
+
+    it("should return zero jobs cause wrong type of jobs", function(done) {
+      queue = buildQueue();
+      queue.add({first:'second'}, {tags:['foo', 'bar']});
+      queue.process(function(job, done) {
+          job.progress(42);
+          done();
+      });
+      queue.on('completed', function(job) {
+        queue.getByTag('completedff', 'bar', function(jobs){
+          expect(jobs.length).to.be(0);
+        });
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
Hi, guys!
I implemented tags for jobs, and its looks something like:

``` javascript
var videoQueue = Queue('video transcoding', 6379, '127.0.0.1');
videoQueue.process(function(job, done){
  videoQueue.getByTag('active', 'bar').then(function(jobs){
        console.log("Active jobs: ", jobs);
    })

  job.progress(42);
  done();
});
videoQueue.add({video: 'http://example.com/video1.mov'}, {tags:['bar']});
videoQueue.add({video: 'http://example.com/video2.mov'});
videoQueue.add({video: 'http://example.com/video3.mov'}, {tags:['foo','bar']});
videoQueue.add({video: 'http://example.com/video4.mov'}, {tags:['foo']});
```

Where, signature of getByTag is `getByTag(type of jobs ['active','delayed',..], tag)`

In general, we can group some of jobs by tag, get it during the work of queue on some of state(progress, paused, failed...) and process it.
What do you think about this?
