### PR TITLE
Try to be smart about the handler

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -222,7 +222,31 @@ Queue.prototype.setHandler = function(concurrency, handler){
   handler = handler.bind(this);
 
   if(handler.length > 1){
-    this.handler = Promise.promisify(handler);
+    this.handler = function(job) {
+      // tell jshint to ignore the next line because I really really want to
+      // create a new promise here.
+      /* eslint-disable */
+      return new Promise(function(resolve, reject) {
+      /* eslint-enable */
+        try{
+          //return Promise.resolve(handler(job, resolve));
+          var result = handler(job, function (err, res) {
+            if(err){
+              reject(err);
+            }else{
+              resolve(res);
+            }
+          });
+          if(result && typeof result.then === 'function'){
+            result.then(resolve, reject);
+          }else if(result){
+            resolve(result);
+          }
+        }catch (e){
+          reject(e);
+        }
+      });
+    };
   }else{
     this.handler = Promise.method(handler);
   }
@@ -544,7 +568,7 @@ Queue.prototype.processJob = function(job){
 
   lockRenewer();
 
-  var jobPromise = Promise.resolve(this.handler(job));
+  var jobPromise = this.handler(job);
 
   if(timeoutMs){
     jobPromise = jobPromise.timeout(timeoutMs);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -229,7 +229,6 @@ Queue.prototype.setHandler = function(concurrency, handler){
       return new Promise(function(resolve, reject) {
       /* eslint-enable */
         try{
-          //return Promise.resolve(handler(job, resolve));
           var result = handler(job, function (err, res) {
             if(err){
               reject(err);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -286,7 +286,7 @@ describe('Queue', function () {
 
     it('process a job that returns a promise', function (done) {
       queue = buildQueue();
-      queue.process(function (job) {
+      queue.process(function (job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         return Promise.delay(250).then(function(){
           return 'my data';

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -286,7 +286,7 @@ describe('Queue', function () {
 
     it('process a job that returns a promise', function (done) {
       queue = buildQueue();
-      queue.process(function (job, jobDone) {
+      queue.process(function (job) {
         expect(job.data.foo).to.be.equal('bar');
         return Promise.delay(250).then(function(){
           return 'my data';
@@ -301,6 +301,73 @@ describe('Queue', function () {
       queue.on('completed', function (job, data) {
         expect(job).to.be.ok();
         expect(data).to.be.eql('my data');
+        done();
+      });
+    });
+
+    it('should try to coerce the process function to a promise (return a promise and also specify a callback)', function (done) {
+      // return a promise and also specify a callback
+      queue = buildQueue();
+      queue.process(function (job, jobDone) {
+        expect(jobDone).to.be.ok();
+        expect(job.data.foo).to.be.equal('bar');
+        return Promise.delay(250).then(function(){
+          return 'my data';
+        });
+      });
+
+      queue.add({ foo: 'bar' }).then(function (job) {
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }).catch(done);
+
+      queue.on('completed', function (job, data) {
+        expect(job).to.be.ok();
+        expect(data).to.be.eql('my data');
+        done();
+      });
+    });
+
+    it('should try to coerce the process function to a promise (ignore callback and return a value)', function (done) {
+      // return a value and ignore promise or callback
+      queue = buildQueue();
+      queue.process(function (job, jobDone) {
+        expect(jobDone).to.be.ok();
+        expect(job.data.foo).to.be.equal('bar');
+        return 'my-data';
+      });
+
+      queue.add({ foo: 'bar' }).then(function (job) {
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }).catch(done);
+
+      queue.on('completed', function (job, data) {
+        console.log('completed?');
+        expect(job).to.be.ok();
+        expect(data).to.be.eql('my-data');
+        done();
+      });
+    });
+
+    it('should try to coerce the process function to a promise (should catch exception and fail job when callback is specified and error is thrown)', function (done) {
+      // return a value and ignore promise or callback
+      var error = new Error('Oh noes!');
+      queue = buildQueue();
+      queue.process(function (job, jobDone) {
+        expect(job.data.foo).to.be.equal('bar');
+        expect(jobDone).to.be.ok();
+        throw error;
+      });
+
+      queue.add({ foo: 'bar' }).then(function (job) {
+        expect(job.jobId).to.be.ok();
+        expect(job.data.foo).to.be('bar');
+      }).catch(done);
+
+      queue.on('failed', function (job) {
+        expect(job).to.be.ok();
+        expect(job.stacktrace).to.be.ok();
         done();
       });
     });
@@ -538,8 +605,8 @@ describe('Queue', function () {
         expect(job.jobId).to.be.ok();
         expect(job.data.foo).to.be('bar');
       }, function (err) {
-          done(err);
-        });
+        done(err);
+      });
 
       queue.once('failed', function (job, err) {
         expect(job.jobId).to.be.ok();


### PR DESCRIPTION
This tries to resolve the easy to make mistake with specifying a handler with a callback and returning a promise.

It's a bit intricate but it does the job :smile:.

This will make these work:

``` js
queue.process(function(job, done) {
  return Promise.resolve();
});
```

and

```
queue.process(function(job, done) {
  return 5;
});
```

This one will probably create a race condition (for as far as possible in js):

``` js
queue.process(function(job, done) {
   done(5);
   return Promise.resolve(6);
});
```

And this one will outright not work for obvious reasons:

``` js
queue.process(function(job, done) {
  setTimeout(done, 500);
  return 4;
});
```
