### PR TITLE
Ensure close() doesn't cause the application to hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ shutdown.
 var Queue = require('bull');
 var queue = Queue('example');
 
-var after100Jobs = _.after(100, function () {
+var after100 = _.after(100, function () {
   queue.close().then(function () { console.log('done') })
 });
 
-queue.on('completed', after100Jobs);
+queue.on('completed', after100);
 ```
 
 `close` can be called from anywhere, with one caveat: if called

--- a/README.md
+++ b/README.md
@@ -447,19 +447,47 @@ __Arguments__
 
 <a name="close"/>                                                               
 #### Queue##close()                                                             
-Closes the underlying redis client. Use this if you are performing a graceful   
+Closes the underlying redis client. Use this to perform a graceful
 shutdown.
 
 ```javascript
-var queue = require('bull')('some job', 6379, '127.0.0.1');
-process.once('SIGTERM', function () {
-  queue.close().then(function() {
-    console.log('Bull shutdown gracefully.');
-    process.exit(0);
-  }, function(err) {
-    console.log('Bull closed with error "' + err.message + '".');
-    process.exit(1);
-  });
+var Queue = require('bull');
+var queue = Queue('example');
+
+var after100Jobs = _.after(100, function () {
+  queue.close().then(function () { console.log('done') })
+});
+
+queue.on('completed', after100Jobs);
+```
+
+`close` can be called from anywhere, with one caveat: if called
+from within a job handler the queue won't close until *after*
+the job has been processed, so the following won't work:
+
+```javascript
+queue.process(function (job, jobDone) {
+  handle(job);
+  queue.close().then(jobDone);
+});
+```
+
+Instead, do this:
+
+```javascript
+queue.process(function (job, jobDone) {
+  handle(job);
+  queue.close();
+  jobDone();
+});
+```
+
+Or this:
+
+```javascript
+queue.process(function (job) {
+  queue.close();
+  return handle(job).then(...);
 });
 ```
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ gulp.task('lint', function (){
   return gulp.src([
     './lib/job.js',
     './lib/queue.js',
+    './lib/timer-manager.js',
     './test/**'
     ])
     .pipe(eslint({
@@ -31,6 +32,7 @@ gulp.task('lint', function (){
           'describe': true,
           'it': true,
           'setTimeout': true,
+          'after': true,
           'afterEach': true,
           'beforeEach': true,
           'before': true

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -75,6 +75,12 @@ PriorityQueue.getQueueName = function(name, priority){
  */
 PriorityQueue.prototype.waitAfterEmptyLoop = 200;
 
+PriorityQueue.prototype.disconnect = function() {
+  return Promise.map(this.queues, function(queue) {
+    return queue.disconnect();
+  })
+}
+
 PriorityQueue.prototype.close = function() {
   return Promise.map(this.queues, function(queue) {
     return queue.close();

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -6,6 +6,7 @@ var redis = require('redis');
 var events = require('events');
 var util = require('util');
 var Job = require('./job');
+var TimerManager = require('./timer-manager');
 var _ = require('lodash');
 var Promise = require('bluebird');
 var uuid = require('node-uuid');
@@ -97,7 +98,6 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   //
   this.eclient = createClient();
 
-  this.delayTimer = null;
   this.processing = 0;
 
   this.token = uuid();
@@ -107,6 +107,11 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   [this.client, this.bclient, this.eclient].forEach(function (client) {
     client.on('error', _this.emit.bind(_this, 'error'));
   });
+
+  // keeps track of active timers. used by close() to
+  // ensure that disconnect() is deferred until all
+  // scheduled redis commands have been executed
+  this.timers = new TimerManager();
 
   // emit ready when redis connections
   this.client.selectAsync(redisDB).then(function(){
@@ -150,7 +155,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
 
 util.inherits(Queue, events.EventEmitter);
 
-Queue.prototype.close = function(){
+Queue.prototype.disconnect = function(){
   var _this = this;
   var timeoutMsg = 'Timed out while waiting for redis clients to close';
 
@@ -163,6 +168,16 @@ Queue.prototype.close = function(){
     _this.bclient.stream.on('close', triggerEvent);
     _this.eclient.stream.on('close', triggerEvent);
   }).timeout(CLIENT_CLOSE_TIMEOUT_MS, timeoutMsg);
+};
+
+Queue.prototype.close = function(){
+  var _this = this;
+
+  return new Promise(function(resolve) {
+    _this.timers.whenIdle(function(){
+      resolve(_this.disconnect());
+    });
+  });
 };
 
 /**
@@ -384,18 +399,19 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
   var _this = this;
 
   if(newDelayedTimestamp < _this.delayedTimestamp){
-    clearTimeout(this.delayTimer);
+    this.timers.clear('delayTimer');
     this.delayedTimestamp = newDelayedTimestamp;
 
     var nextDelayedJob = newDelayedTimestamp - Date.now();
     nextDelayedJob = nextDelayedJob < 0 ? 0 : nextDelayedJob;
 
-    this.delayTimer = setTimeout(function(){
+    this.timers.set('delayTimer', nextDelayedJob, function(){
+      _this.timers.clear('delayTimer');
       updateDelaySet(_this, _this.delayedTimestamp).catch(function(err){
         console.log('Error updating delay timer', err);
       });
       _this.delayedTimestamp = Number.MAX_VALUE;
-    }, nextDelayedJob);
+    });
   }
 };
 
@@ -496,11 +512,10 @@ Queue.prototype.processJobs = function(){
 
 Queue.prototype.processJob = function(job){
   var _this = this;
-  var lockRenewTimeout;
 
   var lockRenewer = function(){
     job.renewLock(_this.token);
-    lockRenewTimeout = setTimeout(lockRenewer, _this.LOCK_RENEW_TIME / 2);
+    _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
   };
 
   var timeoutMs = job.opts.timeout;
@@ -539,7 +554,7 @@ Queue.prototype.processJob = function(job){
   return jobPromise
     .then(handleCompleted, handleFailed)
     .finally(function(){
-      clearTimeout(lockRenewTimeout);
+      _this.timers.clear('lockRenewer');
     });
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -98,6 +98,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   //
   this.eclient = createClient();
 
+  this.delayTimer = null;
   this.processing = 0;
 
   this.token = uuid();
@@ -164,15 +165,15 @@ Queue.prototype.disconnect = function(){
     _this.client.end();
     _this.bclient.end();
     _this.eclient.end();
-    _this.client.stream.on('close', triggerEvent);
-    _this.bclient.stream.on('close', triggerEvent);
-    _this.eclient.stream.on('close', triggerEvent);
+    _this.client.stream.once('close', triggerEvent);
+    _this.bclient.stream.once('close', triggerEvent);
+    _this.eclient.stream.once('close', triggerEvent);
   }).timeout(CLIENT_CLOSE_TIMEOUT_MS, timeoutMsg);
 };
 
 Queue.prototype.close = function(){
   var _this = this;
-
+  clearTimeout(this.delayTimer);
   return new Promise(function(resolve) {
     _this.timers.whenIdle(function(){
       resolve(_this.disconnect());
@@ -399,19 +400,18 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
   var _this = this;
 
   if(newDelayedTimestamp < _this.delayedTimestamp){
-    this.timers.clear('delayTimer');
+    clearTimeout(this.delayTimer);
     this.delayedTimestamp = newDelayedTimestamp;
 
     var nextDelayedJob = newDelayedTimestamp - Date.now();
     nextDelayedJob = nextDelayedJob < 0 ? 0 : nextDelayedJob;
 
-    this.timers.set('delayTimer', nextDelayedJob, function(){
-      _this.timers.clear('delayTimer');
+    this.delayTimer = setTimeout(function(){
       updateDelaySet(_this, _this.delayedTimestamp).catch(function(err){
         console.log('Error updating delay timer', err);
       });
       _this.delayedTimestamp = Number.MAX_VALUE;
-    });
+    }, nextDelayedJob);
   }
 };
 
@@ -512,10 +512,11 @@ Queue.prototype.processJobs = function(){
 
 Queue.prototype.processJob = function(job){
   var _this = this;
+  var lockRenewId;
 
   var lockRenewer = function(){
     job.renewLock(_this.token);
-    _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
+    lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
   };
 
   var timeoutMs = job.opts.timeout;
@@ -554,7 +555,7 @@ Queue.prototype.processJob = function(job){
   return jobPromise
     .then(handleCompleted, handleFailed)
     .finally(function(){
-      _this.timers.clear('lockRenewer');
+      _this.timers.clear(lockRenewId);
     });
 };
 

--- a/lib/timer-manager.js
+++ b/lib/timer-manager.js
@@ -1,12 +1,33 @@
+/*eslint-env node */
+/*global Promise:true */
+'use strict';
+
 var _ = require('lodash');
+var uuid = require('node-uuid');
 
 /**
- Timer Manager.
+  Timer Manager
 
- There are currently two (transient) timers used by queues for
- cleanup/maintenance tasks. They both execute Redis commands,
- which means we can't close queues while these timers are active
- i.e. this won't work:
+  Keep track of timers to ensure that disconnect() is
+  only called (via close()) at a time when it's safe
+  to do so.
+
+  Queues currently use two timers:
+
+    - The first one is used for delayed jobs and is
+    preemptible i.e. it is possible to close a queue
+    while delayed jobs are still pending (they will
+    be processed when the queue is resumed). This timer
+    is cleared by close() and is not managed here.
+
+    - The second one is used to lock Redis while
+    processing jobs. These timers are short-lived,
+    and there can be more than one active at a
+    time.
+
+  The lock timer executes Redis commands, which
+  means we can't close queues while it's active i.e.
+  this won't work:
 
     queue.process(function (job, jobDone) {
       handle(job);
@@ -14,7 +35,7 @@ var _ = require('lodash');
     })
 
   The disconnect() call closes the Redis connections; then, when
-  Bull tries to perform the scheduled Redis commands,
+  a queue tries to perform the scheduled Redis commands,
   they block until a Redis connection becomes available...
 
   The solution is to close the Redis connections when there are no
@@ -36,37 +57,51 @@ var _ = require('lodash');
 */
 
 function TimerManager(){
-  this.timers = {};
   this.idle = true;
   this.listeners = [];
+  this.timers = {};
 }
 
 /**
-  Create a new named timer (setTimeout).
+  Create a new timer (setTimeout).
 */
 TimerManager.prototype.set = function(name, delay, fn){
-  this.timers[name] = setTimeout(fn, delay);
+  var timer = setTimeout(fn, delay);
+  var id = uuid.v4();
+  var now = Date.now();
+
+  // XXX only the timer is used, but the
+  // other fields are useful for
+  // troubleshooting/debugging
+  this.timers[id] = {
+    name: name,
+    created: now,
+    timer: timer
+  };
+
   this.idle = false;
+  return id;
 };
 
 /**
-  Clear a named timer (clearTimeout).
+  Clear a timer (clearTimeout).
 
   Queued listeners are executed if there are no
   remaining timers
 */
-TimerManager.prototype.clear = function(name){
+TimerManager.prototype.clear = function(id){
   var timers = this.timers;
-
-  clearTimeout(timers[name]);
-  delete timers[name];
-
-  if((this.idle === false) && (_.size(timers) === 0)) {
-    this.idle = true;
-
+  var timer = timers[id];
+  if(!timer) {
+    return;
+  }
+  clearTimeout(timer.timer);
+  delete timers[id];
+  if(!this.idle && (_.size(timers) === 0)){
     while(this.listeners.length){
       this.listeners.pop()();
     }
+    this.idle = true;
   }
 };
 
@@ -77,12 +112,12 @@ TimerManager.prototype.clear = function(name){
   queued and executed as soon as the last active timer has been
   cleared.
 */
-TimerManager.prototype.whenIdle = function(fn){
-    if (this.idle){
-      fn();
-    } else {
-        this.listeners.unshift(fn);
-    }
-}
+TimerManager.prototype.whenIdle = function(fn) {
+  if(this.idle) {
+    fn();
+  } else{
+    this.listeners.unshift(fn);
+  }
+};
 
 module.exports = TimerManager;

--- a/lib/timer-manager.js
+++ b/lib/timer-manager.js
@@ -1,0 +1,88 @@
+var _ = require('lodash');
+
+/**
+ Timer Manager.
+
+ There are currently two (transient) timers used by queues for
+ cleanup/maintenance tasks. They both execute Redis commands,
+ which means we can't close queues while these timers are active
+ i.e. this won't work:
+
+    queue.process(function (job, jobDone) {
+      handle(job);
+      queue.disconnect().then(jobDone);
+    })
+
+  The disconnect() call closes the Redis connections; then, when
+  Bull tries to perform the scheduled Redis commands,
+  they block until a Redis connection becomes available...
+
+  The solution is to close the Redis connections when there are no
+  active timers i.e. when the queue is idle. This helper class keeps
+  track of the active timers and executes any queued listeners
+  whenever that count goes to zero.
+
+  Since disconnect() simply can't work if there are active handles,
+  its close() wrapper postpones closing the Redis connections
+  until the next idle state. This means that close() can safely
+  be called from anywhere at any time, even from within a job
+  handler:
+
+    queue.process(function (job, jobDone) {
+      handle(job);
+      queue.close();
+      jobDone();
+    })
+*/
+
+function TimerManager(){
+  this.timers = {};
+  this.idle = true;
+  this.listeners = [];
+}
+
+/**
+  Create a new named timer (setTimeout).
+*/
+TimerManager.prototype.set = function(name, delay, fn){
+  this.timers[name] = setTimeout(fn, delay);
+  this.idle = false;
+};
+
+/**
+  Clear a named timer (clearTimeout).
+
+  Queued listeners are executed if there are no
+  remaining timers
+*/
+TimerManager.prototype.clear = function(name){
+  var timers = this.timers;
+
+  clearTimeout(timers[name]);
+  delete timers[name];
+
+  if((this.idle === false) && (_.size(timers) === 0)) {
+    this.idle = true;
+
+    while(this.listeners.length){
+      this.listeners.pop()();
+    }
+  }
+};
+
+/**
+  Register a callback to be called when there are no active timers.
+
+  Called immediately if there are no active timers. Otherwise,
+  queued and executed as soon as the last active timer has been
+  cleared.
+*/
+TimerManager.prototype.whenIdle = function(fn){
+    if (this.idle){
+      fn();
+    } else {
+        this.listeners.unshift(fn);
+    }
+}
+
+module.exports = TimerManager;

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -57,16 +57,34 @@ describe('Priority queue', function(){
       });
     });
 
-    it('should be callable from within a job handler', function (done) {
-      this.timeout(6000);
-      testQueue.add({ foo: 'bar' }).then(function () {
+    describe('should be callable from within', function () {
+      it('a job handler that takes a callback', function (done) {
+        this.timeout(6000);
+
         testQueue.process(function (job, jobDone) {
           expect(job.data.foo).to.be('bar');
-          testQueue.close().then(function (args) {
-            expect(args).to.eql([ false, false, false, false, false ]);
-            done();
-          });
+          testQueue.close().then(function () { done(); });
           jobDone();
+        });
+
+        testQueue.add({ foo: 'bar' }).then(function (job) {
+          expect(job.jobId).to.be.ok();
+          expect(job.data.foo).to.be('bar');
+        });
+      });
+
+      it('a job handler that returns a promise', function (done) {
+        this.timeout(6000);
+
+        testQueue.process(function (job) {
+          expect(job.data.foo).to.be('bar');
+          testQueue.close().then(function () { done(); });
+          return Promise.resolve();
+        });
+
+        testQueue.add({ foo: 'bar' }).then(function (job) {
+          expect(job.jobId).to.be.ok();
+          expect(job.data.foo).to.be('bar');
         });
       });
     });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -899,7 +899,7 @@ describe('Queue', function () {
           queue.process(fn);
         }).delay(20).then(function () {
           //We simulate a restart
-          return queue.disconnect().then(function () {
+          return queue.close().then(function () {
             return Promise.delay(100).then(function () {
               queue = new Queue(QUEUE_NAME);
               queue.process(fn);


### PR DESCRIPTION
Previously, calling `close` could result in Redis connections being closed before internal timers depending on those connections have executed or been cancelled. This would cause the application to hang indefinitely.

This commit renames the old `close` method to `disconnect` and adds a new `close` implementation which wraps `disconnect` but defers the call until all outstanding timer handles have been released.

This ensures that `close` is safe to call from anywhere at any time, even from within a job handler.
