### PR TITLE
Prevent queue#clean from throwing if job is null

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -787,7 +787,7 @@ Queue.prototype.clean = function (grace, type) {
     _this[getter]().then(function (jobs) {
       //take all jobs outside of the grace period
       return Promise.filter(jobs, function (job) {
-        return (!job.timestamp) || (job.timestamp < Date.now() - grace);
+        return (!job || !job.timestamp) || (job.timestamp < Date.now() - grace);
       });
     }).then(function (jobs) {
       //remove those old jobs


### PR DESCRIPTION
queue#clean should check the `job` parameter from `Promise.filter()` if any of the queue getter functions (`getCompleted`, `getWaiting`, `getActive`, `getDelayed`, `getFailed`) return a false-y value. This check will prevent the issue in https://github.com/OptimalBits/bull/issues/262