### PR TITLE
Make sure `updateDelaySet` is not called with a future timestamp

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -58,7 +58,7 @@ Job.prototype.toData = function(){
     timestamp: this.timestamp,
     attempts: this.attempts,
     attemptsMade: this.attemptsMade,
-    stacktrace: JSON.stringify([])
+    stacktrace: this.stacktrace
   };
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -57,7 +57,8 @@ Job.prototype.toData = function(){
     delay: this.delay,
     timestamp: this.timestamp,
     attempts: this.attempts,
-    attemptsMade: this.attemptsMade
+    attemptsMade: this.attemptsMade,
+    stacktrace: JSON.stringify([])
   };
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -453,6 +453,10 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
   top of the  wait queue (so that it will be processed as soon as possible)
 */
 var updateDelaySet = function(queue, delayedTimestamp){
+  var now = Date.now();
+  if(delayedTimestamp > now){
+    delayedTimestamp = now;
+  }
   var script = [
     'local RESULT = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")',
     'local jobId = RESULT[1]',


### PR DESCRIPTION
Somehow `updateDelaySet` is called with a future timestamp sometimes, and it's very bad. This will guarantees no future jobs are prematurely run before we can hunt down the cause of why the future call is happening.