### PR TITLE
Job promotion allows for delayed job to be started immediately

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -210,6 +210,44 @@ Job.prototype.remove = function(){
     });
 };
 
+/**
+  Forces this job occur immediately if it is delayed, by removing it from "delayed"
+  and placing it in "wait"
+*/
+Job.prototype.promote = function() {
+  var _this = this;
+  var script = [
+    'redis.call("ZREM", KEYS[1], ARGV[1])',
+    'redis.call("LREM", KEYS[2], 0, ARGV[1])',
+    'redis.call("RPUSH", KEYS[3], ARGV[1])',
+    'redis.call("PUBLISH", KEYS[4], ARGV[1])',
+    'redis.call("HSET", ARGV[2], "delay", 0)'
+    ].join('\n');
+
+  var keys = _.map([
+    'delayed',
+    'active',
+    'wait',
+    'jobs'], function(name){
+      return _this.queue.toKey(name);
+    }
+  );
+
+  return this.queue.client.evalAsync(
+    script,
+    keys.length,
+    keys[0],
+    keys[1],
+    keys[2],
+    keys[3],
+    this.jobId,
+    this.queue.toKey(this.jobId)
+  ).then(function() {
+    _this.queue.emit('waiting', _this);
+  });
+};
+
+
 // -----------------------------------------------------------------------------
 // Private methods
 // -----------------------------------------------------------------------------

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -407,10 +407,11 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
     nextDelayedJob = nextDelayedJob < 0 ? 0 : nextDelayedJob;
 
     this.delayTimer = setTimeout(function(){
-      updateDelaySet(_this, _this.delayedTimestamp).catch(function(err){
-        console.log('Error updating delay timer', err);
-      });
+      var prevDelayedTimestamp = _this.delayedTimestamp;
       _this.delayedTimestamp = Number.MAX_VALUE;
+      updateDelaySet(_this, prevDelayedTimestamp).catch(function(err){
+         console.log('Error updating delay timer', err);
+       });
     }, nextDelayedJob);
   }
 };
@@ -432,13 +433,16 @@ var updateDelaySet = function(queue, delayedTimestamp){
     '  redis.call("RPUSH", KEYS[3], jobId)',
     '  redis.call("PUBLISH", KEYS[4], jobId)',
     '  redis.call("HSET", ARGV[1] .. jobId, "delay", 0)',
-    '  local nextTimestamp = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")[2]',
-    '  if(nextTimestamp ~= nil) then',
-    '   redis.call("PUBLISH", KEYS[1], nextTimestamp)',
-    '  end',
-    '  return', // nextTimestamp',
     ' end',
-    ' return score',
+    ' local nextTimestamp = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")[2]',
+    ' if(nextTimestamp ~= nil) then',
+    '  redis.call("PUBLISH", KEYS[1], nextTimestamp)',
+    ' end',
+    ' if score <= ARGV[2] then',
+    '  return',  // nextTimestamp
+    ' else',
+    '  return score',
+    ' end',
     'end'].join('\n');
 
   var keys = _.map([


### PR DESCRIPTION
Sometimes you need a job to be started in X time at the _latest_ but if condition arise sooner, it can be started immediately. 

Does this seem like the cleanest and safest way to do so? Is there anything that can be done to make this cleaner, or is this good enough? Would be happy to clean this up, if there's something you have in mind. 
