### PR TITLE
fixed 'low' priority changes to 'normal'

### DIFF
--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -216,7 +216,7 @@ PriorityQueue.prototype.getFailed = PriorityQueue.genericGetter("getFailed");
 // Private methods
 // ---------------------------------------------------------------------
 PriorityQueue.prototype.getQueue = function(priority) {
-  if (!PriorityQueue.priorities[priority]) {
+  if (!(priority in PriorityQueue.priorities)) {
     //in case of unknown priority, we use normal
     priority = "normal";
   }


### PR DESCRIPTION
jobs can't really be added to the 'low' priority queue because of the way the condition in `getQueue` is formed.
The value is __always `true` under the condition__ `priority == 'low'` (because { 'low': 0, ... })

I opened an issue (#222) on this.