### PR TITLE
fixed; #230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+v0.7.1
+======
+
+- fixed storing of stacktraces
+
+[Changes](https://github.com/OptimalBits/bull/compare/v0.7.0...v0.7.1)v0.7.1
+
 v0.7.0
 ======
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -397,7 +397,6 @@ Job.prototype._moveToSet = function(set, context){
     '  redis.call("HSET", KEYS[3], "returnvalue", ARGV[1])',
     '  redis.call("SADD", KEYS[2], ARGV[2])',
     ' elseif string.find(KEYS[2], "failed$") ~= nil then',
-    '  redis.call("HSET", KEYS[3], "stacktrace", ARGV[1])',
     '  redis.call("SADD", KEYS[2], ARGV[2])',
     ' else',
     '  return -1',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bull",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Job manager",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Using @avermeil's suggestion from #230, I removed the Lua line incorrectly setting the `stacktrace` field when saving a failed job.  `_saveAttempt()` sets this correctly by pushing to the `stacktrace` field.  Turns out `_moveToSet()` was overwriting this. All existing relevant unit tests pass.