### PR TITLE
Fixes the "Illegal access to a strict mode caller function." bug

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -11,6 +11,8 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var uuid = require('node-uuid');
 var semver = require('semver');
+Promise.promisifyAll(redis.RedisClient.prototype);
+Promise.promisifyAll(redis.Multi.prototype);
 
 /**
   Gets or creates a new Queue with the given name.
@@ -66,7 +68,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     }else{
       client = redis.createClient(redisPort, redisHost, redisOptions);
     }
-    return Promise.promisifyAll(client);
+    return client;
   }
 
   redisPort = redisPort || 6379;


### PR DESCRIPTION
- Properly promisify the node redis library based on what the lib
recommends on their site:
https://github.com/NodeRedis/node_redis#promises
- Fixes #211
- Note: this also fixes the current test failure in master