### PR TITLE
Honor start/end range for complete/failed jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -738,7 +738,15 @@ Queue.prototype.getJobs = function(queueType, type, start, end){
       jobs = this.client.lrangeAsync(key, start, end);
       break;
     case 'SET':
-      jobs = this.client.smembersAsync(key);
+      jobs = this.client.smembersAsync(key).then(function(jobIds) {
+        // Can't set a range for smembers. So do the slice programatically instead.
+        // Note that redis ranges are inclusive, so handling for javascript accordingly
+        if (end === -1) {
+          return jobIds.slice(start);
+        }
+
+        return jobIds.slice(start, end + 1);
+      });
       break;
     case 'ZSET':
       jobs = this.client.zrangeAsync(key, start, end);


### PR DESCRIPTION
Queue#getJobs accepts a start and end parameters, which allows for
retrieving a subset of elements with the lrange and zrange
operations. However this can't be done for the smembers operation.

From what I've seen, smembers performs just fine, even when there are
thousands of jobs, however, since this retrieves *All* members in the
complete or failed set, then it can choke the process down in

    return jobs.then(function(jobIds){
      var jobsFromId = jobIds.map(_this.getJobFromId);
      return Promise.all(jobsFromId);
    });

This seems to be alleviated if the jobs are retrieved with batch, instead one by one. I'll open a second PR for this.

Since smembers doesn't accept an offset range, and there's no equivalent that
does, we do the slice programatically, so that it behaves consistently
with the other job types, where a subset is retrieved by passing `start`
and `end`