### PR TITLE
Queue#pause waits until active jobs are finished

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -341,8 +341,9 @@ Queue.prototype.empty = function(){
 */
 Queue.prototype.pause = function(isLocal /* Optional */){
   if(isLocal){
+    var _this = this;
+
     if(!this.paused){
-      var _this = this;
       this.paused = new Promise(function(resolve) {
         _this.resumeLocal = function() {
           resolve();
@@ -350,7 +351,8 @@ Queue.prototype.pause = function(isLocal /* Optional */){
         };
       });
     }
-    return Promise.resolve();
+
+    return this.whenCurrentJobsFinished();
   }else{
     return pauseResumeGlobal(this, true);
   }
@@ -810,6 +812,41 @@ Queue.prototype.clean = function (grace, type) {
       reject(err);
     });
   });
+};
+
+/**
+ * Returns a promise that resolves when active jobs are cleared
+ *
+ * @returns {Promise}
+ */
+Queue.prototype.whenCurrentJobsFinished = function(){
+  var resolve, reject;
+  var promise = new Promise(function(innerResolve, innerReject) {
+    resolve = innerResolve;
+    reject = innerReject;
+  });
+
+  var _this = this;
+
+  var resolver = function(count) {
+    if(count === 0) {
+      resolve();
+    }
+    return count;
+  };
+
+  this.getActiveCount().then(resolver).
+    then(function(count) {
+      if(count === 0) {
+        return null;
+      }
+      _this.on('completed', function() {
+        _this.getActiveCount().then(resolver).catch(reject);
+      });
+      return null;
+    }).catch(reject);
+
+  return promise;
 };
 
 //


### PR DESCRIPTION
This PR makes `Queue#pause` wait until all jobs in `active` state are completed before resolving.

Previously, when pausing a queue, it would immediately resolve the pause promise, making it difficult to perform a clean disconnection.
`Queue#pause` will consume the private method `Queue#whenCurrentJobsFinished`, which checks jobs in `active` state, if there are pending jobs, then it sets up a listener on the `completed` event to recheck for jobs in `active` state. Once active jobs reaches 0, it resolves and in turns resolves the promise returned by `Queue#pause`