### PR TITLE
Emit a 'stalled' event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ A queue emits also some useful events:
   // Job started
   // You can use jobPromise.cancel() to abort this job.
 })
+.on('stalled', function(job){
+  // The job was considered stalled (i.e. its lock was not renewed in LOCK_RENEW_TIME).
+  // Useful for debugging job workers that crash or pause the event loop.
+})
 .on('progress', function(job, progress){
   // Job progress updated!
 })

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -549,6 +549,7 @@ Queue.prototype.processStalledJob = function(job){
         var key = _this.toKey('completed');
         return _this.client.sismemberAsync(key, job.jobId).then(function(isMember){
           if(!isMember){
+            _this.emit('stalled', job);
             return _this.processJob(job);
           }
         });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -416,12 +416,16 @@ describe('Queue', function () {
         });
 
         setTimeout(function(){
+          var stalledCallback = sandbox.spy();
+
           return queueStalled.disconnect().then(function(){
             var queue2 = new Queue('test queue stalled', 6379, '127.0.0.1');
             var doneAfterFour = _.after(4, function () {
+              expect(stalledCallback.calledOnce).to.be(true);
               done();
             });
             queue2.on('completed', doneAfterFour);
+            queue2.on('stalled', stalledCallback);
 
             queue2.process(function (job, jobDone2) {
               jobDone2();


### PR DESCRIPTION
This is useful for debugging because it allows the client code to gather information on which job types are stalling, and fix them.