### PR TITLE
Debugging support and minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ videoQueue.process(function(job, done){
 
   // or give a error if error
   done(Error('error transcoding'));
-  
+
   // or pass it a result
   done(null, { framerate: 29.5 /* etc... */ });
 
@@ -76,7 +76,7 @@ audioQueue.process(function(job, done){
 
   // or give a error if error
   done(Error('error transcoding'));
-  
+
   // or pass it a result
   done(null, { samplerate: 48000 /* etc... */ });
 
@@ -93,7 +93,7 @@ imageQueue.process(function(job, done){
 
   // or give a error if error
   done(Error('error transcoding'));
-  
+
   // or pass it a result
   done(null, { width: 1280, height: 720 /* etc... */ });
 
@@ -116,7 +116,7 @@ videoQueue.process(function(job){ // don't forget to remove the done callback!
   // Handles promise rejection
   return Promise.reject(new Error('error transcoding'));
 
-  // Passes the value the promise is resolved with to the "completed" event 
+  // Passes the value the promise is resolved with to the "completed" event
   return Promise.resolve({ framerate: 29.5 /* etc... */ });
 
   // If the job throws an unhandled exception it is also handled correctly
@@ -404,7 +404,7 @@ __Arguments__
 <a name="pause"/>
 #### Queue##pause([isLocal])
 
-Returns a promise that resolves when the queue is paused. A paused queue will not 
+Returns a promise that resolves when the queue is paused. A paused queue will not
 process new jobs until resumed, but current jobs being processed will continue until
 they are finalized. The pause can be either global or local. If global, all workers in all queue instances for a given queue will be paused. If local, just this worker will stop processing new jobs after the current lock expires. This can be useful to stop a worker from taking new jobs prior to shutting down.
 
@@ -424,7 +424,7 @@ __Arguments__
 #### Queue##resume([isLocal])
 
 Returns a promise that resolves when the queue is resumed after being paused.
-The resume can be either local or global. If global, all workers in all queue 
+The resume can be either local or global. If global, all workers in all queue
 instances for a given queue will be resumed. If local, only this worker will be
 resumed. Note that resuming a queue globally will *not* resume workers that have been
 paused locally; for those, `resume(true)` must be called directly on their instances.
@@ -469,8 +469,8 @@ __Arguments__
 
 ---------------------------------------
 
-<a name="close"/>                                                               
-#### Queue##close()                                                             
+<a name="close"/>
+#### Queue##close()
 Closes the underlying redis client. Use this to perform a graceful
 shutdown.
 
@@ -573,7 +573,7 @@ __Events__
 The cleaner emits the `cleaned` event anytime the queue is cleaned.
 
 ```javascript
-  queue.on('cleaned', function (jobs, type) {}); 
+  queue.on('cleaned', function (jobs, type) {});
 
   jobs {Array} An array of jobs that have been cleaned.
   type {String} The type of job cleaned. Options are completed, waiting, active,
@@ -647,6 +647,13 @@ __Arguments__
 
 ---------------------------------------
 
+####Debugging
+
+To see debug statements set or add `bull` to the NODE_DEBUG environment variable.
+
+```bash
+export NODE_DEBUG=bull
+```
 
 ##License
 

--- a/lib/cluster-queue.js
+++ b/lib/cluster-queue.js
@@ -1,6 +1,6 @@
 "use strict"
 
-var 
+var
   Queue = require('./queue'),
   cluster = require('cluster');
 
@@ -11,14 +11,14 @@ if(cluster.isMaster){
   for (var i = 0; i < numWorkers; i++) {
     cluster.fork();
   }
-  
+
   cluster.on('online', function(worker) {
     // Lets create a few jobs for every created worker
     for(var i=0; i<500; i++){
       queue.add({foo: 'bar'});
     };
   });
-  
+
   cluster.on('exit', function(worker, code, signal) {
     console.log('worker ' + worker.process.pid + ' died');
   });

--- a/lib/job.js
+++ b/lib/job.js
@@ -5,6 +5,7 @@
 var Promise = require('bluebird');
 var _ = require('lodash');
 var scripts = require('./scripts');
+var debuglog = require('debuglog').debuglog('bull');
 
 /**
 interface JobOptions
@@ -48,6 +49,7 @@ Job.create = function(queue, data, opts){
   return addJob(queue, job).then(function(jobId){
     job.jobId = jobId;
     queue.emit('waiting', job);
+    debuglog('Job added', jobId);
     //
     // TODO: emit event based on pubsub
     //_this.emit('delayed', job);
@@ -416,6 +418,7 @@ Job.fromData = function(queue, jobId, data){
     job.returnvalue = JSON.parse(data.returnvalue);
   }catch (e){
     //swallow exception because the returnvalue got corrupted somehow.
+    debuglog('corrupted returnvalue: ' + data.returnvalue, e);
   }
   return job;
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -5,7 +5,7 @@
 var Promise = require('bluebird');
 var _ = require('lodash');
 var scripts = require('./scripts');
-var debuglog = require('debuglog').debuglog('bull');
+var debuglog = require('debuglog')('bull');
 
 /**
 interface JobOptions

--- a/lib/message.js
+++ b/lib/message.js
@@ -5,7 +5,7 @@ var when = require('when');
 /**
 interface JobOptions
 {
-  attempts: number;  
+  attempts: number;
 }
 */
 
@@ -103,7 +103,7 @@ Job.prototype._done = function(list){
   var queue = this.queue;
   var activeList = queue.toKey('active');
   var completedList = queue.toKey(list);
-  
+
   queue.client.multi()
     .lrem(activeList, 0, this.jobId)
     .sadd(completedList, this.jobId)

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -12,7 +12,7 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var uuid = require('node-uuid');
 var semver = require('semver');
-var debuglog = require('debuglog').debuglog('bull');
+var debuglog = require('debuglog')('bull');
 Promise.promisifyAll(redis.RedisClient.prototype);
 Promise.promisifyAll(redis.Multi.prototype);
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -12,6 +12,7 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var uuid = require('node-uuid');
 var semver = require('semver');
+var debuglog = require('debuglog').debuglog('bull');
 Promise.promisifyAll(redis.RedisClient.prototype);
 Promise.promisifyAll(redis.Multi.prototype);
 
@@ -129,9 +130,10 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
       _this.eclient.subscribeAsync(_this.toKey('paused'))
     );
   }).then(function(){
+    debuglog(name + ' queue ready');
     _this.emit('ready');
   }, function(err){
-    console.log('Error initializing queue:', err);
+    console.error('Error initializing queue:', err);
   });
 
   //
@@ -485,7 +487,7 @@ Queue.prototype.processStalledJobs = function(){
       return Job.fromId(_this, jobId).then(_this.processStalledJob);
     });
   }).catch(function(err){
-    console.log(err);
+    console.error(err);
   });
 };
 
@@ -520,7 +522,7 @@ Queue.prototype.processJobs = function(){
     .then(this.processJob)
     // Avoid https://github.com/OptimalBits/bull/issues/243
     .then(this.processJobs, function(err){
-      console.log(err);
+      console.error(err);
       return _this.processJobs;
     });
 };

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -9,7 +9,7 @@
 
 var Promise = require('bluebird');
 var _ = require('lodash');
-var debuglog = require('debuglog').debuglog('bull');
+var debuglog = require('debuglog')('bull');
 
 var cache = {};
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -9,7 +9,7 @@
 
 var Promise = require('bluebird');
 var _ = require('lodash');
-var DEBUG = false;
+var debuglog = require('debuglog').debuglog('bull');
 
 var cache = {};
 
@@ -17,7 +17,7 @@ function execScript(client, hash, script){
   var cached = cache[hash];
   var args = _.drop(arguments, 3);
 
-  //console.log(script, args);
+  debuglog(script, args);
 
   if(!cached){
     cached = cacheScript(client, hash, script);
@@ -26,7 +26,7 @@ function execScript(client, hash, script){
   return cached.then(function(sha){
     args.unshift(sha);
     return client.evalshaAsync.apply(client, args).catch(function(err){
-      DEBUG && console.error(err, script, err.stack);
+      debuglog(err, script, err.stack);
       if(err.code === 'NOSCRIPT'){
         delete cache[hash];
         args = [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "bluebird": "^3.3.4",
-    "gulp-eslint": "^2.0.0",
+    "debuglog": "^1.0.0",
     "lodash": "^4.6.1",
     "node-uuid": "^1.4.7",
     "redis": "^2.5.3",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "gulp": "^3.9.1",
-    "gulp-eslint": "^0.13.2",
+    "gulp-eslint": "^2.0.0",
     "mocha": "^2.4.5",
     "sinon": "^1.17.2"
   },


### PR DESCRIPTION
Adds support for debugging that can be turned on or off through standard nodejs approach of using `NODE_DEBUG`.

Removed extra whitespace at the end of lines.

Made logging of errors consistent by using `console.error` instead of a mixture of `console.log` and `console.error`.
