### PR TITLE
[FIX] correctly allows the specification of the db

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -52,17 +52,17 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     return new Queue(name, redisPort, redisHost, redisOptions);
   }
 
-  var redisDB = 0;
   if(_.isObject(redisPort)){
     var opts = redisPort;
     var redisOpts = opts.redis || {};
     redisPort = redisOpts.port;
     redisHost = redisOpts.host;
     redisOptions = redisOpts.opts;
-    redisDB = redisOpts.DB || redisDB;
-  }
+    redisOptions.db = redisOpts.DB;
+  } 
 
   redisOptions = redisOptions || {};
+  var redisDB = redisOptions.db || 0;
 
   function createClient() {
     var client;


### PR DESCRIPTION
@manast without this change, the only way to specify the DB number is to use the first version of instantiating where the first argument redisPort is an object. This correctly fixes the code to read the db number regardless if it is specified in the first argument as an object property or the last argument as a list of redisOptions.

