### PR TITLE
Correct order delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Bull Job Manager
 
 [![Join the chat at https://gitter.im/OptimalBits/bull](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OptimalBits/bull?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+[![BuildStatus](https://secure.travis-ci.org/OptimalBits/bull.png?branch=master)](http://travis-ci.org/OptimalBits/bull)
+[![NPM version](https://badge.fury.io/js/bull.svg)](http://badge.fury.io/js/bull)
+
 ![bull](http://files.softicons.com/download/animal-icons/animal-icons-by-martin-berube/png/128/bull.png)
 
 A lightweight, robust and fast job processing queue.
@@ -11,8 +14,7 @@ Carefully written for rock solid stability and atomicity.
 It uses redis for persistence, so the queue is not lost if the server goes
 down for any reason.
 
-[![BuildStatus](https://secure.travis-ci.org/OptimalBits/bull.png?branch=master)](http://travis-ci.org/OptimalBits/bull)
-[![NPM version](https://badge.fury.io/js/bull.svg)](http://badge.fury.io/js/bull)
+
 
 Follow [manast](http://twitter.com/manast) for news and updates regarding this library.
 

--- a/README.md
+++ b/README.md
@@ -623,6 +623,12 @@ __Arguments__
 
 Rerun a Job that has failed.
 
+__Arguments__
+
+```javascript
+  returns {Promise} A promise that resolves when the job is scheduled for retry.
+```
+
 ---------------------------------------
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Bull Job Manager
 ================
 
+[![Join the chat at https://gitter.im/OptimalBits/bull](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OptimalBits/bull?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 ![bull](http://files.softicons.com/download/animal-icons/animal-icons-by-martin-berube/png/128/bull.png)
 
 A lightweight, robust and fast job processing queue.

--- a/README.md
+++ b/README.md
@@ -372,7 +372,11 @@ __Arguments__
     to the job processing function in job.opts
   opts.delay {Number} An amount of miliseconds to wait until this job
   can be processed. Note that for accurate delays, both server and clients
-  should have their clocks synchronized.
+  should have their clocks synchronized. [optional]
+  opts.attempts {Number} A number of attempts to retry if the job fails [optional]
+  opts.backoff {Number|Object} Backoff setting for automatic retries if the job fails
+  opts.backoff.type {String} Backoff type, which can be either `fixed` or `exponential`
+  opts.backoff.delay {String} Backoff delay, in milliseconds
   opts.lifo {Boolean} A boolean which, if true, adds the job to the right
     of the queue instead of the left (default false)
   opts.timeout {Number} The number of milliseconds after which the job
@@ -611,6 +615,13 @@ __Arguments__
 ```javascript
   returns {Promise} A promise that resolves when the job is removed.
 ```
+
+---------------------------------------
+
+<a name="retry"/>
+#### Job##retry()
+
+Rerun a Job that has failed.
 
 ---------------------------------------
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -118,7 +118,6 @@ Job.prototype.delayIfNeeded = function(){
         return true;
       });
     }
-    return Promise.resolve(false);
   }
   return Promise.resolve(false);
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -165,6 +165,54 @@ Job.prototype.isFailed = function(){
   return this._isDone('failed');
 };
 
+Job.prototype.isDelayed = function() {
+  return this.queue.client
+    .zrankAsync(this.queue.toKey('delayed'), this.jobId).then(function(rank) {
+      return rank !== null;
+    });
+};
+
+Job.prototype.isActive = function() {
+  return this._isInList('active');
+};
+
+Job.prototype.isWaiting = function() {
+  return this._isInList('wait');
+};
+
+Job.prototype.isPaused = function() {
+  return this._isInList('paused');
+};
+
+Job.prototype.isStuck = function() {
+  return this.getState().then(function(state) {
+    return state === 'stuck';
+  });
+};
+
+Job.prototype.getState = function() {
+  var _this = this;
+  var fns = [
+    { fn: 'isCompleted', state: 'completed' },
+    { fn: 'isFailed', state: 'failed' },
+    { fn: 'isDelayed', state: 'delayed' },
+    { fn: 'isActive', state: 'active' },
+    { fn: 'isWaiting', state: 'waiting' },
+    { fn: 'isPaused', state: 'paused' }
+  ];
+
+  return Promise.reduce(fns, function(state, fn) {
+    if(state){
+      return state;
+    }
+    return _this[fn.fn]().then(function(result) {
+      return result ? fn.state : null;
+    });
+  }, null).then(function(result) {
+    return result ? result : 'stuck';
+  });
+};
+
 /**
   Removes a job from the queue and from all the lists where it may be stored.
 */
@@ -218,6 +266,25 @@ Job.prototype._isDone = function(list){
     .sismemberAsync(this.queue.toKey(list), this.jobId).then(function(isMember){
       return isMember === 1;
     });
+};
+
+Job.prototype._isInList = function(list) {
+  var script = [
+    'local function item_in_list (list, item)',
+    '  for _, v in pairs(list) do',
+    '    if v == item then',
+    '      return 1',
+    '    end',
+    '  end',
+    '  return nil',
+    'end',
+    'local items = redis.call("LRANGE", KEYS[1], 0, -1)',
+    'return item_in_list(items, ARGV[1])'
+  ].join('\n');
+
+  return this.queue.client.evalAsync(script, 1, this.queue.toKey(list), this.jobId).then(function(result){
+    return result === 1;
+  });
 };
 
 Job.prototype._moveToSet = function(set, delayTimestamp){

--- a/lib/job.js
+++ b/lib/job.js
@@ -23,7 +23,7 @@ var Job = function(queue, jobId, data, opts){
   this._progress = 0;
   this.delay = this.opts.delay;
   this.timestamp = opts.timestamp || Date.now();
-  this.stacktrace = null;
+  this.stacktrace = [];
   if(this.opts.attempts > 1){
     this.attempts = this.opts.attempts;
   }else{
@@ -136,7 +136,7 @@ Job.prototype.moveToCompleted = function(){
 
 Job.prototype.moveToFailed = function(err){
   var _this = this;
-  this.stacktrace = err.stack;
+  this.stacktrace.push(err.stack);
   if(isNaN(this.attemptsMade)){
     this.attemptsMade = 1;
   }else{
@@ -144,7 +144,7 @@ Job.prototype.moveToFailed = function(err){
   }
   // Update job states
   return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), {
-    stacktrace: err.stack,
+    stacktrace: JSON.stringify(this.stacktrace),
     attemptsMade: this.attemptsMade
   }).then(function() {
     // Check if an automatic retry should be performed
@@ -474,7 +474,17 @@ Job.fromData = function(queue, jobId, data){
     job.attempts = 1; // Default to 1 try for legacy jobs
   }
   job.attemptsMade = parseInt(data.attemptsMade);
-  job.stacktrace = data.stacktrace;
+  var _traces;
+  try{
+    _traces = JSON.stringify(data.stacktrace);
+    if(!(_traces instanceof Array)){
+      _traces = [];
+    }
+  } catch (err) {
+    _traces = [];
+  }
+  job.stacktrace = _traces;
+
   return job;
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -286,18 +286,28 @@ Job.prototype._isInList = function(list) {
   });
 };
 
-Job.prototype._moveToSet = function(set, delayTimestamp){
+Job.prototype._moveToSet = function(setName, delayTimestamp){
   var queue = this.queue;
   var jobId = this.jobId;
 
   delayTimestamp = +delayTimestamp || 0;
   delayTimestamp = delayTimestamp < 0 ? 0 : delayTimestamp;
 
+  //
+  // Bake in the job id first 20 bits into the timestamp
+  // to guarantee correct execution order of delayed jobs
+  // (up to 1M jobs per given timestamp or 1M jobs apart per timestamp)
+  //
+  if(delayTimestamp > 0){
+    delayTimestamp = delayTimestamp * 0x1000 + (jobId & 0xfff);
+  }
+
   var script = [
     'if redis.call("EXISTS", KEYS[3]) == 1 then',
-    ' if tonumber(ARGV[1]) ~= 0 then',
-    '  redis.call("ZADD", KEYS[2], ARGV[1], ARGV[2])',
-    '  redis.call("PUBLISH", KEYS[2], ARGV[1])',
+    ' local score = tonumber(ARGV[1])',
+    ' if score ~= 0 then',
+    '  redis.call("ZADD", KEYS[2], score, ARGV[2])',
+    '  redis.call("PUBLISH", KEYS[2], score / 0x1000)',
     ' else',
     '  redis.call("SADD", KEYS[2], ARGV[2])',
     ' end',
@@ -310,7 +320,7 @@ Job.prototype._moveToSet = function(set, delayTimestamp){
 
   var keys = _.map([
     'active',
-    set,
+    setName,
     jobId], function(name){
       return queue.toKey(name);
     }
@@ -325,7 +335,44 @@ Job.prototype._moveToSet = function(set, delayTimestamp){
     delayTimestamp,
     jobId).then(function(result){
       if(result === -1){
-        throw new Error('Missing Job ' + jobId + ' when trying to move from active to ' + set);
+        throw new Error('Missing Job ' + jobId + ' when trying to move from active to ' + setName);
+      }
+    });
+};
+
+Job.prototype._addToDelayed = function(delayTimestamp){
+  var queue = this.queue;
+  var jobId = this.jobId;
+
+  delayTimestamp = delayTimestamp * 0x1000 + (jobId & 0xfff);
+
+  var script = [
+    'if redis.call("EXISTS", KEYS[2]) == 1 then',
+    ' local score = tonumber(ARGV[1])',
+    ' redis.call("ZADD", KEYS[1], score, ARGV[2])',
+    ' redis.call("PUBLISH", KEYS[1], score / 0x1000)',
+    ' return 0',
+    'else',
+    ' return -1',
+    'end'
+    ].join('\n');
+
+  var keys = _.map([
+    'delayed',
+    jobId], function(name){
+      return queue.toKey(name);
+    }
+  );
+
+  return queue.client.evalAsync(
+    script,
+    keys.length,
+    keys[0],
+    keys[1],
+    delayTimestamp,
+    jobId).then(function(result){
+      if(result === -1){
+        throw new Error('Missing Job ' + jobId + ' when trying to add to delayed');
       }
     });
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -294,9 +294,11 @@ Job.prototype._moveToSet = function(setName, delayTimestamp){
   delayTimestamp = delayTimestamp < 0 ? 0 : delayTimestamp;
 
   //
-  // Bake in the job id first 20 bits into the timestamp
+  // Bake in the job id first 12 bits into the timestamp
   // to guarantee correct execution order of delayed jobs
-  // (up to 1M jobs per given timestamp or 1M jobs apart per timestamp)
+  // (up to 4096 jobs per given timestamp or 4096 jobs apart per timestamp)
+  //
+  // WARNING: Jobs that are so far apart that they wrap around will cause FIFO to fail
   //
   if(delayTimestamp > 0){
     delayTimestamp = delayTimestamp * 0x1000 + (jobId & 0xfff);
@@ -307,7 +309,7 @@ Job.prototype._moveToSet = function(setName, delayTimestamp){
     ' local score = tonumber(ARGV[1])',
     ' if score ~= 0 then',
     '  redis.call("ZADD", KEYS[2], score, ARGV[2])',
-    '  redis.call("PUBLISH", KEYS[2], score / 0x1000)',
+    '  redis.call("PUBLISH", KEYS[2], (score / 0x1000))',
     ' else',
     '  redis.call("SADD", KEYS[2], ARGV[2])',
     ' end',
@@ -350,7 +352,7 @@ Job.prototype._addToDelayed = function(delayTimestamp){
     'if redis.call("EXISTS", KEYS[2]) == 1 then',
     ' local score = tonumber(ARGV[1])',
     ' redis.call("ZADD", KEYS[1], score, ARGV[2])',
-    ' redis.call("PUBLISH", KEYS[1], score / 0x1000)',
+    ' redis.call("PUBLISH", KEYS[1], (score / 0x1000))',
     ' return 0',
     'else',
     ' return -1',

--- a/lib/job.js
+++ b/lib/job.js
@@ -272,6 +272,7 @@ Job.fromData = function(queue, jobId, data){
   job._progress = parseInt(data.progress);
   job.delay = parseInt(data.delay);
   job.timestamp = parseInt(data.timestamp);
+  job.stacktrace = data.stacktrace;
 
   return job;
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -24,6 +24,12 @@ var Job = function(queue, jobId, data, opts){
   this.delay = this.opts.delay;
   this.timestamp = opts.timestamp || Date.now();
   this.stacktrace = null;
+  if(this.opts.attempts > 1){
+    this.attempts = this.opts.attempts;
+  }else{
+    this.attempts = 1;
+  }
+  this.attemptsMade = 0;
 };
 
 Job.create = function(queue, jobId, data, opts){
@@ -49,7 +55,9 @@ Job.prototype.toData = function(){
     opts: JSON.stringify(this.opts || {}),
     progress: this._progress,
     delay: this.delay,
-    timestamp: this.timestamp
+    timestamp: this.timestamp,
+    attempts: this.attempts,
+    attemptsMade: this.attemptsMade
   };
 };
 
@@ -128,9 +136,31 @@ Job.prototype.moveToCompleted = function(){
 
 Job.prototype.moveToFailed = function(err){
   var _this = this;
-  return this._moveToSet('failed').then(function() {
-    _this.stacktrace = err.stack;
-    return _this.queue.client.hsetAsync(_this.queue.toKey(_this.jobId), 'stacktrace', err.stack);
+  this.stacktrace = err.stack;
+  if(isNaN(this.attemptsMade)){
+    this.attemptsMade = 1;
+  }else{
+    this.attemptsMade++;
+  }
+  // Update job states
+  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), {
+    stacktrace: err.stack,
+    attemptsMade: this.attemptsMade
+  }).then(function() {
+    // Check if an automatic retry should be performed
+    if(_this.attemptsMade < _this.attempts){
+      // Check if backoff is needed
+      var backoff = _this._getBackOff();
+      if(backoff){
+        // If so, move to delayed
+        return _this._moveToSet('delayed', Date.now() + backoff);
+      }else{
+        // If not, retry immediately
+        return _this._retryAtOnce();
+      }
+    }
+    // If not, move to failed
+    return _this._moveToSet('failed');
   });
 };
 
@@ -379,6 +409,58 @@ Job.prototype._addToDelayed = function(delayTimestamp){
     });
 };
 
+Job.prototype._getBackOff = function() {
+  var backoff = 0;
+  var delay;
+  if(this.opts.backoff){
+    if(!isNaN(this.opts.backoff)){
+      backoff = this.opts.backoff;
+    }else if(this.opts.backoff.type === 'fixed'){
+      backoff = this.opts.backoff.delay;
+    }else if(this.opts.backoff.type === 'exponential'){
+      delay = this.opts.backoff.delay;
+      backoff = Math.round((Math.pow(2, this.attemptsMade) - 1) * delay);
+    }
+  }
+  return backoff;
+};
+
+Job.prototype._retryAtOnce = function(){
+  var queue = this.queue;
+  var jobId = this.jobId;
+
+  var script = [
+    'if redis.call("EXISTS", KEYS[3]) == 1 then',
+    ' redis.call("LREM", KEYS[1], 0, ARGV[2])',
+    ' redis.call(ARGV[1], KEYS[2], ARGV[2])',
+    ' return 0',
+    'else',
+    ' return -1',
+    'end'
+    ].join('\n');
+
+  var keys = _.map([
+    'active',
+    'wait',
+    jobId], function(name){
+      return queue.toKey(name);
+    }
+  );
+  var pushCmd = (this.opts.lifo ? 'R' : 'L') + 'PUSH';
+
+  return queue.client.evalAsync(
+    script,
+    keys.length,
+    keys[0],
+    keys[1],
+    keys[2],
+    pushCmd,
+    jobId).then(function(result){
+      if(result === -1){
+        throw new Error('Missing Job ' + jobId + ' during retry');
+      }
+    });
+};
 
 /**
 */
@@ -387,8 +469,12 @@ Job.fromData = function(queue, jobId, data){
   job._progress = parseInt(data.progress);
   job.delay = parseInt(data.delay);
   job.timestamp = parseInt(data.timestamp);
+  job.attempts = parseInt(data.attempts);
+  if(isNaN(job.attempts)) {
+    job.attempts = 1; // Default to 1 try for legacy jobs
+  }
+  job.attemptsMade = parseInt(data.attemptsMade);
   job.stacktrace = data.stacktrace;
-
   return job;
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -26,7 +26,7 @@ var semver = require('semver');
     job -> wait -> active
         |    ^        |   \
         v    |        |    -- > failed
-        delayed 
+        delayed
 */
 
 /**

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -42,6 +42,7 @@ var semver = require('semver');
 var MINIMUM_REDIS_VERSION = '2.8.11';
 var LOCK_RENEW_TIME = 5000; // 5 seconds is the renew time.
 var CLIENT_CLOSE_TIMEOUT_MS = 5000;
+var POLLING_INTERVAL = 5000;
 
 var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   if(!(this instanceof Queue)){
@@ -145,12 +146,26 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   //
   // Init delay timestamp.
   //
-  _this.delayedTimestamp = Number.MAX_VALUE;
+  this.delayedTimestamp = Number.MAX_VALUE;
   updateDelaySet(this, Date.now()).then(function(timestamp){
     if(timestamp){
       _this.updateDelayTimer(timestamp);
     }
   });
+
+  //
+  // Create a guardian timer to revive delayTimer if necessary
+  // This is necessary when redis connection is unstable, which can cause the pub/sub to fail
+  //
+  this.guardianTimer = setInterval(function() {
+    if(_this.delayedTimestamp - Date.now() > POLLING_INTERVAL){
+      updateDelaySet(_this, Date.now()).then(function(timestamp){
+        if(timestamp){
+          _this.updateDelayTimer(timestamp);
+        }
+      });
+    }
+  }, POLLING_INTERVAL);
 
 };
 
@@ -174,6 +189,7 @@ Queue.prototype.disconnect = function(){
 Queue.prototype.close = function(){
   var _this = this;
   clearTimeout(this.delayTimer);
+  clearInterval(this.guardianTimer);
   return new Promise(function(resolve) {
     _this.timers.whenIdle(function(){
       resolve(_this.disconnect());
@@ -515,10 +531,8 @@ Queue.prototype.processJobs = function(){
 
   return this.processStalledJobs().then(function() {
     return _this.getNextJob();
-  }).then(function (job) {
-    return job.delayIfNeeded().then(function(delayed) {
-      return !delayed && job.takeLock(_this.token);
-    }).then(function (locked) {
+  }).then(function(job) {
+    return job.takeLock(_this.token).then(function(locked) {
       if(locked){
         return _this.processJob(job);
       }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -688,7 +688,7 @@ Queue.prototype.clean = function (grace, type) {
     _this[getter]().then(function (jobs) {
       //take all jobs outside of the grace period
       return Promise.filter(jobs, function (job) {
-        return job.timestamp < Date.now() - grace;
+        return (!job.timestamp) || (job.timestamp < Date.now() - grace);
       });
     }).then(function (jobs) {
       //remove those old jobs

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -158,7 +158,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   // This is necessary when redis connection is unstable, which can cause the pub/sub to fail
   //
   this.guardianTimer = setInterval(function() {
-    if(_this.delayedTimestamp - Date.now() > POLLING_INTERVAL){
+    if(_this.delayedTimestamp < Date.now() || _this.delayedTimestamp - Date.now() > POLLING_INTERVAL){
       updateDelaySet(_this, Date.now()).then(function(timestamp){
         if(timestamp){
           _this.updateDelayTimer(timestamp);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -253,6 +253,14 @@ Queue.prototype.add = function(data, opts){
   return _this.client.incrAsync(this.toKey('id')).then(function(jobId){
     return Job.create(_this, jobId, data, opts);
   }).then(function(job){
+    if(job.delay){
+      var jobDelayedTimestamp = job.timestamp + job.delay;
+      if(jobDelayedTimestamp > Date.now()){
+        return job._addToDelayed(jobDelayedTimestamp).then(function(){
+          return job;
+        });
+      }
+    }
     return addJob(_this, job.jobId, opts).then(function(){
       _this.emit('waiting', job);
       return job;
@@ -408,7 +416,12 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
 
     this.delayTimer = setTimeout(function(){
       updateDelaySet(_this, _this.delayedTimestamp).then(function(nextTimestamp){
-        _this.updateDelayTimer(nextTimestamp !== null ? nextTimestamp : Number.MAX_VALUE);
+        if(nextTimestamp){
+          nextTimestamp = nextTimestamp < Date.now() ? Date.now() : nextTimestamp;
+        }else{
+          nextTimestamp = Number.MAX_VALUE;
+        }
+        _this.updateDelayTimer(nextTimestamp);
       }).catch(function(err){
         console.log('Error updating the delay timer', err);
       });
@@ -428,14 +441,16 @@ var updateDelaySet = function(queue, delayedTimestamp){
     'local jobId = RESULT[1]',
     'local score = RESULT[2]',
     'if (score ~= nil) then',
-    ' if (score <= ARGV[2]) then',
+    ' score = score / 0x1000 ',
+    ' if (score <= tonumber(ARGV[2])) then',
     '  redis.call("ZREM", KEYS[1], jobId)',
     '  redis.call("LREM", KEYS[2], 0, jobId)',
-    '  redis.call("RPUSH", KEYS[3], jobId)',
+    '  redis.call("LPUSH", KEYS[3], jobId)',
     '  redis.call("PUBLISH", KEYS[4], jobId)',
     '  redis.call("HSET", ARGV[1] .. jobId, "delay", 0)',
     '  local nextTimestamp = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")[2]',
     '  if(nextTimestamp ~= nil) then',
+    '   nextTimestamp = nextTimestamp / 0x1000',
     '   redis.call("PUBLISH", KEYS[1], nextTimestamp)',
     '  end',
     '  return nextTimestamp',

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -407,8 +407,10 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
     nextDelayedJob = nextDelayedJob < 0 ? 0 : nextDelayedJob;
 
     this.delayTimer = setTimeout(function(){
-      updateDelaySet(_this, _this.delayedTimestamp).catch(function(err){
-        console.log('Error updating delay timer', err);
+      updateDelaySet(_this, _this.delayedTimestamp).then(function(nextTimestamp){
+        _this.updateDelayTimer(nextTimestamp !== null ? nextTimestamp : Number.MAX_VALUE);
+      }).catch(function(err){
+        console.log('Error updating the delay timer', err);
       });
       _this.delayedTimestamp = Number.MAX_VALUE;
     }, nextDelayedJob);
@@ -436,7 +438,7 @@ var updateDelaySet = function(queue, delayedTimestamp){
     '  if(nextTimestamp ~= nil) then',
     '   redis.call("PUBLISH", KEYS[1], nextTimestamp)',
     '  end',
-    '  return', // nextTimestamp',
+    '  return nextTimestamp',
     ' end',
     ' return score',
     'end'].join('\n');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -257,6 +257,7 @@ Queue.prototype.add = function(data, opts){
       var jobDelayedTimestamp = job.timestamp + job.delay;
       if(jobDelayedTimestamp > Date.now()){
         return job._addToDelayed(jobDelayedTimestamp).then(function(){
+          _this.emit('delayed', job);
           return job;
         });
       }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -24,9 +24,9 @@ var semver = require('semver');
                            -- >completed
                           /
     job -> wait -> active
-             ^        |   \
-             |        |    -- > failed
-             |----- delayed
+        |    ^        |   \
+        v    |        |    -- > failed
+        delayed 
 */
 
 /**

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "sinon": "^1.14.1"
   },
   "scripts": {
-    "test": "gulp && mocha test/* --reporter spec",
+    "test": "gulp && mocha test/test_* --reporter spec",
     "postpublish": "git push && git push --tags"
   }
 }

--- a/test/cluster_worker.js
+++ b/test/cluster_worker.js
@@ -1,0 +1,23 @@
+/*eslint-env node */
+/*global Promise:true */
+'use strict';
+
+var Queue = require('../');
+
+var STD_QUEUE_NAME = 'cluster test queue';
+
+function buildQueue(name) {
+  var qName = name || STD_QUEUE_NAME;
+  return new Queue(qName, 6379, '127.0.0.1');
+}
+
+var queue = buildQueue();
+
+queue.process(1, function(job, jobDone) {
+  console.log('Start processing: ', job.jobId);
+  jobDone();
+  process.send({
+    id: job.jobId,
+    data: job.data
+  });
+});

--- a/test/cluster_worker.js
+++ b/test/cluster_worker.js
@@ -14,7 +14,6 @@ function buildQueue(name) {
 var queue = buildQueue();
 
 queue.process(1, function(job, jobDone) {
-  console.log('Start processing: ', job.jobId);
   jobDone();
   process.send({
     id: job.jobId,

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -1,0 +1,118 @@
+/*eslint-env node */
+/*global Promise:true */
+'use strict';
+
+var cluster = require('cluster');
+var os = require('os');
+var path = require('path');
+var Queue = require('../');
+var expect = require('expect.js');
+var Promise = require('bluebird');
+var redis = require('redis');
+var sinon = require('sinon');
+var _ = require('lodash');
+var uuid = require('node-uuid');
+
+var STD_QUEUE_NAME = 'cluster test queue';
+
+function buildQueue(name) {
+  var qName = name || STD_QUEUE_NAME;
+  return new Queue(qName, 6379, '127.0.0.1');
+}
+
+function purgeQueue(queue) {
+  var client = redis.createClient(6379, '127.0.0.1', {});
+  client = Promise.promisifyAll(client);
+  client.selectAsync(0);
+
+  var script = [
+    'local KS = redis.call("KEYS", ARGV[1])',
+    'local result = redis.call("DEL", unpack(KS))',
+    'return'].join('\n');
+
+  return queue.client.evalAsync(
+    script,
+    0,
+    queue.toKey('*'));
+}
+
+cluster.setupMaster({
+  exec: path.join(__dirname, '/cluster_worker.js')
+});
+
+var workerMessageHandler;
+function workerMessageHandlerWrapper(message) {
+  if(workerMessageHandler) {
+    workerMessageHandler(message);
+  }
+}
+
+var worker;
+var _i = 0;
+for(_i; _i < os.cpus().length - 1; _i++) {
+  worker = cluster.fork();
+  worker.on('message', workerMessageHandlerWrapper);
+  console.log('Worker spawned, #', worker.id);
+}
+
+describe.only('Cluster', function () {
+
+  var queue;
+
+  afterEach(function(){
+    if(queue){
+      return purgeQueue(queue).then(function() {
+        return queue.close.bind(queue)().then(function() {
+          queue = undefined;
+          workerMessageHandler = undefined;
+        });
+      });
+    }
+  });
+
+  it('should process each job once', function(done) {
+    var jobs = [];
+    queue = buildQueue();
+
+    workerMessageHandler = function(job) {
+      jobs.push(job.id);
+      if(jobs.length === 11) {
+        var counts = {};
+        var j = 0;
+        for(j; j < jobs.length; j++) {
+          expect(counts[jobs[j]]).to.be(undefined);
+          counts[jobs[j]] = 1;
+        }
+        done();
+      }
+    };
+
+    var i = 0;
+    for(i; i < 11; i++) {
+      queue.add({});
+    }
+  });
+
+  it('should process delayed jobs in correct order', function(done) {
+    this.timeout(12000);
+    queue = buildQueue();
+    var orders = [];
+
+    workerMessageHandler = function(job) {
+      orders.push(job.data.order);
+      console.log(orders);
+    };
+
+    queue.add({ order: 1 }, { delay: 1000 });
+    queue.add({ order: 6 }, { delay: 6000 });
+    queue.add({ order: 10 }, { delay: 10000 });
+    queue.add({ order: 2 }, { delay: 2000 });
+    queue.add({ order: 9 }, { delay: 9000 });
+    queue.add({ order: 5 }, { delay: 5000 });
+    queue.add({ order: 3 }, { delay: 3000 });
+    queue.add({ order: 7 }, { delay: 7000 });
+    queue.add({ order: 4 }, { delay: 4000 });
+    queue.add({ order: 8 }, { delay: 8000 });
+  });
+
+});

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -120,12 +120,13 @@ describe('Cluster', function () {
   it.skip('should process delayed jobs scheduled at the same timestamp in correct order (FIFO)', function(done) {
     /**
      * Note:
-     * By logging out the jobId that is fetched in `updateDelaySet via redis`:
+     * By logging out the jobId that is fetched in `updateDelaySet` via redis:
      * `redis.log(redis.LOG_WARNING, jobId)``
-     * via redis, we can actually see that the jobs are being promoted in a correct order.
+     * we can actually see that the jobs are being promoted in a correct order.
      * However, the following test almost always fails, one possible reason is that even though
      * jobs are fetched in order, there are enough workers to process them at the same time
      * therefore they appear to finish simultaneously.
+     * TODO: find a better way to test this
      */
 
     this.timeout(5000);

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -46,11 +46,13 @@ function workerMessageHandlerWrapper(message) {
   }
 }
 
+var workers = [];
 var worker;
 var _i = 0;
 for(_i; _i < os.cpus().length - 1; _i++) {
   worker = cluster.fork();
   worker.on('message', workerMessageHandlerWrapper);
+  workers.push(worker);
   console.log('Worker spawned: #', worker.id);
 }
 
@@ -151,6 +153,13 @@ describe('Cluster', function () {
     queue.add({ order: 8 }, { delay: 200 });
     queue.add({ order: 9 }, { delay: 200 });
     queue.add({ order: 10 }, { delay: 200 });
+  });
+
+  after(function() {
+    _i = 0;
+    for(_i; _i < workers.length; _i++) {
+      workers[_i].kill();
+    }
   });
 
 });

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -198,6 +198,7 @@ describe('Job', function(){
           return job.isFailed().then(function(isFailed){
             expect(isFailed).to.be(true);
             expect(job.stacktrace).not.be(null);
+            expect(job.stacktrace.length).to.be(1);
           });
         });
       });
@@ -213,6 +214,7 @@ describe('Job', function(){
           return job.isFailed().then(function(isFailed){
             expect(isFailed).to.be(false);
             expect(job.stacktrace).not.be(null);
+            expect(job.stacktrace.length).to.be(1);
             return job.isWaiting().then(function(isWaiting){
               expect(isWaiting).to.be(true);
             });
@@ -231,6 +233,7 @@ describe('Job', function(){
           return job.isFailed().then(function(isFailed){
             expect(isFailed).to.be(true);
             expect(job.stacktrace).not.be(null);
+            expect(job.stacktrace.length).to.be(1);
           });
         });
       });
@@ -246,6 +249,7 @@ describe('Job', function(){
           return job.isFailed().then(function(isFailed){
             expect(isFailed).to.be(false);
             expect(job.stacktrace).not.be(null);
+            expect(job.stacktrace.length).to.be(1);
             return job.isDelayed().then(function(isDelayed){
               expect(isDelayed).to.be(true);
             });

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -203,6 +203,57 @@ describe('Job', function(){
       });
     });
 
+    it('moves the job to wait for retry if attempts are given', function() {
+      return Job.create(queue, 5, {foo: 'bar'}, {attempts: 3}).then(function(job){
+        return job.isFailed().then(function(isFailed){
+          expect(isFailed).to.be(false);
+        }).then(function(){
+          return job.moveToFailed(new Error('test error'));
+        }).then(function(){
+          return job.isFailed().then(function(isFailed){
+            expect(isFailed).to.be(false);
+            expect(job.stacktrace).not.be(null);
+            return job.isWaiting().then(function(isWaiting){
+              expect(isWaiting).to.be(true);
+            });
+          });
+        });
+      });
+    });
+
+    it('marks the job as failed when attempts made equal to attempts given', function() {
+      return Job.create(queue, 6, {foo: 'bar'}, {attempts: 1}).then(function(job){
+        return job.isFailed().then(function(isFailed){
+          expect(isFailed).to.be(false);
+        }).then(function(){
+          return job.moveToFailed(new Error('test error'));
+        }).then(function(){
+          return job.isFailed().then(function(isFailed){
+            expect(isFailed).to.be(true);
+            expect(job.stacktrace).not.be(null);
+          });
+        });
+      });
+    });
+
+    it('moves the job to delayed for retry if attempts are given and backoff is non zero', function() {
+      return Job.create(queue, 7, {foo: 'bar'}, {attempts: 3, backoff: 300}).then(function(job){
+        return job.isFailed().then(function(isFailed){
+          expect(isFailed).to.be(false);
+        }).then(function(){
+          return job.moveToFailed(new Error('test error'));
+        }).then(function(){
+          return job.isFailed().then(function(isFailed){
+            expect(isFailed).to.be(false);
+            expect(job.stacktrace).not.be(null);
+            return job.isDelayed().then(function(isDelayed){
+              expect(isDelayed).to.be(true);
+            });
+          });
+        });
+      });
+    });
+
     it('get job status', function() {
       var client = Promise.promisifyAll(redis.createClient());
       return Job.create(queue, 100, {foo: 'baz'}).then(function(job) {

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -217,6 +217,8 @@ describe('Priority queue', function(){
   });
 
   it('processes several stalled jobs when starting several queues', function(done){
+    this.timeout(5000);
+
     var NUM_QUEUES = 5;
     var NUM_JOBS_PER_QUEUE = 10;
     var stalledQueues = [];

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -932,53 +932,59 @@ describe('Queue', function () {
         order++;
       };
 
+      var now = Date.now();
       queue.on('ready', function() {
-
         Promise.join(
-          queue.add({ order: 1 }, { delay: 1000 }),
-          queue.add({ order: 2 }, { delay: 1000 }),
-          queue.add({ order: 3 }, { delay: 1000 }),
-          queue.add({ order: 4 }, { delay: 1000 }),
-          queue.add({ order: 5 }, { delay: 1000 }),
-          queue.add({ order: 6 }, { delay: 1000 }),
-          queue.add({ order: 7 }, { delay: 1000 }),
-          queue.add({ order: 8 }, { delay: 1000 }),
-          queue.add({ order: 9 }, { delay: 1000 }),
-          queue.add({ order: 10 }, { delay: 1000 }),
-          queue.add({ order: 11 }, { delay: 1000 }),
-          queue.add({ order: 12 }, { delay: 1000 })
+          queue.add({ order: 1 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 2 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 3 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 4 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 5 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 6 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 7 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 8 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 9 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 10 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 11 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          }),
+          queue.add({ order: 12 }, {
+            delay: 1000,
+            timestamp: Date.now()
+          })
         ).then(function () {
-          var now = Date.now();
-
-          return Promise.join(
-            client.hsetAsync('bull:' + queue.name + ':1', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':2', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':3', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':4', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':5', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':6', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':7', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':8', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':9', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':10', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':11', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':12', 'timestamp', now),
-            client.hsetAsync('bull:' + queue.name + ':1', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':2', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':3', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':4', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':5', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':6', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':7', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':8', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':9', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':10', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':11', 'delay', 2000),
-            client.hsetAsync('bull:' + queue.name + ':12', 'delay', 2000)
-          ).then(function () {
-
-            queue.process(fn);
-          });
+          queue.process(fn);
         });
       });
     });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -937,51 +937,51 @@ describe('Queue', function () {
         Promise.join(
           queue.add({ order: 1 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 2 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 3 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 4 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 5 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 6 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 7 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 8 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 9 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 10 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 11 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           }),
           queue.add({ order: 12 }, {
             delay: 1000,
-            timestamp: Date.now()
+            timestamp: now
           })
         ).then(function () {
           queue.process(fn);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -932,58 +932,17 @@ describe('Queue', function () {
         order++;
       };
 
-      var now = Date.now();
       queue.on('ready', function() {
-        Promise.join(
-          queue.add({ order: 1 }, {
+        var now = Date.now();
+        var _promises = [];
+        var _i = 1;
+        for(_i; _i <= 12; _i++){
+          _promises.push(queue.add({ order: _i }, {
             delay: 1000,
             timestamp: now
-          }),
-          queue.add({ order: 2 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 3 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 4 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 5 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 6 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 7 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 8 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 9 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 10 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 11 }, {
-            delay: 1000,
-            timestamp: now
-          }),
-          queue.add({ order: 12 }, {
-            delay: 1000,
-            timestamp: now
-          })
-        ).then(function () {
+          }));
+        }
+        Promise.join.apply(null, _promises).then(function () {
           queue.process(fn);
         });
       });


### PR DESCRIPTION
Expanding on the concept of using 21 bits of the timestamp to store jobId to achieve FIFO behavior, I fixed the errors with the lua script.

Also updated the timestamp for the delay timer to avoid it being set to something in the past, fixes #180

I tried to add a test for the FIFO behavior when jobs are scheduled at the exact timestamp, however, the test fails. I am not sure if the test is flawed or that the solution for the FIFO behavior doesn't work, so if you can take a look that will be great. Maybe it has to do with the loss of precision when numbers are converted?