### PR TITLE
added stacktrace on job.fromData

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -272,6 +272,7 @@ Job.fromData = function(queue, jobId, data){
   job._progress = parseInt(data.progress);
   job.delay = parseInt(data.delay);
   job.timestamp = parseInt(data.timestamp);
+  job.stacktrace = data.stacktrace;
 
   return job;
 };


### PR DESCRIPTION
I want the stacktrace on Queue.getFailed() so that i can retry jobs depending on the error they got ^^