### PR TITLE
Increase attemptsMade for successful jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -131,7 +131,19 @@ Job.prototype.delayIfNeeded = function(){
 };
 
 Job.prototype.moveToCompleted = function(){
-  return this._moveToSet('completed');
+  var _this = this;
+  if(isNaN(this.attemptsMade)){
+    this.attemptsMade = 1;
+  }else{
+    this.attemptsMade++;
+  }
+  // Update job states
+  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), {
+    attemptsMade: this.attemptsMade
+  }).then(function() {
+    // Move to completed
+    return _this._moveToSet('completed');
+  });
 };
 
 Job.prototype.moveToFailed = function(err){


### PR DESCRIPTION
This was missing from the implementation of attempts: before only the failed attempts will increment attemptsMade, while successful attempts should do the same as well.