### PR TITLE
Job Promotion, Attempts Made Fix

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -131,7 +131,19 @@ Job.prototype.delayIfNeeded = function(){
 };
 
 Job.prototype.moveToCompleted = function(){
-  return this._moveToSet('completed');
+  var _this = this;
+  if(isNaN(this.attemptsMade)){
+    this.attemptsMade = 1;
+  }else{
+    this.attemptsMade++;
+  }
+  // Update job states
+  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), {
+    attemptsMade: this.attemptsMade
+  }).then(function() {
+    // Move to completed
+    return _this._moveToSet('completed');
+  });
 };
 
 Job.prototype.moveToFailed = function(err){

--- a/lib/job.js
+++ b/lib/job.js
@@ -132,15 +132,7 @@ Job.prototype.delayIfNeeded = function(){
 
 Job.prototype.moveToCompleted = function(){
   var _this = this;
-  if(isNaN(this.attemptsMade)){
-    this.attemptsMade = 1;
-  }else{
-    this.attemptsMade++;
-  }
-  // Update job states
-  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), {
-    attemptsMade: this.attemptsMade
-  }).then(function() {
+  return this._saveAttempt().then(function() {
     // Move to completed
     return _this._moveToSet('completed');
   });
@@ -149,16 +141,7 @@ Job.prototype.moveToCompleted = function(){
 Job.prototype.moveToFailed = function(err){
   var _this = this;
   this.stacktrace.push(err.stack);
-  if(isNaN(this.attemptsMade)){
-    this.attemptsMade = 1;
-  }else{
-    this.attemptsMade++;
-  }
-  // Update job states
-  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), {
-    stacktrace: JSON.stringify(this.stacktrace),
-    attemptsMade: this.attemptsMade
-  }).then(function() {
+  return this._saveAttempt().then(function() {
     // Check if an automatic retry should be performed
     if(_this.attemptsMade < _this.attempts){
       // Check if backoff is needed
@@ -504,6 +487,21 @@ Job.prototype._retryAtOnce = function(){
         throw new Error('Missing Job ' + jobId + ' during retry');
       }
     });
+};
+
+Job.prototype._saveAttempt = function(stacktrace){
+  if(isNaN(this.attemptsMade)){
+    this.attemptsMade = 1;
+  }else{
+    this.attemptsMade++;
+  }
+  var params = {
+    attemptsMade: this.attemptsMade
+  };
+  if(stacktrace){
+    params.stacktrace = JSON.stringify(this.stacktrace);
+  }
+  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), params);
 };
 
 /**

--- a/lib/job.js
+++ b/lib/job.js
@@ -180,6 +180,38 @@ Job.prototype.moveToDelayed = function(timestamp){
   return this._moveToSet('delayed', timestamp);
 };
 
+Job.prototype.promote = function(){
+  var queue = this.queue;
+  var jobId = this.jobId;
+
+  var script = [
+    'if redis.call("ZREM", KEYS[1], ARGV[1]) == 1 then',
+    ' redis.call("LPUSH", KEYS[2], ARGV[1])',
+    ' return 0',
+    'else',
+    ' return -1',
+    'end'
+    ].join('\n');
+
+  var keys = _.map([
+    'delayed',
+    'wait'], function(name){
+      return queue.toKey(name);
+    }
+  );
+
+  return queue.client.evalAsync(
+    script,
+    keys.length,
+    keys[0],
+    keys[1],
+    jobId).then(function(result){
+      if(result === -1){
+        throw new Error('Job ' + jobId + ' is not in a delayed state');
+      }
+    });
+};
+
 Job.prototype.retry = function(){
   var key = this.queue.toKey('wait');
   var failed = this.queue.toKey('failed');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -24,8 +24,8 @@ var semver = require('semver');
                            -- >completed
                           /
     job -> wait -> active
-        |    ^        |   \
-        v    |        |    -- > failed
+        |    ^            \
+        v    |             -- > failed
         delayed
 */
 


### PR DESCRIPTION
Added a method to promote a job from delayed immediately to wait, instead of having to wait for the timer. 

Also fix the issue where a successful attempt at processing the job does not increment the `attemptsMade` counter.

Fix job tests level: `get job status` should not be part of `.moveToFailed`