### PR TITLE
clean jobs without timestamp

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -688,7 +688,7 @@ Queue.prototype.clean = function (grace, type) {
     _this[getter]().then(function (jobs) {
       //take all jobs outside of the grace period
       return Promise.filter(jobs, function (job) {
-        return job.timestamp < Date.now() - grace;
+        return (!job.timestamp) || (job.timestamp < Date.now() - grace);
       });
     }).then(function (jobs) {
       //remove those old jobs


### PR DESCRIPTION
Allthough I don't really understand how it could be undefined. I'm seeing timestamp is `NaN`. But this should take care of both situations.