### PR TITLE
Add Redis server required authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,43 @@ if(cluster.isMaster){
 }
 ```
 
+Authenticated redis client connection
+---------------
+
+Bull can also be used with a Redis server required authentication
+like in Heroku (or other hosting) application hosting. Set-up a Redis
+addons and get configs information. You can deploy bull queue with
+authentication credentials. 
+
+```javascript
+var redisCredentials = {
+  auth: true,
+  password: 'my-password-to-connect'
+};
+
+var redisOptions = {
+  port: 6379,
+  host: '127.0.0.1'
+};
+
+var Bull = require('bull');
+// Create queue object
+var queue = Queue('my-queue-id', {
+  auth: redisCredentials.auth,
+  password: redisCredentials.password,
+  redis: redisOptions
+});
+
+// Or use all parameters pattern
+var queue = Queue(
+  'my-queue-id',
+  redisOptions.port, 
+  redisOptions.host,
+  redisCredentials.auth,
+  redisCredentials.password
+);
+```
+
 Useful patterns
 ---------------
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -44,13 +44,15 @@ Promise.promisifyAll(redis);
 var MINIMUM_REDIS_VERSION = '2.8.11';
 var LOCK_RENEW_TIME = 5000; // 5 seconds is the renew time.
 var CLIENT_CLOSE_TIMEOUT_MS = 5000;
+var AUTH_PWD_REQUIRES_ERROR_MSG = 'Redis client in authetication mode requires a password.';
 
-var Queue = function Queue(name, redisPort, redisHost, redisOptions){
+var Queue = function Queue(name, redisPort, redisHost, redisOptions, authRedisRequired, redisPassword){
   if(!(this instanceof Queue)){
     return new Queue(name, redisPort, redisHost, redisOptions);
   }
 
   var redisDB = 0;
+
   if(_.isObject(redisPort)){
     var opts = redisPort;
     var redisOpts = opts.redis || {};
@@ -58,10 +60,17 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisHost = redisOpts.host;
     redisOptions = redisOpts.opts || {};
     redisDB = redisOpts.DB || redisDB;
+    // 
+    // Authentication settings
+    // 
+    authRedisRequired = opts.authRedisRequired;
+    redisPassword = opts.redisPassword;
   }
 
   redisPort = redisPort || 6379;
   redisHost = redisHost || '127.0.0.1';
+  authRedisRequired = authRedisRequired || false;
+  redisPassword = redisPassword || null;
 
   var _this = this;
 
@@ -71,6 +80,14 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   // Create queue client (used to add jobs, pause queues, etc);
   //
   this.client = redis.createClient(redisPort, redisHost, redisOptions);
+  //
+  // Check auth. for client connection
+  // 
+  if(authRedisRequired) {
+    if(redisPassword !== null) {
+      this.client.auth(redisPassword, function(){});
+    } else throw new Error(AUTH_PWD_REQUIRES_ERROR_MSG);
+  }
 
   getRedisVersion(this.client).then(function(version){
     if(semver.lt(version, MINIMUM_REDIS_VERSION)){
@@ -84,11 +101,27 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   // Create blocking client (used to wait for jobs)
   //
   this.bclient = redis.createClient(redisPort, redisHost, redisOptions);
+  //
+  // Check auth. for client connection
+  // 
+  if(authRedisRequired) {
+    if(redisPassword !== null) {
+      this.bclient.auth(redisPassword, function(){});
+    } else throw new Error(AUTH_PWD_REQUIRES_ERROR_MSG);
+  }
 
   //
   // Create event subscriber client (receive messages from other instance of the queue)
   //
   this.eclient = redis.createClient(redisPort, redisHost, redisOptions);
+  //
+  // Check auth. for client connection
+  // 
+  if(authRedisRequired) {
+    if(redisPassword !== null) {
+      this.eclient.auth(redisPassword, function(){});
+    } else throw new Error(AUTH_PWD_REQUIRES_ERROR_MSG);
+  }
 
   this.delayTimer = null;
   this.processing = 0;


### PR DESCRIPTION
Hey, 

I change the Queue object for supporting authenticated Redis connection. I need this because I try to used the lib in an Heroku application for task managing. I don't find how could i make an authenticated connection. So check the code and validate it or give me feedback. I want to used the Bull lib. and not my version. Thank's. Fred