### PR TITLE
Catch and log error when trying to create Job from ID

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -503,7 +503,7 @@ Queue.prototype.processStalledJobs = function(){
   var _this = this;
   return this.client.lrangeAsync(this.toKey('active'), 0, -1).then(function(jobs){
     return Promise.each(jobs, function(jobId) {
-      return Job.fromId(_this, jobId).then(_this.processStalledJob.bind(_this));
+      return Job.fromId(_this, jobId).then(_this.processStalledJob.bind(_this)).catch(function(err){console.error(err);});
     });
   });
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -503,7 +503,7 @@ Queue.prototype.processStalledJobs = function(){
   var _this = this;
   return this.client.lrangeAsync(this.toKey('active'), 0, -1).then(function(jobs){
     return Promise.each(jobs, function(jobId) {
-      return Job.fromId(_this, jobId).then(_this.processStalledJob.bind(_this)).catch(function(err){console.error(err);});
+      return Job.fromId(_this, jobId).then(_this.processStalledJob.bind(_this)).catch(function(err){console.error("job %s is invalid: %s", jobId, err);});
     });
   });
 };


### PR DESCRIPTION
Currently if the fromId function fails (due to corrupted job?), processStalledJobs will never finish.