### PR TITLE
Add timeout to blocking call

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,7 @@ gulp.task('lint', function (){
   return gulp.src([
     './lib/job.js',
     './lib/queue.js',
-    '!./test/**'
+    './test/**'
     ])
     .pipe(eslint({
       rules: {
@@ -27,7 +27,13 @@ gulp.task('lint', function (){
             'no-underscore-dangle': 0
         },
         globals: {
-          'define': true
+          'define': true,
+          'describe': true,
+          'it': true,
+          'setTimeout': true,
+          'afterEach': true,
+          'beforeEach': true,
+          'before': true
         }
     }))
     .pipe(eslint.format())

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -170,6 +170,7 @@ Queue.prototype.process = function(concurrency, handler){
     handler = concurrency;
     concurrency = 1;
   }
+
   if(this.handler) {
     throw new Error('Cannot define a handler more than once per Queue instance');
   }
@@ -476,6 +477,7 @@ Queue.prototype.processJobs = function(){
   var _this = this;
 
   return this.getNextJob().then(function (job) {
+    if(job === null) { return null; }
     return job.delayIfNeeded().then(function(delayed) {
       return !delayed && job.takeLock(_this.token);
     }).then(function (locked) {
@@ -526,6 +528,7 @@ Queue.prototype.processJob = function(job){
   this.emit('active', job);
 
   lockRenewer();
+
   var jobPromise = runHandler(job);
 
   if(timeoutMs){
@@ -541,7 +544,12 @@ Queue.prototype.processJob = function(job){
 Queue.prototype.getNextJob = function(opts){
   var getJobFromId = Job.fromId.bind(null, this); //should this be a queue method?
 
-  return this.moveJob('wait', 'active', opts).then(getJobFromId);
+  return this.moveJob('wait', 'active', opts).then(function (jobId) {
+    if(jobId !== null) {
+      return getJobFromId(jobId);
+    }
+    return null;
+  });
 };
 
 Queue.prototype.multi = function(){
@@ -559,7 +567,7 @@ Queue.prototype.moveJob = function(src, dst, opts) {
   if(opts && opts.block === false){
     return this.bclient.rpoplpushAsync(this.toKey(src), this.toKey(dst));
   }else{
-    return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst), 0);
+    return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst), Math.floor(this.LOCK_RENEW_TIME / 1000));
   }
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -464,8 +464,9 @@ Queue.prototype.processStalledJob = function(job){
 Queue.prototype.processJobs = function(){
   var _this = this;
 
-  return this.getNextJob().then(function (job) {
-    if(job === null) { return null; }
+  return this.processStalledJobs().then(function() {
+    return _this.getNextJob();
+  }).then(function (job) {
     return job.delayIfNeeded().then(function(delayed) {
       return !delayed && job.takeLock(_this.token);
     }).then(function (locked) {
@@ -532,12 +533,7 @@ Queue.prototype.processJob = function(job){
 Queue.prototype.getNextJob = function(opts){
   var getJobFromId = Job.fromId.bind(null, this); //should this be a queue method?
 
-  return this.moveJob('wait', 'active', opts).then(function (jobId) {
-    if(jobId !== null) {
-      return getJobFromId(jobId);
-    }
-    return null;
-  });
+  return this.moveJob('wait', 'active', opts).then(getJobFromId);
 };
 
 Queue.prototype.multi = function(){
@@ -555,7 +551,14 @@ Queue.prototype.moveJob = function(src, dst, opts) {
   if(opts && opts.block === false){
     return this.bclient.rpoplpushAsync(this.toKey(src), this.toKey(dst));
   }else{
-    return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst), Math.floor(this.LOCK_RENEW_TIME / 1000));
+    return this.bclient.brpoplpushAsync(this.toKey(src), this.toKey(dst),
+                Math.floor(this.LOCK_RENEW_TIME / 1000)).then(function(jobId) {
+      if(jobId){
+        return jobId;
+      }else{
+        return Promise.reject();
+      }
+    });
   }
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -436,18 +436,6 @@ var updateDelaySet = function(queue, delayedTimestamp){
 Queue.prototype.processStalledJobs = function(){
   var _this = this;
 
-/*
-<<<<<<< HEAD
-  return this.client.lrangeAsync(this.toKey('active'), 0, -1).then(function(active){
-    return Promise.all(active.map(function(jobId){
-      return Job.fromId(_this, jobId);
-    }));
-  }).then(function(jobs){
-    var tasks = jobs.map(function(job){
-      return _this.processStalledJob.bind(_this, job);
-
-=======
-*/
   return this.client.lrangeAsync(this.toKey('active'), 0, -1).then(function(jobs){
     return Promise.each(jobs, function(jobId) {
       return Job.fromId(_this, jobId).then(_this.processStalledJob.bind(_this));

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -423,8 +423,8 @@ describe('Priority queue', function(){
 
       // Add a job to pend proccessing
       queue.add({'count': 0}).then(function(){
-        Promise.delay(100).then(function() {
-          queue.pause().then(function(){
+        Promise.delay(500).then(function() {
+           queue.pause().then(function(){
             // Add a series of jobs in a predictable order
             var fn = function(cb){
               queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -1,10 +1,10 @@
-"use strict";
+/*eslint-env node */
+/*global Promise:true */
+'use strict';
 
-var Job = require('../lib/job');
 var Queue = require('../lib/priority-queue');
 var expect = require('expect.js');
 var Promise = require('bluebird');
-var redis = require('redis');
 var sinon = require('sinon');
 var _ = require('lodash');
 var uuid = require('node-uuid');
@@ -28,7 +28,7 @@ describe('Priority queue', function(){
     if(queue){
       return cleanupQueue(queue).then(function(){
         queue = undefined;
-      })
+      });
     }
     sandbox.restore();
   });
@@ -37,7 +37,7 @@ describe('Priority queue', function(){
     var testQueue;
 
     beforeEach(function () {
-        testQueue = buildQueue('test');
+      testQueue = buildQueue('test');
     });
 
     it('should return a promise', function () {
@@ -48,15 +48,15 @@ describe('Priority queue', function(){
   });
 
   it('creates a queue with dots in its name', function(){
-    queue = Queue('using. dots. in.name.');
+    queue = new Queue('using. dots. in.name.');
 
     return queue.add({foo: 'bar'}).then(function(job){
-        expect(job.jobId).to.be.ok()
-        expect(job.data.foo).to.be('bar')
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
       })
       .then(function(){
         queue.process(function(job, jobDone){
-          expect(job.data.foo).to.be.equal('bar')
+          expect(job.data.foo).to.be.equal('bar');
           jobDone();
         });
       });
@@ -71,8 +71,8 @@ describe('Priority queue', function(){
     });
 
     queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok()
-      expect(job.data.foo).to.be('bar')
+      expect(job.jobId).to.be.ok();
+      expect(job.data.foo).to.be('bar');
     }).catch(done);
   });
 
@@ -127,14 +127,14 @@ describe('Priority queue', function(){
 
     queueStalled.empty().then(function() {
       Promise.all(jobs).then(function(){
-        return queueStalled.process(function(job) {
+        return queueStalled.process(function() {
           // instead of completing we just close the queue to simulate a crash.
           return queueStalled.close().then(function() {
             var queue2 = buildQueue('test queue stalled');
             var doneAfterFour = _.after(4, function () {
               done();
             });
-            queue2.on('completed', function (job) {
+            queue2.on('completed', function () {
               doneAfterFour();
             });
 
@@ -143,8 +143,8 @@ describe('Priority queue', function(){
             });
           });
         });
-      }).catch(done)
-    })
+      }).catch(done);
+    });
   });
 
   it('processes jobs that were added before the queue backend started', function(){
@@ -165,7 +165,7 @@ describe('Priority queue', function(){
           jobDone();
         });
 
-        return new Promise(function(resolve, reject){
+        return new Promise(function(resolve){
           var resolveAfterAllJobs = _.after(jobs.length, resolve);
           queue.on('completed', resolveAfterAllJobs);
         });
@@ -178,49 +178,51 @@ describe('Priority queue', function(){
     var stalledQueues = [];
     var jobs = [];
 
-    for(var i=0; i<NUM_QUEUES; i++){
-      var queue = buildQueue('test queue stalled 2');
-      stalledQueues.push(queue);
-      queue.setLockRenewTime(10);
+    for(var i = 0; i < NUM_QUEUES; i++){
+      var stalledQueue = buildQueue('test queue stalled 2');
+      stalledQueues.push(stalledQueue);
+      stalledQueue.setLockRenewTime(10);
 
-      for(var j=0; j<NUM_JOBS_PER_QUEUE; j++){
-        jobs.push(queue.add({job: j}));
+      for(var j = 0; j < NUM_JOBS_PER_QUEUE; j++){
+        jobs.push(stalledQueue.add({job: j}));
       }
     }
 
     Promise.all(jobs).then(function(){
       var processed = 0;
-      for(var k=0; k<stalledQueues.length; k++){
-        stalledQueues[k].process(function(job){
-          // instead of completing we just close the queue to simulate a crash.
-          this.close().then(function() {
-            processed ++;
-            if(processed === stalledQueues.length){
-              setTimeout(function(){
-                var queue2 = buildQueue('test queue stalled 2');
-                queue2.process(function(job, jobDone){
-                  jobDone();
-                });
+      var procFn = function(){
+        // instead of completing we just close the queue to simulate a crash.
+        this.close().then(function() {
+          processed++;
+          if(processed === stalledQueues.length){
+            setTimeout(function(){
+              var queue2 = buildQueue('test queue stalled 2');
+              queue2.process(function(job2, jobDone){
+                jobDone();
+              });
 
-                var counter = 0;
-                queue2.on('completed', function(job){
-                  counter ++;
-                  if(counter === NUM_QUEUES * NUM_JOBS_PER_QUEUE) {
-                    queue2.close().then(function(){
-                        done();
-                    });
-                  }
-                });
-              }, 100);
-            }
-          });
+              var counter = 0;
+              queue2.on('completed', function(){
+                counter++;
+                if(counter === NUM_QUEUES * NUM_JOBS_PER_QUEUE) {
+                  queue2.close().then(function(){
+                    done();
+                  });
+                }
+              });
+            }, 100);
+          }
         });
+      };
+
+      for(var k = 0; k < stalledQueues.length; k++){
+        stalledQueues[k].process(procFn);
       }
     });
   });
 
   it('does not process a job that is being processed when a new queue starts', function(done){
-    this.timeout(5000)
+    this.timeout(5000);
     var err = null;
     var anotherQueue;
     var queueName = uuid();
@@ -235,9 +237,9 @@ describe('Priority queue', function(){
         }
 
         anotherQueue = buildQueue(queueName);
-        anotherQueue.process(function(job, jobDone){
+        anotherQueue.process(function(job2, jobDone2){
           err = new Error('The second queue should not have received a job to process');
-          jobDone();
+          jobDone2();
         });
 
         setTimeout(jobDone, 100);
@@ -252,7 +254,7 @@ describe('Priority queue', function(){
   it.skip('process stalled jobs without requiring a queue restart');
 
   it('process a job that fails', function(done){
-    var jobError = Error("Job Failed");
+    var jobError = new Error('Job Failed');
     queue = buildQueue();
 
     queue.process(function(job, jobDone){
@@ -276,11 +278,11 @@ describe('Priority queue', function(){
   });
 
   it('process a job that throws an exception', function(done){
-    var jobError = new Error("Job Failed");
+    var jobError = new Error('Job Failed');
 
     queue = buildQueue();
 
-    queue.process(function(job, jobDone){
+    queue.process(function(job){
       expect(job.data.foo).to.be.equal('bar');
       throw jobError;
     });
@@ -310,23 +312,24 @@ describe('Priority queue', function(){
       expect(job.data.num).to.be.equal(counter);
       expect(job.data.foo).to.be.equal('bar');
       jobDone();
-      if(counter == maxJobs) done();
+      if(counter === maxJobs){
+        done();
+      }
       counter++;
     });
 
-    for(var i=1; i<=maxJobs; i++){
+    for(var i = 1; i <= maxJobs; i++){
       queue.add({foo: 'bar', num: i});
     }
   });
 
   it('count added, unprocessed jobs', function(){
-    var counter = 1;
     var maxJobs = 100;
     var added = [];
 
     queue = buildQueue();
 
-    for(var i=1; i<=maxJobs; i++){
+    for(var i = 1; i <= maxJobs; i++){
       added.push(queue.add({foo: 'bar', num: i}));
     }
 
@@ -352,7 +355,9 @@ describe('Priority queue', function(){
       expect(job.data.foo).to.be.equal('paused');
       jobDone();
       counter--;
-      if(counter === 0) done();
+      if(counter === 0){
+        done();
+      }
     });
 
     queue.pause();
@@ -406,7 +411,7 @@ describe('Priority queue', function(){
 
   it('process a lifo queue', function(done){
     var currentValue = 0, first = true;
-    queue = Queue('test lifo');
+    queue = new Queue('test lifo');
 
     queue.once('ready', function(){
       queue.process(function(job, jobDone){
@@ -426,7 +431,7 @@ describe('Priority queue', function(){
       // Add a job to pend proccessing
       queue.add({'count': 0}).then(function(){
         Promise.delay(500).then(function() {
-           queue.pause().then(function(){
+          queue.pause().then(function(){
             // Add a series of jobs in a predictable order
             var fn = function(cb){
               queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);
@@ -435,12 +440,12 @@ describe('Priority queue', function(){
               queue.resume();
             }))));
           });
-        })
+        });
       });
     });
   });
 
-  describe("Jobs getters", function(){
+  describe('Jobs getters', function(){
     it('should get waitting jobs', function(done){
       queue = buildQueue();
       Promise.join(queue.add({foo: 'bar'}), queue.add({baz: 'qux'})).then(function(){
@@ -455,8 +460,6 @@ describe('Priority queue', function(){
     });
 
     it('should get active jobs', function(done){
-      var counter = 2;
-
       queue = buildQueue();
       queue.process(function(job, jobDone){
         queue.getActive().then(function(jobs){
@@ -471,7 +474,7 @@ describe('Priority queue', function(){
       queue.add({foo: 'bar'});
     });
 
-    it('should get completed jobs', function(){
+    it('should get completed jobs', function(done){
       var counter = 2;
 
       queue = buildQueue();
@@ -480,7 +483,7 @@ describe('Priority queue', function(){
       });
 
       queue.on('completed', function(){
-        counter --;
+        counter--;
 
         if(counter === 0){
           queue.getCompleted().then(function(jobs){
@@ -502,11 +505,11 @@ describe('Priority queue', function(){
       queue = buildQueue();
 
       queue.process(function(job, jobDone){
-        jobDone(Error("Forced error"));
+        jobDone(new Error('Forced error'));
       });
 
       queue.on('failed', function(){
-        counter --;
+        counter--;
 
         if(counter === 0){
           queue.getFailed().then(function(jobs){

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -7,6 +7,7 @@ var Promise = require('bluebird');
 var redis = require('redis');
 var sinon = require('sinon');
 var _ = require('lodash');
+var uuid = require('node-uuid');
 
 var STD_QUEUE_NAME = 'test queue';
 
@@ -222,8 +223,8 @@ describe('Priority queue', function(){
     this.timeout(5000)
     var err = null;
     var anotherQueue;
-
-    queue = buildQueue();
+    var queueName = uuid();
+    queue = buildQueue(queueName);
 
     queue.add({foo: 'bar'}).then(function(addedJob){
       queue.process(function(job, jobDone){
@@ -235,7 +236,7 @@ describe('Priority queue', function(){
         setTimeout(jobDone, 100);
       });
 
-      anotherQueue = buildQueue();
+      anotherQueue = buildQueue(queueName);
       anotherQueue.process(function(job, jobDone){
         err = new Error('The second queue should not have received a job to process');
         jobDone();

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -233,13 +233,14 @@ describe('Priority queue', function(){
         if(addedJob.jobId !== job.jobId){
           err = new Error('Processed job id does not match that of added job');
         }
-        setTimeout(jobDone, 100);
-      });
 
-      anotherQueue = buildQueue(queueName);
-      anotherQueue.process(function(job, jobDone){
-        err = new Error('The second queue should not have received a job to process');
-        jobDone();
+        anotherQueue = buildQueue(queueName);
+        anotherQueue.process(function(job, jobDone){
+          err = new Error('The second queue should not have received a job to process');
+          jobDone();
+        });
+
+        setTimeout(jobDone, 100);
       });
 
       queue.on('completed', function(){

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1,6 +1,7 @@
-"use strict";
+/*eslint-env node */
+/*global Promise:true */
+'use strict';
 
-var Job = require('../lib/job');
 var Queue = require('../');
 var expect = require('expect.js');
 var Promise = require('bluebird');
@@ -27,7 +28,7 @@ describe('Queue', function(){
     if(queue){
       return cleanupQueue(queue).then(function(){
         queue = undefined;
-      })
+      });
     }
     sandbox.restore();
   });
@@ -36,7 +37,7 @@ describe('Queue', function(){
     var testQueue;
 
     beforeEach(function () {
-        testQueue = new Queue('test');
+      testQueue = new Queue('test');
     });
 
     it('should call end on the client', function () {
@@ -69,7 +70,7 @@ describe('Queue', function(){
 
   describe('instantiation', function(){
     it('should create a queue with standard redis opts', function(done){
-      queue = Queue('standard');
+      queue = new Queue('standard');
 
       queue.once('ready', function(){
         expect(queue.client.connectionOption.host).to.be('127.0.0.1');
@@ -86,7 +87,7 @@ describe('Queue', function(){
     });
 
     it('creates a queue using the supplied redis DB', function(done){
-      queue = Queue('custom', {redis: {DB: 1}});
+      queue = new Queue('custom', {redis: {DB: 1}});
 
       queue.once('ready', function(){
         expect(queue.client.connectionOption.host).to.be('127.0.0.1');
@@ -103,7 +104,7 @@ describe('Queue', function(){
     });
 
     it('creates a queue using custom the supplied redis host', function(done){
-      queue = Queue('custom', {redis: {host: 'localhost'}});
+      queue = new Queue('custom', {redis: {host: 'localhost'}});
 
       queue.once('ready', function(){
         expect(queue.client.connectionOption.host).to.be('localhost');
@@ -116,14 +117,14 @@ describe('Queue', function(){
     });
 
     it('creates a queue with dots in its name', function(){
-      queue = Queue('using. dots. in.name.');
+      queue = new Queue('using. dots. in.name.');
 
       return queue.add({foo: 'bar'}).then(function(job){
-        expect(job.jobId).to.be.ok()
-        expect(job.data.foo).to.be('bar')
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
       }).then(function(){
         queue.process(function(job, jobDone){
-          expect(job.data.foo).to.be.equal('bar')
+          expect(job.data.foo).to.be.equal('bar');
           jobDone();
         });
       });
@@ -132,8 +133,8 @@ describe('Queue', function(){
 
   describe('connection', function(){
     it('should recover from a connection loss', function(done){
-      queue = Queue('test connection loss');
-      queue.on('error', function(err){
+      queue = new Queue('test connection loss');
+      queue.on('error', function(){
         // error event has to be observed or the exception will bubble up
       }).process(function(job, jobDone){
         expect(job.data.foo).to.be.equal('bar');
@@ -154,9 +155,9 @@ describe('Queue', function(){
 
       var runSpy = sandbox.spy(queue, 'run');
       queue.process(function (job, jobDone) {
-          expect(runSpy.callCount).to.be(2);
-          jobDone();
-          done();
+        expect(runSpy.callCount).to.be(2);
+        jobDone();
+        done();
       });
 
       expect(runSpy.callCount).to.be(1);
@@ -174,358 +175,372 @@ describe('Queue', function(){
 
       setTimeout(function() {
         expect(runSpy.callCount).to.be(0);
-        done()
-      }, 100)
+        done();
+      }, 100);
     });
   });
 
   describe(' a worker', function(){
     it('should process a job', function(done){
-    queue = buildQueue();
-    queue.process(function(job, jobDone){
-      expect(job.data.foo).to.be.equal('bar');
-      jobDone();
-      done();
+      queue = buildQueue();
+      queue.process(function(job, jobDone){
+        expect(job.data.foo).to.be.equal('bar');
+        jobDone();
+        done();
+      });
+
+      queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }).catch(done);
     });
 
-    queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok()
-      expect(job.data.foo).to.be('bar')
-    }).catch(done);
-  });
+    it('process a job that updates progress', function(done){
+      queue = buildQueue();
+      queue.process(function(job, jobDone){
+        expect(job.data.foo).to.be.equal('bar');
+        job.progress(42);
+        jobDone();
+      });
 
-  it('process a job that updates progress', function(done){
-    queue = buildQueue();
-    queue.process(function(job, jobDone){
-      expect(job.data.foo).to.be.equal('bar');
-      job.progress(42);
-      jobDone();
+      queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }).catch(done);
+
+      queue.on('progress', function(job, progress){
+        expect(job).to.be.ok();
+        expect(progress).to.be.eql(42);
+        done();
+      });
     });
 
-    queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-    }).catch(done);
+    it('process a job that returns data in the process handler', function(done){
+      queue = buildQueue();
+      queue.process(function(job, jobDone){
+        expect(job.data.foo).to.be.equal('bar');
+        jobDone(null, 37);
+      });
 
-    queue.on('progress', function(job, progress){
-      expect(job).to.be.ok();
-      expect(progress).to.be.eql(42);
-      done();
+      queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }).catch(done);
+
+      queue.on('completed', function(job, data){
+        expect(job).to.be.ok();
+        expect(data).to.be.eql(37);
+        done();
+      });
     });
-  });
 
-  it('process a job that returns data in the process handler', function(done){
-    queue = buildQueue();
-    queue.process(function(job, jobDone){
-      expect(job.data.foo).to.be.equal('bar');
-      jobDone(null, 37);
+    it('process stalled jobs when starting a queue', function(done){
+      var queueStalled = new Queue('test queue stalled', 6379, '127.0.0.1');
+      queueStalled.LOCK_RENEW_TIME = 10;
+      var jobs = [
+        queueStalled.add({bar: 'baz'}),
+        queueStalled.add({bar1: 'baz1'}),
+        queueStalled.add({bar2: 'baz2'}),
+        queueStalled.add({bar3: 'baz3'})
+      ];
+
+      Promise.all(jobs).then(function(){
+        queueStalled.process(function(){
+          // instead of completing we just close the queue to simulate a crash.
+          queueStalled.close();
+          setTimeout(function(){
+            var queue2 = new Queue('test queue stalled', 6379, '127.0.0.1');
+            var doneAfterFour = _.after(4, function(){
+              done();
+            });
+            queue2.on('completed', doneAfterFour);
+
+            queue2.process(function(job, jobDone){
+              jobDone();
+            });
+          }, 100);
+        });
+      });
     });
 
-    queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-    }).catch(done);
+    it('processes jobs that were added before the queue backend started', function(){
+      var queueStalled = new Queue('test queue added before', 6379, '127.0.0.1');
+      queueStalled.LOCK_RENEW_TIME = 10;
+      var jobs = [
+        queueStalled.add({bar: 'baz'}),
+        queueStalled.add({bar1: 'baz1'}),
+        queueStalled.add({bar2: 'baz2'}),
+        queueStalled.add({bar3: 'baz3'})
+      ];
 
-    queue.on('completed', function(job, data){
-      expect(job).to.be.ok();
-      expect(data).to.be.eql(37);
-      done();
-    });
-  });
-
-  it('process stalled jobs when starting a queue', function(done){
-    var queueStalled = Queue('test queue stalled', 6379, '127.0.0.1');
-    queueStalled.LOCK_RENEW_TIME = 10;
-    var jobs = [
-      queueStalled.add({bar: 'baz'}),
-      queueStalled.add({bar1: 'baz1'}),
-      queueStalled.add({bar2: 'baz2'}),
-      queueStalled.add({bar3: 'baz3'})
-    ];
-
-    Promise.all(jobs).then(function(){
-      queueStalled.process(function(job){
-        // instead of completing we just close the queue to simulate a crash.
-        queueStalled.close();
-        setTimeout(function(){
-          var queue2 = Queue('test queue stalled', 6379, '127.0.0.1');
-          var doneAfterFour = _.after(4, function(){
-            done();
-          });
-          queue2.on('completed', doneAfterFour);
-
-          queue2.process(function(job, jobDone){
+      return Promise.all(jobs)
+        .then(queueStalled.close.bind(queueStalled))
+        .then(function(){
+          queue = new Queue('test queue added before', 6379, '127.0.0.1');
+          queue.process(function(job, jobDone){
             jobDone();
           });
-        }, 100);
-      });
+
+          return new Promise(function(resolve){
+            var resolveAfterAllJobs = _.after(jobs.length, resolve);
+            queue.on('completed', resolveAfterAllJobs);
+          });
+        });
     });
-  });
 
-  it('processes jobs that were added before the queue backend started', function(){
-    var queueStalled = Queue('test queue added before', 6379, '127.0.0.1');
-    queueStalled.LOCK_RENEW_TIME = 10;
-    var jobs = [
-      queueStalled.add({bar: 'baz'}),
-      queueStalled.add({bar1: 'baz1'}),
-      queueStalled.add({bar2: 'baz2'}),
-      queueStalled.add({bar3: 'baz3'})
-    ];
+    it('processes several stalled jobs when starting several queues', function(done){
+      var NUM_QUEUES = 10;
+      var NUM_JOBS_PER_QUEUE = 20;
+      var stalledQueues = [];
+      var jobs = [];
 
-    return Promise.all(jobs)
-      .then(queueStalled.close.bind(queueStalled))
-      .then(function(){
-        queue = Queue('test queue added before', 6379, '127.0.0.1');
-        queue.process(function(job, jobDone){
-          jobDone();
-        });
+      for(var i = 0; i < NUM_QUEUES; i++){
+        var queueStalled2 = new Queue('test queue stalled 2', 6379, '127.0.0.1');
+        stalledQueues.push(queueStalled2);
+        queueStalled2.LOCK_RENEW_TIME = 10;
 
-        return new Promise(function(resolve, reject){
-          var resolveAfterAllJobs = _.after(jobs.length, resolve);
-          queue.on('completed', resolveAfterAllJobs);
-        });
-      });
-  });
-
-  it('processes several stalled jobs when starting several queues', function(done){
-    var NUM_QUEUES = 10;
-    var NUM_JOBS_PER_QUEUE = 20;
-    var stalledQueues = [];
-    var jobs = [];
-
-    for(var i=0; i<NUM_QUEUES; i++){
-      var queue = Queue('test queue stalled 2', 6379, '127.0.0.1');
-      stalledQueues.push(queue);
-      queue.LOCK_RENEW_TIME = 10;
-
-      for(var j=0; j<NUM_JOBS_PER_QUEUE; j++){
-        jobs.push(queue.add({job: j}));
+        for(var j = 0; j < NUM_JOBS_PER_QUEUE; j++){
+          jobs.push(queueStalled2.add({job: j}));
+        }
       }
-    }
 
-    Promise.all(jobs).then(function(){
-      var processed = 0;
-      for(var k=0; k<stalledQueues.length; k++){
-        stalledQueues[k].process(function(job){
+      Promise.all(jobs).then(function(){
+        var processed = 0;
+        var procFn = function() {
           // instead of completing we just close the queue to simulate a crash.
           this.close();
 
-          processed ++;
+          processed++;
           if(processed === stalledQueues.length){
             setTimeout(function(){
-              var queue2 = Queue('test queue stalled 2', 6379, '127.0.0.1');
-              queue2.process(function(job, jobDone){
+              var queue2 = new Queue('test queue stalled 2', 6379, '127.0.0.1');
+              queue2.process(function(job2, jobDone){
                 jobDone();
               });
 
               var counter = 0;
-              queue2.on('completed', function(job){
-                counter ++;
+              queue2.on('completed', function(){
+                counter++;
                 if(counter === NUM_QUEUES * NUM_JOBS_PER_QUEUE) {
                   queue2.close().then(function(){
-                      done();
+                    done();
                   });
                 }
               });
             }, 100);
           }
-        });
-      }
+        };
+
+        for(var k = 0; k < stalledQueues.length; k++){
+          stalledQueues[k].process(procFn);
+        }
+      });
     });
-  });
 
-  it('does not process a job that is being processed when a new queue starts', function(done){
-    this.timeout(5000)
-    var err = null;
-    var anotherQueue;
+    it('does not process a job that is being processed when a new queue starts', function(done){
+      this.timeout(5000);
+      var err = null;
+      var anotherQueue;
 
-    queue = buildQueue();
+      queue = buildQueue();
 
-    queue.add({foo: 'bar'}).then(function(addedJob){
+      queue.add({foo: 'bar'}).then(function(addedJob){
+        queue.process(function(job, jobDone){
+          expect(job.data.foo).to.be.equal('bar');
+
+          if(addedJob.jobId !== job.jobId){
+            err = new Error('Processed job id does not match that of added job');
+          }
+          setTimeout(jobDone, 100);
+        });
+        setTimeout(function() {
+          anotherQueue = buildQueue();
+          anotherQueue.process(function(job, jobDone){
+            err = new Error('The second queue should not have received a job to process');
+            jobDone();
+          });
+
+          queue.on('completed', function(){
+            cleanupQueue(anotherQueue).then(done.bind(null, err));
+          });
+        }, 10);
+      });
+    });
+
+    it('process stalled jobs without requiring a queue restart', function (done) {
+      queue = buildQueue();
       queue.process(function(job, jobDone){
         expect(job.data.foo).to.be.equal('bar');
-
-        if(addedJob.jobId !== job.jobId){
-          err = new Error('Processed job id does not match that of added job');
-        }
-        setTimeout(jobDone, 100);
+        jobDone();
+        done();
       });
-      setTimeout(function() {
-        anotherQueue = buildQueue();
-        anotherQueue.process(function(job, jobDone){
-          err = new Error('The second queue should not have received a job to process');
-          jobDone();
-        });
-
-        queue.on('completed', function(){
-          cleanupQueue(anotherQueue).then(done.bind(null, err));
-        });
-      }, 10);
-    });
-  });
-
-  it('process stalled jobs without requiring a queue restart');
-
-  it('process a job that fails', function(done){
-    var jobError = Error("Job Failed");
-    queue = buildQueue();
-
-    queue.process(function(job, jobDone){
-      expect(job.data.foo).to.be.equal('bar');
-      jobDone(jobError);
-    });
-
-    queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-    }, function(err){
-      done(err);
-    });
-
-    queue.once('failed', function(job, err){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-      expect(err).to.be.eql(jobError);
-      done();
-    });
-  });
-
-  it('process a job that throws an exception', function(done){
-    var jobError = new Error("Job Failed");
-
-    queue = buildQueue();
-
-    queue.process(function(job, jobDone){
-      expect(job.data.foo).to.be.equal('bar');
-      throw jobError;
-    });
-
-    queue.add({foo: 'bar'}).then(function(job){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-    }, function(err){
-      done(err);
-    });
-
-    queue.once('failed', function(job, err){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-      expect(err).to.be.eql(jobError);
-      done();
-    });
-  });
-
-  it('retry a job that fails', function(done){
-    var called = 0
-    var messages = 0;
-    var failedOnce = false;
-
-    var queue = buildQueue('retry-test-queue');
-    var client = redis.createClient(6379, '127.0.0.1', {});
-
-    client.select(0);
-
-    client.on('ready', function () {
-      client.on("message", function(channel, message) {
-        expect(channel).to.be.equal(queue.toKey("jobs"));
-        expect(parseInt(message, 10)).to.be.a('number');
-        messages++;
-      });
-      client.subscribe(queue.toKey("jobs"));
 
       queue.add({foo: 'bar'}).then(function(job){
         expect(job.jobId).to.be.ok();
         expect(job.data.foo).to.be('bar');
+      }).catch(done);
+    });
+
+    it('process a job that fails', function(done){
+      var jobError = new Error('Job Failed');
+      queue = buildQueue();
+
+      queue.process(function(job, jobDone){
+        expect(job.data.foo).to.be.equal('bar');
+        jobDone(jobError);
+      });
+
+      queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }, function(err){
+        done(err);
+      });
+
+      queue.once('failed', function(job, err){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+        expect(err).to.be.eql(jobError);
+        done();
       });
     });
 
-    queue.process(function(job, jobDone){
-      called++;
-      if (called % 2 !== 0){
-        throw new Error("Not even!")
-      }
-      jobDone();
+    it('process a job that throws an exception', function(done){
+      var jobError = new Error('Job Failed');
+
+      queue = buildQueue();
+
+      queue.process(function(job){
+        expect(job.data.foo).to.be.equal('bar');
+        throw jobError;
+      });
+
+      queue.add({foo: 'bar'}).then(function(job){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }, function(err){
+        done(err);
+      });
+
+      queue.once('failed', function(job, err){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+        expect(err).to.be.eql(jobError);
+        done();
+      });
     });
 
-    queue.once('failed', function(job, err){
-      expect(job.jobId).to.be.ok();
-      expect(job.data.foo).to.be('bar');
-      expect(err.message).to.be.eql("Not even!");
-      failedOnce = true
-      queue.retryJob(job);
-    });
+    it('retry a job that fails', function(done){
+      var called = 0;
+      var messages = 0;
+      var failedOnce = false;
 
-    queue.once('completed', function(){
-      expect(failedOnce).to.be(true);
-      expect(messages).to.eql(2);
-      done();
-    });
-  });
+      var retryQueue = buildQueue('retry-test-queue');
+      var client = redis.createClient(6379, '127.0.0.1', {});
 
-  it('process several jobs serially', function(done){
-    var counter = 1;
-    var maxJobs = 100;
+      client.select(0);
 
-    queue = buildQueue();
+      client.on('ready', function () {
+        client.on('message', function(channel, message) {
+          expect(channel).to.be.equal(retryQueue.toKey('jobs'));
+          expect(parseInt(message, 10)).to.be.a('number');
+          messages++;
+        });
+        client.subscribe(retryQueue.toKey('jobs'));
 
-    queue.process(function(job, jobDone){
-      expect(job.data.num).to.be.equal(counter);
-      expect(job.data.foo).to.be.equal('bar');
-      jobDone();
-      if(counter == maxJobs) done();
-      counter++;
-    });
+        retryQueue.add({foo: 'bar'}).then(function(job){
+          expect(job.jobId).to.be.ok();
+          expect(job.data.foo).to.be('bar');
+        });
+      });
 
-    for(var i=1; i<=maxJobs; i++){
-      queue.add({foo: 'bar', num: i});
-    }
-  });
-
-  it('process a lifo queue', function(done){
-    var currentValue = 0, first = true;
-    queue = Queue('test lifo');
-
-    queue.once('ready', function(){
-      queue.process(function(job, jobDone){
-        // Catching the job before the pause
-        if(first){
-          expect(job.data.count).to.be.equal(0);
-          first = false;
-          return jobDone();
+      retryQueue.process(function(job, jobDone){
+        called++;
+        if(called % 2 !== 0){
+          throw new Error('Not even!');
         }
-        expect(job.data.count).to.be.equal(currentValue--);
         jobDone();
-        if(currentValue === 0){
+      });
+
+      retryQueue.once('failed', function(job, err){
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+        expect(err.message).to.be.eql('Not even!');
+        failedOnce = true;
+        retryQueue.retryJob(job);
+      });
+
+      retryQueue.once('completed', function(){
+        expect(failedOnce).to.be(true);
+        expect(messages).to.eql(2);
+        done();
+      });
+    });
+
+    it('process several jobs serially', function(done){
+      var counter = 1;
+      var maxJobs = 100;
+
+      queue = buildQueue();
+
+      queue.process(function(job, jobDone){
+        expect(job.data.num).to.be.equal(counter);
+        expect(job.data.foo).to.be.equal('bar');
+        jobDone();
+        if(counter === maxJobs) {
           done();
         }
+        counter++;
       });
 
-      // Add a job to pend proccessing
-      queue.add({'count': 0}).then(function(){
-        queue.pause().then(function(){
-          // Add a series of jobs in a predictable order
-          var fn = function(cb){
-            queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);
-          };
-          fn(fn(fn(fn(function(){
-            queue.resume();
-          }))));
+      for(var i = 1; i <= maxJobs; i++){
+        queue.add({foo: 'bar', num: i});
+      }
+    });
+
+    it('process a lifo queue', function(done){
+      var currentValue = 0, first = true;
+      queue = new Queue('test lifo');
+
+      queue.once('ready', function(){
+        queue.process(function(job, jobDone){
+          // Catching the job before the pause
+          if(first){
+            expect(job.data.count).to.be.equal(0);
+            first = false;
+            return jobDone();
+          }
+          expect(job.data.count).to.be.equal(currentValue--);
+          jobDone();
+          if(currentValue === 0){
+            done();
+          }
+        });
+
+        // Add a job to pend proccessing
+        queue.add({'count': 0}).then(function(){
+          queue.pause().then(function(){
+            // Add a series of jobs in a predictable order
+            var fn = function(cb){
+              queue.add({'count': ++currentValue}, {'lifo': true}).then(cb);
+            };
+            fn(fn(fn(fn(function(){
+              queue.resume();
+            }))));
+          });
         });
       });
     });
-  });
 
   });
-
 
   it('count added, unprocessed jobs', function(){
-    var counter = 1;
     var maxJobs = 100;
     var added = [];
 
     queue = buildQueue();
 
-    for(var i=1; i<=maxJobs; i++){
+    for(var i = 1; i <= maxJobs; i++){
       added.push(queue.add({foo: 'bar', num: i}));
     }
 
@@ -550,13 +565,13 @@ describe('Queue', function(){
     });
   });
 
-  describe(".pause", function(){
+  describe('.pause', function(){
     it('should pause a queue until resumed', function(){
       var ispaused = false, counter = 2;
 
       queue = buildQueue();
 
-      var resultPromise = new Promise(function(resolve, reject){
+      var resultPromise = new Promise(function(resolve){
         queue.process(function(job, jobDone){
           expect(ispaused).to.be(false);
           expect(job.data.foo).to.be.equal('paused');
@@ -569,15 +584,15 @@ describe('Queue', function(){
       });
 
       return Promise.join(queue.pause().then(function(){
-          ispaused = true;
-          return queue.add({foo: 'paused'});
+        ispaused = true;
+        return queue.add({foo: 'paused'});
       }).then(function(){
         return queue.add({foo: 'paused'});
       }).then(function(){
-          ispaused = false;
-          queue.resume();
-      }), resultPromise);;
-    })
+        ispaused = false;
+        queue.resume();
+      }), resultPromise);
+    });
 
     it('should be able to pause a running queue and emit relevant events', function(done){
       var ispaused = false, isresumed = true, first = true;
@@ -619,44 +634,44 @@ describe('Queue', function(){
   it('should publish a message when a new message is added to the queue', function(done) {
     var client = redis.createClient(6379, '127.0.0.1', {});
     client.select(0);
-    queue = Queue('test pub sub');
+    queue = new Queue('test pub sub');
     client.on('ready', function () {
-      client.on("message", function(channel, message) {
-        expect(channel).to.be.equal(queue.toKey("jobs"));
+      client.on('message', function(channel, message) {
+        expect(channel).to.be.equal(queue.toKey('jobs'));
         expect(parseInt(message, 10)).to.be.a('number');
         done();
       });
-      client.subscribe(queue.toKey("jobs"));
-      queue.add({test: "stuff"});
+      client.subscribe(queue.toKey('jobs'));
+      queue.add({test: 'stuff'});
     });
   });
 
-  it("should emit an event when a job becomes active", function (done) {
+  it('should emit an event when a job becomes active', function (done) {
     queue = buildQueue();
     queue.process(function(job, jobDone){
       jobDone();
     });
     queue.add({});
-    queue.once('active', function (job) {
-      queue.once('completed', function (job) {
+    queue.once('active', function () {
+      queue.once('completed', function () {
         done();
       });
     });
   });
 
-  describe("Delayed jobs", function(){
-    it("should process a delayed job only after delayed time", function(done){
+  describe('Delayed jobs', function(){
+    it('should process a delayed job only after delayed time', function(done){
       var delay = 500;
-      queue = Queue("delayed queue simple");
+      queue = new Queue('delayed queue simple');
       var client = redis.createClient(6379, '127.0.0.1', {});
       var timestamp = Date.now();
       var publishHappened = false;
       client.on('ready', function () {
-        client.on("message", function(channel, message) {
+        client.on('message', function(channel, message) {
           expect(parseInt(message, 10)).to.be.a('number');
           publishHappened = true;
         });
-        client.subscribe(queue.toKey("jobs"));
+        client.subscribe(queue.toKey('jobs'));
       });
 
       queue.process(function(job, jobDone){
@@ -670,7 +685,7 @@ describe('Queue', function(){
         }).then(function(){
           return queue.getDelayed().then(function(jobs){
             expect(jobs.length).to.be.equal(0);
-          })
+          });
         }).then(function(){
           expect(publishHappened).to.be(true);
           done();
@@ -679,16 +694,16 @@ describe('Queue', function(){
 
       queue.on('ready', function () {
         queue.add({delayed: 'foobar'}, {delay: delay}).then(function(job){
-          expect(job.jobId).to.be.ok()
-          expect(job.data.delayed).to.be('foobar')
-          expect(job.delay).to.be(delay)
+          expect(job.jobId).to.be.ok();
+          expect(job.data.delayed).to.be('foobar');
+          expect(job.delay).to.be(delay);
         });
       });
     });
 
-    it("should process delayed jobs in correct order", function(done){
+    it('should process delayed jobs in correct order', function(done){
       var order = 0;
-      queue = Queue("delayed queue multiple");
+      queue = new Queue('delayed queue multiple');
 
       queue.process(function(job, jobDone){
         expect(order).to.be.below(job.data.order);
@@ -712,17 +727,17 @@ describe('Queue', function(){
       queue.add({order: 8}, {delay: 800});
     });
 
-    it("should process delayed jobs in correct order even in case of restart", function(done){
-      var QUEUE_NAME = "delayed queue multiple";
+    it('should process delayed jobs in correct order even in case of restart', function(done){
+      var QUEUE_NAME = 'delayed queue multiple';
       var order = 1;
 
-      queue = Queue(QUEUE_NAME);
+      queue = new Queue(QUEUE_NAME);
 
       var fn = function(job, jobDone){
         expect(order).to.be.equal(job.data.order);
         jobDone();
 
-        if (order === 4 ) {
+        if(order === 4 ){
           done();
         }
 
@@ -743,27 +758,27 @@ describe('Queue', function(){
           //We simulate a restart
           return queue.close().then(function() {
             return Promise.delay(100).then(function() {
-              queue = Queue(QUEUE_NAME);
+              queue = new Queue(QUEUE_NAME);
               queue.process(fn);
-            })
+            });
           });
         });
     });
 
   });
 
-  describe("Concurrency process", function() {
-    it("should run job in sequence if I specify a concurrency of 1", function (done) {
+  describe('Concurrency process', function() {
+    it('should run job in sequence if I specify a concurrency of 1', function (done) {
       queue = buildQueue();
 
       var processing = false;
 
-      queue.process(1, function (job, done) {
+      queue.process(1, function (job, jobDone) {
         expect(processing).to.be.equal(false);
         processing = true;
         Promise.delay(50).then(function () {
           processing = false;
-          done();
+          jobDone();
         });
       });
 
@@ -776,14 +791,14 @@ describe('Queue', function(){
 
     //This job use delay to check that at any time we have 4 process in parallel.
     //Due to time to get new jobs and call process, false negative can appear.
-    it("should process job respecting the concurrency set", function (done) {
-      queue = buildQueue("test concurrency");
+    it('should process job respecting the concurrency set', function (done) {
+      queue = buildQueue('test concurrency');
       queue.empty().then(function() {
         var nbProcessing = 0;
         var pendingMessageToProcess = 8;
         var wait = 100;
 
-        queue.process(4, function (job, done) {
+        queue.process(4, function (job, jobDone) {
           nbProcessing++;
           expect(nbProcessing).to.be.lessThan(5);
 
@@ -796,7 +811,7 @@ describe('Queue', function(){
 
             pendingMessageToProcess--;
             nbProcessing--;
-            done();
+            jobDone();
           });
         }).catch(done);
 
@@ -814,34 +829,34 @@ describe('Queue', function(){
       });
     });
 
-    it("should wait for all concurrent processing in case of pause", function (done) {
+    it('should wait for all concurrent processing in case of pause', function (done) {
       queue = buildQueue();
 
       var i = 0;
       var nbJobFinish = 0;
 
-      queue.process(3, function (job, done) {
+      queue.process(3, function (job, jobDone) {
         var error = null;
 
-        if (++i === 4) {
+        if(++i === 4){
           queue.pause().then(function () {
             Promise.delay(500).then(function(){ // Wait for all the active jobs to finalize.
               expect(nbJobFinish).to.be.above(3);
               queue.resume();
-            })
+            });
           });
         }
 
         // We simulate an error of one processing job.
         // They had a bug in pause() with this special case.
-        if (i % 3 == 0) {
+        if(i % 3 === 0){
           error = new Error();
         }
 
         //100 - i*20 is to force to finish job n°4 before lower job that will wait longer
-        Promise.delay(100 - i*10).then(function () {
+        Promise.delay(100 - i * 10).then(function () {
           nbJobFinish++;
-          done(error);
+          jobDone(error);
         });
       }).catch(done);
 
@@ -861,7 +876,7 @@ describe('Queue', function(){
     });
   });
 
-  describe("Jobs getters", function(){
+  describe('Jobs getters', function(){
     it('should get waitting jobs', function(done){
       queue = buildQueue();
       Promise.join(queue.add({foo: 'bar'}), queue.add({baz: 'qux'})).then(function(){
@@ -876,8 +891,6 @@ describe('Queue', function(){
     });
 
     it('should get active jobs', function(done){
-      var counter = 2;
-
       queue = buildQueue();
       queue.process(function(job, jobDone){
         queue.getActive().then(function(jobs){
@@ -902,10 +915,10 @@ describe('Queue', function(){
           expect(returnedJob.jobId).to.be(job.jobId);
           done();
         });
-      })
+      });
     });
 
-    it('should get completed jobs', function(){
+    it('should get completed jobs', function(done){
       var counter = 2;
 
       queue = buildQueue();
@@ -914,7 +927,7 @@ describe('Queue', function(){
       });
 
       queue.on('completed', function(){
-        counter --;
+        counter--;
 
         if(counter === 0){
           queue.getCompleted().then(function(jobs){
@@ -936,11 +949,11 @@ describe('Queue', function(){
       queue = buildQueue();
 
       queue.process(function(job, jobDone){
-        jobDone(Error("Forced error"));
+        jobDone(new Error('Forced error'));
       });
 
       queue.on('failed', function(){
-        counter --;
+        counter--;
 
         if(counter === 0){
           queue.getFailed().then(function(jobs){

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -8,6 +8,7 @@ var Promise = require('bluebird');
 var redis = require('redis');
 var sinon = require('sinon');
 var _ = require('lodash');
+var uuid = require('node-uuid');
 
 var STD_QUEUE_NAME = 'test queue';
 
@@ -35,7 +36,6 @@ describe('Queue', function(){
 
   describe('.close', function () {
     var testQueue;
-
     beforeEach(function () {
       testQueue = new Queue('test');
     });
@@ -368,10 +368,12 @@ describe('Queue', function(){
     });
 
     it('process stalled jobs without requiring a queue restart', function (done) {
+      this.timeout(5000);
       var collect = _.after(2, done);
 
-      queue = buildQueue('running-stalled-job');
-      queue.LOCK_RENEW_TIME = 500;
+      queue = buildQueue('running-stalled-job-' + uuid());
+
+      queue.LOCK_RENEW_TIME = 1000;
 
       queue.on('completed', function() {
         collect();


### PR DESCRIPTION
In some edge cases we were seeing clients that haven't been cleaned up correctly and leave a remaining blocking call. 

This means the queue won't be reactivated when the next job is added. The job ends up as stalled jobs immediately, because the job is added to the wait list and no handler is called for it. 

It has an added bonus bull checks for stalled jobs every 5 seconds this way. :smile: