### PR TITLE
Fixes Queue.prototype.close with long running jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -548,10 +548,7 @@ Queue.prototype.processJob = function(job){
 
   var lockRenewer = function(){
     job.renewLock(_this.token);
-    lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, function () {
-      _this.timers.clear(lockRenewId);
-      lockRenewer();
-    });
+    lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
   };
 
   var timeoutMs = job.opts.timeout;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -548,7 +548,10 @@ Queue.prototype.processJob = function(job){
 
   var lockRenewer = function(){
     job.renewLock(_this.token);
-    lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
+    lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, function () {
+      _this.timers.clear(lockRenewId);
+      lockRenewer();
+    });
   };
 
   var timeoutMs = job.opts.timeout;

--- a/lib/timer-manager.js
+++ b/lib/timer-manager.js
@@ -64,11 +64,21 @@ function TimerManager(){
 
 /**
   Create a new timer (setTimeout).
+
+  Expired timers are automatically cleared
+
+  @param {String} name - Name of a timer key. Used only for debugging.
+  @param {Number} delay - delay of timeout
+  @param {Function} fn - Function to execute after delay
+  @returns {Number} id - The timer id. Used to clear the timer
 */
 TimerManager.prototype.set = function(name, delay, fn){
-  var timer = setTimeout(fn, delay);
   var id = uuid.v4();
   var now = Date.now();
+  var timer = setTimeout(function (timerInstance, timeoutId) {
+    timerInstance.clear(timeoutId);
+    fn();
+  }, delay, this, id);
 
   // XXX only the timer is used, but the
   // other fields are useful for

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -81,6 +81,21 @@ describe('Queue', function () {
       return closePromise;
     });
 
+    it('should close if the job expires after the LOCK_RENEW_TIME', function (done) {
+      var closeQueue = new Queue('close timeout');
+      closeQueue.LOCK_RENEW_TIME = 10;
+      closeQueue.process(function () {
+        return Promise.delay(40);
+      });
+
+      closeQueue.on('completed', function () {
+        closeQueue.close().then(function () {
+          done();
+        });
+      });
+      closeQueue.add({ foo: 'bar' });
+    });
+
     describe('should be callable from within', function () {
       it('a job handler that takes a callback', function (done) {
         this.timeout(6000);


### PR DESCRIPTION
This PR fixes an issue with the lockRenewer in the `Queue.prototype.processJob` function. If a job runs longer than the LOCK_RENEW_TIME, the queue now clears the timer before resetting a new timer.