### PR TITLE
Adds local variants of pause and resume.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features:
 - Retries.
 - Priority.
 - Concurrency.
-- Global pause/resume.
+- Pause/resume (globally or locally).
 
 
 Install:
@@ -126,7 +126,8 @@ videoQueue.process(function(job){ // don't forget to remove the done callback!
 });
 ```
 
-A queue can be paused and resumed:
+A queue can be paused and resumed globally (pass `true` to pause processing for
+just this worker):
 ```javascript
 queue.pause().then(function(){
   // queue is paused now
@@ -397,18 +398,18 @@ __Arguments__
 
 
 <a name="pause"/>
-#### Queue##pause()
+#### Queue##pause([isLocal])
 
-Returns a promise that resolves when the queue is paused. The pause is
-global, meaning that all workers in all queue instances for a given queue
-will be paused. A paused queue will not process new jobs until resumed, but
-current jobs being processed will continue until they are finalized.
+Returns a promise that resolves when the queue is paused. A paused queue will not 
+process new jobs until resumed, but current jobs being processed will continue until
+they are finalized. The pause can be either global or local. If global, all workers in all queue instances for a given queue will be paused. If local, just this worker will stop processing new jobs after the current lock expires. This can be useful to stop a worker from taking new jobs prior to shutting down.
 
 Pausing a queue that is already paused does nothing.
 
 __Arguments__
 
 ```javascript
+  isLocal {Boolean} True to only pause the local worker. Defaults to false.
   returns {Promise} A promise that resolves when the queue is paused.
 ```
 
@@ -416,17 +417,20 @@ __Arguments__
 
 
 <a name="resume"/>
-#### Queue##resume()
+#### Queue##resume([isLocal])
 
 Returns a promise that resolves when the queue is resumed after being paused.
-The resume is global, meaning that all workers in all queue instances for
-a given queue will be resumed.
+The resume can be either local or global. If global, all workers in all queue 
+instances for a given queue will be resumed. If local, only this worker will be
+resumed. Note that resuming a queue globally will *not* resume workers that have been
+paused locally; for those, `resume(true)` must be called directly on their instances.
 
 Resuming a queue that is not paused does nothing.
 
 __Arguments__
 
 ```javascript
+  isLocal {Boolean} True to resume only the local worker. Defaults to false.
   returns {Promise} A promise that resolves when the queue is resumed.
 ```
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -171,6 +171,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
 
   // Bind these methods to avoid constant rebinding and/or creating closures
   // in processJobs etc.
+  this.processStalledJobs = this.processStalledJobs.bind(this);
   this.getNextJob = this.getNextJob.bind(this);
   this.processJobs = this.processJobs.bind(this);
   this.takeLockAndProcessJob = this.takeLockAndProcessJob.bind(this);
@@ -366,25 +367,45 @@ Queue.prototype.empty = function(){
 };
 
 /**
-  Pauses the processing of this queue.
+  Pauses the processing of this queue, locally if true passed, otherwise globally.
 
-  We use an atomic RENAME operation on the wait queue. Since we have
-  blocking calls with BRPOPLPUSH on the wait queue, as long as the queue
+  For global pause, we use an atomic RENAME operation on the wait queue. Since
+  we have blocking calls with BRPOPLPUSH on the wait queue, as long as the queue
   is renamed to 'paused', no new jobs will be processed (the current ones
   will run until finalized).
 
   Adding jobs requires a LUA script to check first if the paused list exist
   and in that case it will add it there instead of the wait list.
 */
-Queue.prototype.pause = function(){
-  return pauseResume(this, true);
+Queue.prototype.pause = function(isLocal /* Optional */){
+  if(isLocal){
+    if(!this.paused){
+      var _this = this;
+      this.paused = new Promise(function(resolve) {
+        _this.resumeLocal = function() {
+          resolve();
+          _this.paused = null; // Allow pause to be checked externally for paused state.
+        };
+      });
+    }
+    return Promise.resolve();
+  }else{
+    return pauseResumeGlobal(this, true);
+  }
 };
 
-Queue.prototype.resume = function(){
-  return pauseResume(this, false);
+Queue.prototype.resume = function(isLocal /* Optional */){
+  if(isLocal){
+    if(this.resumeLocal){
+      this.resumeLocal();
+    }
+    return Promise.resolve();
+  }else{
+    return pauseResumeGlobal(this, false);
+  }
 };
 
-function pauseResume(queue, pause){
+function pauseResumeGlobal(queue, pause){
   var src = 'wait', dst = 'paused';
   if(!pause){
     src = 'paused';
@@ -535,7 +556,8 @@ Queue.prototype.processStalledJob = function(job){
 };
 
 Queue.prototype.processJobs = function(){
-  return this.processStalledJobs()
+  return (this.paused || Promise.resolve())
+    .then(this.processStalledJobs)
     .then(this.getNextJob)
     .then(this.takeLockAndProcessJob)
     // Avoid https://github.com/OptimalBits/bull/issues/243


### PR DESCRIPTION
Enhances Queue#pause and Queue#resume methods to pause local workers.

This is useful for graceful shutdown. For example:
```
process.on('SIGUSR2', function() {
  // Stop processing new jobs.
  queue.pause(true /* Local */);

  // Wait for all currently processing jobs to complete (not covered in this snippet).
  onAllJobsComplete(function(){
    process.exit(1);
  });
});
```

Let me know if this works! Happy to make changes. I think it's incredibly useful as a step towards supporting graceful shutdown (a la https://github.com/Automattic/kue#graceful-shutdown).

Note that the only part of the API that I'm not completely happy with is that `pause(true)` only actually pauses after the current promise-loop has expired. So it's possible for another job to get processed after `pause(true)` has been called. This is usually fine for the graceful shutdown use case above. But perhaps you have a better idea.