### PR TITLE
Swap `redis` for `ioredis` (this breaks the current implementation) [Adds redis sentinel and cluster support]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,46 @@
-v0.5.0
+v1.0.0
 ======
 
 - Refactored to support [ioredis](https://github.com/luin/ioredis). **This breaks the original API**.
+
+Non sentinel
+
+````
+var redisConfig = {
+    host: '127.0.0.1',
+    port: 6379,
+    connectTimeout: 5000,
+    db: 0
+};
+
+var videoQueue = Queue('video transcoding', redisConfig);
+````
+
+Sentinel support
+
+````
+var redisConfig = {
+    name: 'mymaster',
+    connectTimeout: 5000,
+    db: 0,
+    sentinels: [
+        {
+            host: '10.0.0.1',
+            port: 26379
+        },
+        {
+            host: '10.0.0.2',
+            port: 26380
+        },
+        {
+            host: '10.0.0.3',
+            port: 26380
+        }
+    ]
+};
+
+var videoQueue = Queue('video transcoding', redisConfig);
+````
 
 v0.4.0
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.5.0
+======
+
+- Refactored to support [ioredis](https://github.com/luin/ioredis). **This breaks the original API**.
+
 v0.4.0
 ======
 - added a Queue##clean method

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ videoQueue.process(function(job, done){
 
   // or give a error if error
   done(Error('error transcoding'));
-  
+
   // or pass it a result
   done(null, { framerate: 29.5 /* etc... */ });
 
@@ -72,7 +72,7 @@ audioQueue.process(function(job, done){
 
   // or give a error if error
   done(Error('error transcoding'));
-  
+
   // or pass it a result
   done(null, { samplerate: 48000 /* etc... */ });
 
@@ -89,7 +89,7 @@ imageQueue.process(function(job, done){
 
   // or give a error if error
   done(Error('error transcoding'));
-  
+
   // or pass it a result
   done(null, { width: 1280, height: 720 /* etc... */ });
 
@@ -112,7 +112,7 @@ videoQueue.process(function(job){ // don't forget to remove the done callback!
   // Handles promise rejection
   return Promise.reject(new Error('error transcoding'));
 
-  // Passes the value the promise is resolved with to the "completed" event 
+  // Passes the value the promise is resolved with to the "completed" event
   return Promise.resolve({ framerate: 29.5 /* etc... */ });
 
   // If the job throws an unhandled exception it is also handled correctly
@@ -280,7 +280,7 @@ listened by some other service that stores the results in a database.
 ## Reference
 
 <a name="queue"/>
-###Queue(queueName, redisPort, redisHost, [redisOpts])
+###Queue(queueName, redisConfig)
 
 This is the Queue constructor. It creates a new Queue that is persisted in
 Redis. Everytime the same queue is instantiated it tries to process all the
@@ -290,9 +290,27 @@ __Arguments__
 
 ```javascript
     queueName {String} A unique name for this Queue.
-    redisPort {Number} A port where redis server is running.
-    redisHost {String} A host specified as IP or domain where redis is running.
-    redisOptions {Object} Options to pass to the redis client. https://github.com/mranney/node_redis
+    redisConfig {Object} see https://github.com/luin/ioredis
+
+        Example
+            {
+                name: 'mymaster',
+                connectTimeout: 5000,
+                sentinels: [
+                    {
+                        host: '10.0.0.1',
+                        port: 26379
+                    },
+                    {
+                        host: '10.0.0.2',
+                        port: 26380
+                    },
+                    {
+                        host: '10.0.0.3',
+                        port: 26380
+                    }
+                ]
+            }
 ```
 
 ---------------------------------------
@@ -445,8 +463,8 @@ __Arguments__
 
 ---------------------------------------
 
-<a name="close"/>                                                               
-#### Queue##close()                                                             
+<a name="close"/>
+#### Queue##close()
 Closes the underlying redis client. Use this to perform a graceful
 shutdown.
 
@@ -549,7 +567,7 @@ __Events__
 The cleaner emits the `cleaned` event anytime the queue is cleaned.
 
 ```javascript
-  queue.on('cleaned', function (jobs, type) {}); 
+  queue.on('cleaned', function (jobs, type) {});
 
   jobs {Array} An array of jobs that have been cleaned.
   type {String} The type of job cleaned. Options are completed, waiting, active,
@@ -560,7 +578,7 @@ The cleaner emits the `cleaned` event anytime the queue is cleaned.
 
 
 <a name="priorityQueue"/>
-###PriorityQueue(queueName, redisPort, redisHost, [redisOpts])
+###PriorityQueue(queueName, redisConfig)
 
 This is the Queue constructor of priority queue. It works same a normal queue, with same function and parameters.
 The only difference is that the Queue#add() allow an options opts.priority that could take

--- a/README.md
+++ b/README.md
@@ -38,9 +38,29 @@ Quick Guide
 ```javascript
 var Queue = require('bull');
 
-var videoQueue = Queue('video transcoding', 6379, '127.0.0.1');
-var audioQueue = Queue('audio transcoding', 6379, '127.0.0.1');
-var imageQueue = Queue('image transcoding', 6379, '127.0.0.1');
+var redisConfig = {
+    name: 'mymaster',
+    connectTimeout: 5000,
+    db: 0,
+    sentinels: [
+        {
+            host: '10.0.0.1',
+            port: 26379
+        },
+        {
+            host: '10.0.0.2',
+            port: 26380
+        },
+        {
+            host: '10.0.0.3',
+            port: 26380
+        }
+    ]
+};
+
+var videoQueue = Queue('video transcoding', redisConfig);
+var audioQueue = Queue('audio transcoding', redisConfig);
+var imageQueue = Queue('image transcoding', redisConfig);
 
 videoQueue.process(function(job, done){
 
@@ -296,6 +316,7 @@ __Arguments__
             {
                 name: 'mymaster',
                 connectTimeout: 5000,
+                db: 0,
                 sentinels: [
                     {
                         host: '10.0.0.1',

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ var
   cluster = require('cluster');
 
 var numWorkers = 8;
-var queue = Queue("test concurrent queue", 6379, '127.0.0.1');
+var queue = Queue("test concurrent queue", redisConfig);
 
 if(cluster.isMaster){
   for (var i = 0; i < numWorkers; i++) {

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ __Arguments__
 
 ```javascript
     queueName {String} A unique name for this Queue.
-    redisConfig {Object} see https://github.com/luin/ioredis
+    redisConfig {Object} see [https://github.com/luin/ioredis](https://github.com/luin/ioredis)
 
         Example
             {

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -12,9 +12,9 @@ var util = require('util');
  stability and robustness. The priority queue is in fact several Queues,
  one for every possible priority.
  */
-var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisOptions) {
+var PriorityQueue = module.exports = function(name, redisConfig) {
   if (!(this instanceof PriorityQueue)) {
-    return new PriorityQueue(name, redisPort, redisHost, redisOptions);
+    return new PriorityQueue(name, redisConfig);
   }
 
   var _this = this;
@@ -22,7 +22,7 @@ var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisO
   this.queues = [];
 
   for (var key in PriorityQueue.priorities) {
-    var queue = Queue(PriorityQueue.getQueueName(name, key), redisPort, redisHost, redisOptions);
+    var queue = Queue(PriorityQueue.getQueueName(name, key), redisConfig);
     this.queues[PriorityQueue.priorities[key]] = queue;
   }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,7 +2,7 @@
 /*global Promise:true */
 'use strict';
 
-var redis = require('ioredis');
+var Redis = require('ioredis');
 var events = require('events');
 var util = require('util');
 var Job = require('./job');
@@ -48,16 +48,22 @@ var Queue = function Queue(name, redisConfig) {
     return new Queue(name, redisConfig);
   }
 
+  var redisDB;
+
   function createClient() {
     if(!redisConfig) {
-        redisConfig = {
-            host: '127.0.0.1',
-            port: 6379,
-            db: 0
-        };
+      redisConfig = {
+        host: '127.0.0.1',
+        port: 6379,
+        db: 0
+      };
     }
 
-    var client = new redis(redisConfig);
+    redisConfig.host = redisConfig.host || '127.0.0.1';
+    redisConfig.port = redisConfig.port || 6379;
+    redisDB = redisConfig.db || 0;
+
+    var client = new Redis(redisConfig);
     return Promise.promisifyAll(client);
   }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -49,6 +49,14 @@ var Queue = function Queue(name, redisConfig) {
   }
 
   function createClient() {
+    if(!redisConfig) {
+        redisConfig = {
+            host: '127.0.0.1',
+            port: 6379,
+            db: 0
+        };
+    }
+
     var client = new redis(redisConfig);
     return Promise.promisifyAll(client);
   }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,7 +2,7 @@
 /*global Promise:true */
 'use strict';
 
-var redis = require('redis');
+var redis = require('ioredis');
 var events = require('events');
 var util = require('util');
 var Job = require('./job');
@@ -43,33 +43,15 @@ var MINIMUM_REDIS_VERSION = '2.8.11';
 var LOCK_RENEW_TIME = 5000; // 5 seconds is the renew time.
 var CLIENT_CLOSE_TIMEOUT_MS = 5000;
 
-var Queue = function Queue(name, redisPort, redisHost, redisOptions){
+var Queue = function Queue(name, redisConfig) {
   if(!(this instanceof Queue)){
-    return new Queue(name, redisPort, redisHost, redisOptions);
-  }
-
-  var redisDB = 0;
-  if(_.isObject(redisPort)){
-    var opts = redisPort;
-    var redisOpts = opts.redis || {};
-    redisPort = redisOpts.port;
-    redisHost = redisOpts.host;
-    redisOptions = redisOpts.opts || {};
-    redisDB = redisOpts.DB || redisDB;
+    return new Queue(name, redisConfig);
   }
 
   function createClient() {
-    var client;
-    if(redisOptions !== undefined && redisOptions.createClient !== undefined){
-      client = redisOptions.createClient();
-    }else{
-      client = redis.createClient(redisPort, redisHost, redisOptions);
-    }
+    var client = new redis(redisConfig);
     return Promise.promisifyAll(client);
   }
-
-  redisPort = redisPort || 6379;
-  redisHost = redisHost || '127.0.0.1';
 
   var _this = this;
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -52,18 +52,16 @@ var Queue = function Queue(name, redisConfig) {
 
   function createClient() {
     if(!redisConfig) {
-      redisConfig = {
-        host: '127.0.0.1',
-        port: 6379,
-        db: 0
-      };
+      redisConfig = {};
     }
 
     redisConfig.host = redisConfig.host || '127.0.0.1';
     redisConfig.port = redisConfig.port || 6379;
-    redisDB = redisConfig.db || 0;
+    redisConfig.db = redisConfig.db || 0;
+    redisDB = redisConfig.db;
 
     var client = new Redis(redisConfig);
+
     return Promise.promisifyAll(client);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bull",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Job manager",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bull",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Job manager",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bluebird": "^2.9.30",
     "lodash": "^3.9.3",
     "node-uuid": "^1.4.3",
-    "redis": "^0.12.1",
+    "ioredis": "1.7.5",
     "semver": "^4.2.0"
   },
   "devDependencies": {

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -11,7 +11,7 @@ describe('Job', function(){
   var queue;
 
   before(function(done){
-    queue = new Queue('test', 6379, '127.0.0.1');
+    queue = new Queue('test');
     queue.client.keys(queue.toKey('*'), function(err, keys){
       if(keys.length){
         queue.client.del(keys, function(err2){

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -15,7 +15,7 @@ var STD_QUEUE_NAME = 'test queue';
 
 function buildQueue(name) {
   var qName = name || STD_QUEUE_NAME;
-  return new Queue(qName, 6379, '127.0.0.1');
+  return new Queue(qName);
 }
 
 function cleanupQueue(queue){

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -9,7 +9,6 @@ var Promise = require('bluebird');
 var sinon = require('sinon');
 var _ = require('lodash');
 var uuid = require('node-uuid');
-var redis = require('redis');
 
 var STD_QUEUE_NAME = 'test queue';
 
@@ -33,15 +32,6 @@ describe('Priority queue', function(){
       });
     }
     sandbox.restore();
-  });
-
-  it('allow custom clients', function(){
-    var clients = 0;
-    queue = new Queue(STD_QUEUE_NAME, {redis: {opts: {createClient: function(){
-      clients++;
-      return redis.createClient();
-    }}}});
-    expect(clients).to.be(15);
   });
 
   describe('.close', function () {

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -5,7 +5,7 @@
 var Queue = require('../');
 var expect = require('expect.js');
 var Promise = require('bluebird');
-var redis = require('redis');
+var Redis = require('ioredis');
 var sinon = require('sinon');
 var _ = require('lodash');
 var uuid = require('node-uuid');
@@ -137,7 +137,7 @@ describe('Queue', function () {
     });
 
     it('creates a queue using the supplied redis DB', function (done) {
-      queue = new Queue('custom', { redis: { DB: 1 } });
+      queue = new Queue('custom', { host: '127.0.0.1', port: 6379, db: 1 });
 
       queue.once('ready', function () {
         expect(queue.client.connectionOption.host).to.be('127.0.0.1');
@@ -154,7 +154,7 @@ describe('Queue', function () {
     });
 
     it('creates a queue using custom the supplied redis host', function (done) {
-      queue = new Queue('custom', { redis: { host: 'localhost' } });
+      queue = new Queue('custom', { host: 'localhost' });
 
       queue.once('ready', function () {
         expect(queue.client.connectionOption.host).to.be('localhost');
@@ -489,7 +489,11 @@ describe('Queue', function () {
       queue.process(function (job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
-        var client = redis.createClient();
+        var client = new Redis({
+          host: '127.0.0.1',
+          port: 6379
+        });
+
         client.srem(queue.toKey('completed'), 1);
         client.lpush(queue.toKey('active'), 1);
       });
@@ -579,7 +583,12 @@ describe('Queue', function () {
       var failedOnce = false;
 
       var retryQueue = buildQueue('retry-test-queue');
-      var client = redis.createClient(6379, '127.0.0.1', {});
+
+      var client = new Redis({
+        host: '127.0.0.1',
+        port: 6379,
+        db: 0
+      });
 
       client.select(0);
 
@@ -774,7 +783,12 @@ describe('Queue', function () {
   });
 
   it('should publish a message when a new message is added to the queue', function (done) {
-    var client = redis.createClient(6379, '127.0.0.1', {});
+    var client = new Redis({
+      host: '127.0.0.1',
+      port: 6379,
+      db: 0
+    });
+
     client.select(0);
     queue = new Queue('test pub sub');
     client.on('ready', function () {
@@ -805,7 +819,12 @@ describe('Queue', function () {
     it('should process a delayed job only after delayed time', function (done) {
       var delay = 500;
       queue = new Queue('delayed queue simple');
-      var client = redis.createClient(6379, '127.0.0.1', {});
+      var client = new Redis({
+        host: '127.0.0.1',
+        port: 6379,
+        db: 0
+      });
+
       var timestamp = Date.now();
       var publishHappened = false;
       client.on('ready', function () {

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -14,7 +14,7 @@ var STD_QUEUE_NAME = 'test queue';
 
 function buildQueue(name) {
   var qName = name || STD_QUEUE_NAME;
-  return new Queue(qName, 6379, '127.0.0.1');
+  return new Queue(qName);
 }
 
 function cleanupQueue(queue) {

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -137,7 +137,7 @@ describe('Queue', function () {
     });
 
     it('creates a queue using the supplied redis DB', function (done) {
-      queue = new Queue('custom', { host: '127.0.0.1', port: 6379, db: 1 });
+      queue = new Queue('custom', { db: 1 });
 
       queue.once('ready', function () {
         expect(queue.client.connectionOption.host).to.be('127.0.0.1');
@@ -586,8 +586,7 @@ describe('Queue', function () {
 
       var client = new Redis({
         host: '127.0.0.1',
-        port: 6379,
-        db: 0
+        port: 6379
       });
 
       client.select(0);
@@ -785,8 +784,7 @@ describe('Queue', function () {
   it('should publish a message when a new message is added to the queue', function (done) {
     var client = new Redis({
       host: '127.0.0.1',
-      port: 6379,
-      db: 0
+      port: 6379
     });
 
     client.select(0);
@@ -821,8 +819,7 @@ describe('Queue', function () {
       queue = new Queue('delayed queue simple');
       var client = new Redis({
         host: '127.0.0.1',
-        port: 6379,
-        db: 0
+        port: 6379
       });
 
       var timestamp = Date.now();


### PR DESCRIPTION
I tried to get everything updated. Note, I bumped the version to `1.0.0` to signify a breaking change.

However, when running the tests, I could not figure out why they are breaking with:

````
Unhandled rejection SyntaxError: Unexpected token u
    at Object.parse (native)
    at Function.Job.fromData (/Users/justin/Sites/bull/lib/job.js:271:40)
    at /Users/justin/Sites/bull/lib/job.js:39:18
    at tryCatcher (/Users/justin/Sites/bull/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/Users/justin/Sites/bull/node_modules/bluebird/js/main/promise.js:503:31)
    at Promise._settlePromiseAt (/Users/justin/Sites/bull/node_modules/bluebird/js/main/promise.js:577:18)
    at Promise._settlePromises (/Users/justin/Sites/bull/node_modules/bluebird/js/main/promise.js:693:14)
    at Async._drainQueue (/Users/justin/Sites/bull/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/Users/justin/Sites/bull/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/justin/Sites/bull/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```