### PR TITLE
Replace the hardwired redis dependency with a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Install:
 
     npm install bull
 
+The [redis npm module](https://www.npmjs.com/package/redis) is a [peer dependency](https://blog.domenic.me/peer-dependencies/)
+of Bull, so it will need to be installed if it hasn't been already:
+
+    npm install redis
+
 Note that you need a redis version higher or equal than 2.8.11 for bull to work properly.
 
 Quick Guide

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "bluebird": "^2.9.30",
     "lodash": "^3.9.3",
     "node-uuid": "^1.4.3",
-    "redis": "^0.12.1",
     "semver": "^4.2.0"
   },
   "devDependencies": {
@@ -28,7 +27,11 @@
     "gulp": "^3.8.11",
     "gulp-eslint": "^0.13.2",
     "mocha": "^2.2.5",
+    "redis": "^1.0.0",
     "sinon": "^1.14.1"
+  },
+  "peerDependencies": {
+    "redis": ">= 0.12.1 < 2"
   },
   "scripts": {
     "test": "gulp && mocha test/* --reporter spec",


### PR DESCRIPTION
This PR:

- replaces the hardwired redis dependency with a [peer dependency](https://blog.domenic.me/peer-dependencies/)
- tests against the latest redis release ([1.0.0](https://github.com/NodeRedis/node_redis/releases/tag/v1.0.0))