### PR TITLE
Revert "Emit a 'stalled' event." (it's misleading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,6 @@ A queue emits also some useful events:
   // Job started
   // You can use jobPromise.cancel() to abort this job.
 })
-.on('stalled', function(job){
-  // The job was considered stalled (i.e. its lock was not renewed in LOCK_RENEW_TIME).
-  // Useful for debugging job workers that crash or pause the event loop.
-})
 .on('progress', function(job, progress){
   // Job progress updated!
 })

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -549,7 +549,6 @@ Queue.prototype.processStalledJob = function(job){
         var key = _this.toKey('completed');
         return _this.client.sismemberAsync(key, job.jobId).then(function(isMember){
           if(!isMember){
-            _this.emit('stalled', job);
             return _this.processJob(job);
           }
         });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -416,16 +416,12 @@ describe('Queue', function () {
         });
 
         setTimeout(function(){
-          var stalledCallback = sandbox.spy();
-
           return queueStalled.disconnect().then(function(){
             var queue2 = new Queue('test queue stalled', 6379, '127.0.0.1');
             var doneAfterFour = _.after(4, function () {
-              expect(stalledCallback.calledOnce).to.be(true);
               done();
             });
             queue2.on('completed', doneAfterFour);
-            queue2.on('stalled', stalledCallback);
 
             queue2.process(function (job, jobDone2) {
               jobDone2();


### PR DESCRIPTION
Reverts OptimalBits/bull#254

@manast I realized that this event is actually misleading. New jobs are being processed through `processStalledJobs` even though they haven't been attempted before.

For example:
1. Worker 1: creates job
2. Worker 2: picks up job in getNextJob() and moves it from 'wait' to 'active'
3. Worker 3: runs `processStalledJobs` immediately after and gets the job lock before Worker 2 can get it.

I'm testing this in production with 1M+ jobs/day with 20 workers, and seeing more jobs get picked up by `processStalledJobs` than are picked up by `takeLockAndProcessJob`.

So if that's the case, this event is misleading.