### PR TITLE
Listening to failed jobs on pause

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -827,6 +827,7 @@ Queue.prototype.whenCurrentJobsFinished = function(){
         resolve();
       }else{
         _this.on('completed', _.after(count, resolve));
+        _this.on('failed', _.after(count, resolve));
       }
     }, reject);
   });


### PR DESCRIPTION
Pause now listens to `failed` in order to decrease the count of active jobs