### PR TITLE
Enhance Queue#pause and Queue#resume methods to pause local worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features:
 - Retries.
 - Priority.
 - Concurrency.
-- Global pause/resume.
+- Pause/resume (globally or locally).
 
 
 Install:
@@ -126,7 +126,8 @@ videoQueue.process(function(job){ // don't forget to remove the done callback!
 });
 ```
 
-A queue can be paused and resumed globally:
+A queue can be paused and resumed globally (pass `true` to pause processing for
+just this worker):
 ```javascript
 queue.pause().then(function(){
   // queue is paused now
@@ -280,8 +281,6 @@ listened by some other service that stores the results in a database.
 * [Queue##add](#add)
 * [Queue##pause](#pause)
 * [Queue##resume](#resume)
-* [Queue##pauseLocal](#pauseLocal)
-* [Queue##resumeLocal](#resumeLocal)
 * [Queue##count](#count)
 * [Queue##empty](#empty)
 * [Queue##clean](#clean)
@@ -399,18 +398,19 @@ __Arguments__
 
 
 <a name="pause"/>
-#### Queue##pause()
+#### Queue##pause([isLocal])
 
-Returns a promise that resolves when the queue is paused. The pause is
-global, meaning that all workers in all queue instances for a given queue
-will be paused. A paused queue will not process new jobs until resumed, but
-current jobs being processed will continue until they are finalized.
+Returns a promise that resolves when the queue is paused. A paused queue will not 
+process new jobs until resumed, but current jobs being processed will continue until
+they are finalized. The pause can be either global or local. If global, all workers in all queue instances for a given queue will be paused. If local, just this worker will stop processing new jobs. This can be useful to stop a worker from
+taking new jobs prior to shutting down.
 
 Pausing a queue that is already paused does nothing.
 
 __Arguments__
 
 ```javascript
+  isLocal {Boolean} True to only pause the local worker. Defaults to false.
   returns {Promise} A promise that resolves when the queue is paused.
 ```
 
@@ -418,57 +418,20 @@ __Arguments__
 
 
 <a name="resume"/>
-#### Queue##resume()
+#### Queue##resume([isLocal])
 
 Returns a promise that resolves when the queue is resumed after being paused.
-The resume is global, meaning that all workers in all queue instances for
-a given queue will be resumed.
+The resume can be either local or global. If global, all workers in all queue 
+instances for a given queue will be resumed. If local, only this worker will be
+resumed. Note that resuming a queue globally will *not* resume workers that have been
+paused locally; for those, `resume(true)` must be called directly on their instances.
 
 Resuming a queue that is not paused does nothing.
 
 __Arguments__
 
 ```javascript
-  returns {Promise} A promise that resolves when the queue is resumed.
-```
-
----------------------------------------
-
-
-<a name="pause"/>
-#### Queue##pauseLocal()
-
-Returns a promise that resolves when the queue is paused. Unlike its global
-counterpart, this pauses only this queue instance. It is useful if you're
-shutting down the server. A paused queue will not process new jobs until resumed, but
-current jobs being processed will continue until they are finalized.
-
-Pausing a queue that is already paused does nothing.
-
-Calling this method will set `Queue##isPausedLocal` to `true`.
-
-__Arguments__
-
-```javascript
-  returns {Promise} A promise that resolves when the queue is paused.
-```
-
----------------------------------------
-
-
-<a name="resume"/>
-#### Queue##resumeLocal()
-
-Returns a promise that resolves when the queue is resumed after being paused.
-Unlike its global counterpart, it resumes only this queue instance.
-
-Resuming a queue that is not paused does nothing.
-
-Calling this method will set `Queue##isPausedLocal` to `false`.
-
-__Arguments__
-
-```javascript
+  isLocal {Boolean} True to resume only the local worker. Defaults to false.
   returns {Promise} A promise that resolves when the queue is resumed.
 ```
 

--- a/README.md
+++ b/README.md
@@ -402,8 +402,7 @@ __Arguments__
 
 Returns a promise that resolves when the queue is paused. A paused queue will not 
 process new jobs until resumed, but current jobs being processed will continue until
-they are finalized. The pause can be either global or local. If global, all workers in all queue instances for a given queue will be paused. If local, just this worker will stop processing new jobs. This can be useful to stop a worker from
-taking new jobs prior to shutting down.
+they are finalized. The pause can be either global or local. If global, all workers in all queue instances for a given queue will be paused. If local, just this worker will stop processing new jobs after the current lock expires. This can be useful to stop a worker from taking new jobs prior to shutting down.
 
 Pausing a queue that is already paused does nothing.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ videoQueue.process(function(job){ // don't forget to remove the done callback!
 });
 ```
 
-A queue can be paused and resumed:
+A queue can be paused and resumed globally:
 ```javascript
 queue.pause().then(function(){
   // queue is paused now
@@ -280,6 +280,8 @@ listened by some other service that stores the results in a database.
 * [Queue##add](#add)
 * [Queue##pause](#pause)
 * [Queue##resume](#resume)
+* [Queue##pauseLocal](#pauseLocal)
+* [Queue##resumeLocal](#resumeLocal)
 * [Queue##count](#count)
 * [Queue##empty](#empty)
 * [Queue##clean](#clean)
@@ -421,6 +423,42 @@ __Arguments__
 Returns a promise that resolves when the queue is resumed after being paused.
 The resume is global, meaning that all workers in all queue instances for
 a given queue will be resumed.
+
+Resuming a queue that is not paused does nothing.
+
+__Arguments__
+
+```javascript
+  returns {Promise} A promise that resolves when the queue is resumed.
+```
+
+---------------------------------------
+
+
+<a name="pause"/>
+#### Queue##pauseLocal()
+
+Returns a promise that resolves when the queue is paused. Unlike its global
+counterpart, this pauses only this queue instance. It is useful if you're
+shutting down the server. A paused queue will not process new jobs until resumed, but
+current jobs being processed will continue until they are finalized.
+
+Pausing a queue that is already paused does nothing.
+
+__Arguments__
+
+```javascript
+  returns {Promise} A promise that resolves when the queue is paused.
+```
+
+---------------------------------------
+
+
+<a name="resume"/>
+#### Queue##resumeLocal()
+
+Returns a promise that resolves when the queue is resumed after being paused.
+Unlike its global counterpart, it resumes only this queue instance.
 
 Resuming a queue that is not paused does nothing.
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -545,21 +545,6 @@ Queue.prototype.processStalledJob = function(job){
   }
 };
 
-Queue.prototype.pauseLocal = function() {
-  var _this = this;
-  if (!this.paused){
-    this.paused = new Promise(function(resolve) {
-      _this.resumeLocal = function() {
-        resolve();
-        _this.paused = null;
-        return Promise.resolve(); // For API consistency.
-      };
-    });
-  }
-
-  return Promise.resolve(); // For API consistency.
-};
-
 Queue.prototype.processJobs = function(){
   var _this = this;
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -167,6 +167,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     }
   }, POLLING_INTERVAL);
 
+  this.checkWorkerPaused = Promise.resolve();
 };
 
 util.inherits(Queue, events.EventEmitter);
@@ -526,10 +527,34 @@ Queue.prototype.processStalledJob = function(job){
   }
 };
 
+Queue.prototype.pauseLocal = function() {
+  var resolve, reject;
+  this.checkWorkerPaused = new Promise(function(innerResolve, innerReject) {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+  this.checkWorkerPaused.resolve = resolve;
+  this.checkWorkerPaused.reject = reject;
+
+  return Promise.resolve(); // For API consistency.
+};
+
+Queue.prototype.resumeLocal = function() {
+  this.checkWorkerPaused.resolve();
+
+  return Promise.resolve(); // For API consistency.
+};
+
+Queue.prototype.checkPausedLocally = function() {
+  return this.checkWorkerPaused;
+};
+
 Queue.prototype.processJobs = function(){
   var _this = this;
 
-  return this.processStalledJobs().then(function() {
+  return this.checkPausedLocally().then(function(){
+    return _this.processStalledJobs();
+  }).then(function() {
     return _this.getNextJob();
   }).then(function(job) {
     return job.takeLock(_this.token).then(function(locked) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -368,8 +368,8 @@ Queue.prototype.empty = function(){
   and in that case it will add it there instead of the wait list.
 */
 Queue.prototype.pause = function(isLocal /* Optional */){
-  if (isLocal){
-    if (!this.paused){
+  if(isLocal){
+    if(!this.paused){
       var _this = this;
       this.paused = new Promise(function(resolve) {
         _this.resumeLocal = function() {
@@ -379,18 +379,18 @@ Queue.prototype.pause = function(isLocal /* Optional */){
       });
     }
     return Promise.resolve();
-  } else {
+  }else{
     return pauseResumeGlobal(this, true);
   }
 };
 
 Queue.prototype.resume = function(isLocal /* Optional */){
-  if (isLocal) {
-    if (this.resumeLocal) {
+  if(isLocal){
+    if(this.resumeLocal){
       this.resumeLocal();
     }
     return Promise.resolve();
-  } else {
+  }else{
     return pauseResumeGlobal(this, false);
   }
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -171,6 +171,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
 
   // Bind these methods to avoid constant rebinding and/or creating closures
   // in processJobs etc.
+  this.processStalledJobs = this.processStalledJobs.bind(this);
   this.getNextJob = this.getNextJob.bind(this);
   this.processJobs = this.processJobs.bind(this);
   this.takeLockAndProcessJob = this.takeLockAndProcessJob.bind(this);
@@ -555,8 +556,8 @@ Queue.prototype.processStalledJob = function(job){
 };
 
 Queue.prototype.processJobs = function(){
-  return this.processStalledJobs()
-    .then(this.paused || Promise.resolve())
+  return (this.paused || Promise.resolve())
+    .then(this.processStalledJobs)
     .then(this.getNextJob)
     .then(this.takeLockAndProcessJob)
     // Avoid https://github.com/OptimalBits/bull/issues/243

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -166,9 +166,6 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
       });
     }
   }, POLLING_INTERVAL);
-
-  this.isPausedLocal = false;
-  this.checkWorkerPaused = Promise.resolve();
 };
 
 util.inherits(Queue, events.EventEmitter);
@@ -360,25 +357,45 @@ Queue.prototype.empty = function(){
 };
 
 /**
-  Pauses the processing of this queue.
+  Pauses the processing of this queue, locally if true passed, otherwise globally.
 
-  We use an atomic RENAME operation on the wait queue. Since we have
-  blocking calls with BRPOPLPUSH on the wait queue, as long as the queue
+  For global pause, we use an atomic RENAME operation on the wait queue. Since
+  we have blocking calls with BRPOPLPUSH on the wait queue, as long as the queue
   is renamed to 'paused', no new jobs will be processed (the current ones
   will run until finalized).
 
   Adding jobs requires a LUA script to check first if the paused list exist
   and in that case it will add it there instead of the wait list.
 */
-Queue.prototype.pause = function(){
-  return pauseResume(this, true);
+Queue.prototype.pause = function(isLocal /* Optional */){
+  if (isLocal){
+    if (!this.paused){
+      var _this = this;
+      this.paused = new Promise(function(resolve) {
+        _this.resumeLocal = function() {
+          resolve();
+          _this.paused = null; // Allow pause to be checked externally for paused state.
+        };
+      });
+    }
+    return Promise.resolve();
+  } else {
+    return pauseResumeGlobal(this, true);
+  }
 };
 
-Queue.prototype.resume = function(){
-  return pauseResume(this, false);
+Queue.prototype.resume = function(isLocal /* Optional */){
+  if (isLocal) {
+    if (this.resumeLocal) {
+      this.resumeLocal();
+    }
+    return Promise.resolve();
+  } else {
+    return pauseResumeGlobal(this, false);
+  }
 };
 
-function pauseResume(queue, pause){
+function pauseResumeGlobal(queue, pause){
   var src = 'wait', dst = 'paused';
   if(!pause){
     src = 'paused';
@@ -529,35 +546,24 @@ Queue.prototype.processStalledJob = function(job){
 };
 
 Queue.prototype.pauseLocal = function() {
-  var resolve, reject;
-  this.checkWorkerPaused = new Promise(function(innerResolve, innerReject) {
-    resolve = innerResolve;
-    reject = innerReject;
-  });
-  this.checkWorkerPaused.resolve = resolve;
-  this.checkWorkerPaused.reject = reject;
-
-  this.isPausedLocal = true;
-
-  return Promise.resolve(); // For API consistency.
-};
-
-Queue.prototype.resumeLocal = function() {
-  this.isPausedLocal = false;
-
-  this.checkWorkerPaused.resolve();
+  var _this = this;
+  if (!this.paused){
+    this.paused = new Promise(function(resolve) {
+      _this.resumeLocal = function() {
+        resolve();
+        _this.paused = null;
+        return Promise.resolve(); // For API consistency.
+      };
+    });
+  }
 
   return Promise.resolve(); // For API consistency.
-};
-
-Queue.prototype.checkPausedLocally = function() {
-  return this.checkWorkerPaused;
 };
 
 Queue.prototype.processJobs = function(){
   var _this = this;
 
-  return this.checkPausedLocally().then(function(){
+  return (this.paused || Promise.resolve()).then(function(){
     return _this.processStalledJobs();
   }).then(function() {
     return _this.getNextJob();

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -834,6 +834,30 @@ describe('Queue', function () {
       });
     });
 
+    it('should pause the queue locally', function(testDone){
+      var ispaused = false, counter = 2;
+
+      queue = buildQueue();
+
+      queue.pause(true /* Local */).then(function(){
+        queue.process(function(job, done){
+          expect(queue.paused).not.to.be.ok();
+          done();
+          counter--;
+          if(counter === 0){
+            testDone();
+          }
+        });
+      }).then(function(){
+        return queue.add({ foo: 'paused' });
+      }).then(function(){
+        return queue.add({ foo: 'paused' });
+      }).then(function(){
+        expect(counter).to.be(2);
+        expect(queue.paused).to.be.ok(); // Parameter should exist.
+        return queue.resume(true /* Local */);
+      });
+    });
   });
 
   it('should publish a message when a new message is added to the queue', function (done) {

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -840,6 +840,9 @@ describe('Queue', function () {
       queue = buildQueue();
 
       queue.pause(true /* Local */).then(function(){
+        // Add the worker after the queue is in paused mode since the normal behavior is to pause
+        // it after the current lock expires. This way, we can ensure there isn't a lock already
+        // to test that pausing behavior works.
         queue.process(function(job, done){
           expect(queue.paused).not.to.be.ok();
           done();


### PR DESCRIPTION
Enhances Queue#pause and Queue#resume methods to pause local workers.

This is useful for graceful shutdown. For example:
```
process.on('SIGUSR2', function() {
  // Stop processing new jobs.
  queue.pause(true /* Local */);

  // Wait for all currently processing jobs to complete (not covered in this snippet).
  onAllJobsComplete(function(){
    process.exit(1);
  });
});
```

Let me know if this works! Happy to make changes. I think it's incredibly useful as a step towards supporting graceful shutdown (a la https://github.com/Automattic/kue#graceful-shutdown).

Note that the only part of the API that I'm not completely happy with is that `pause(true)` only actually pauses after the current promise-loop has expired. So it's possible for another job to get processed after `pause(true)` has been called. This is usually fine for the graceful shutdown use case above. But perhaps you have a better idea.