### PR TITLE
Fixed test_cluster.js

### DIFF
--- a/test/cluster_worker.js
+++ b/test/cluster_worker.js
@@ -20,3 +20,12 @@ queue.process(1, function(job, jobDone) {
     data: job.data
   });
 });
+
+process.on('disconnect', function () {
+  queue.close().then(function () {
+    process.exit(0);
+  }).catch(function (err) {
+    console.err(err);
+    process.exit(-1);
+  });
+});


### PR DESCRIPTION
This fixes test_cluster.js by closing queues started by cluster workers when they are killed