### PR TITLE
Taking lock on removal.

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -294,9 +294,7 @@ Job.prototype.remove = function(){
         queue.emit('removed', job);
       })
       .finally(function () {
-        return job.releaseLock().then(function() {
-          return job;
-        });
+        return job.releaseLock();
       });
   });
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -283,8 +283,21 @@ Job.prototype.getState = function() {
 Job.prototype.remove = function(){
   var queue = this.queue;
   var job = this;
-  return scripts.remove(queue, this.jobId).then(function(){
-    queue.emit('removed', job);
+
+  return job.takeLock().then(function(lock) {
+    if (!lock) {
+      throw new Error('Could not get lock for job: ' + job.jobId + '. Cannot remove job.');
+    }
+
+    return scripts.remove(queue, job.jobId)
+      .then(function() {
+        queue.emit('removed', job);
+      })
+      .finally(function () {
+        return job.releaseLock().then(function() {
+          return job;
+        });
+      });
   });
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -557,7 +557,9 @@ Queue.prototype.processJob = function(job, renew){
     //This substraction is duplicate in handleCompleted and handleFailed because it have to be made before throwing any
     //event completed or failed in order to allow pause() to work correctly without getting stuck.
     _this.processing--;
-    return job.moveToCompleted(data).then(function(){
+    return job.moveToCompleted(data)
+      .then(job.releaseLock.bind(job, _this.token))
+      .then(function(){
       _this.emit('completed', job, data);
       return null; // Fixes #253
     });

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -228,12 +228,10 @@ var scripts = {
   },
   remove: function(queue, jobId){
     var script = [
-      'if (redis.call("SISMEMBER", KEYS[5], ARGV[1]) == 0) and (redis.call("SISMEMBER", KEYS[6], ARGV[1]) == 0) then',
-      '  redis.call("LREM", KEYS[1], 0, ARGV[1])',
-      '  redis.call("LREM", KEYS[2], 0, ARGV[1])',
-      '  redis.call("ZREM", KEYS[3], ARGV[1])',
-      '  redis.call("LREM", KEYS[4], 0, ARGV[1])',
-      'end',
+      'redis.call("LREM", KEYS[1], 0, ARGV[1])',
+      'redis.call("LREM", KEYS[2], 0, ARGV[1])',
+      'redis.call("ZREM", KEYS[3], ARGV[1])',
+      'redis.call("LREM", KEYS[4], 0, ARGV[1])',
       'redis.call("SREM", KEYS[5], ARGV[1])',
       'redis.call("SREM", KEYS[6], ARGV[1])',
       'redis.call("DEL", KEYS[7])'].join('\n');

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -72,6 +72,41 @@ describe('Job', function(){
         });
     });
 
+    it('fails to remove a locked job', function() {
+      return Job.create(queue, 1, {foo: 'bar'}).then(function(job) {
+        return job.takeLock().then(function(lock) {
+          expect(lock).to.be(true);
+        }).then(function() {
+          return job.remove();
+        }).then(function() {
+          throw new Error('Should not be able to remove a locked job');
+        }).catch(function(err) {
+          expect(err.message).to.equal('Could not get lock for job: ' + job.jobId + '. Cannot remove job.');
+        });
+      });
+    });
+
+    it('removes any job from active set', function() {
+      return queue.add({ foo: 'bar' }).then(function(job) {
+        // Simulate a job in active state but not locked
+        return queue.moveJob('wait', 'active').then(function() {
+          return job.isActive().then(function(isActive) {
+            expect(isActive).to.be(true);
+            return job.remove();
+          });
+        }).then(function() {
+          return Job.fromId(queue, job.jobId);
+        }).then(function(stored) {
+          expect(stored).to.be(null);
+          return job.getState();
+        }).then(function(state) {
+          // This check is a bit of a hack. A job that is not found in any list will return the state
+          // stuck.
+          expect(state).to.equal('stuck');
+        });
+      });
+    });
+
     it('emits removed event', function (cb) {
       queue.once('removed', function (job) {
         expect(job.data.foo).to.be.equal('bar');
@@ -79,6 +114,30 @@ describe('Job', function(){
       });
       Job.create(queue, {foo: 'bar'}).then(function(job){
         job.remove();
+      });
+    });
+
+    it('a succesful job should be removable', function(done) {
+      queue.process(function () {
+        return Promise.resolve();
+      });
+
+      queue.add({ foo: 'bar' });
+
+      queue.on('completed', function(job) {
+        job.remove().then(done).catch(done);
+      });
+    });
+
+    it('a failed job should be removable', function(done) {
+      queue.process(function () {
+        throw new Error();
+      });
+
+      queue.add({ foo: 'bar' });
+
+      queue.on('failed', function(job) {
+        job.remove().then(done).catch(done);
       });
     });
   });


### PR DESCRIPTION
Currently, when removing a job, it is possible that the job is currently being processed, but `Job#remove` will remove it regardless if it's being under process or not, which may result in corrupt state. `Jobs#remove` will throw if the job is under process, so this may break compatibility for users that expect `Job#remove` to always remove the job.

Also, as of this commit: https://github.com/OptimalBits/bull/commit/5d724a1f42bd52cedda5ea8660351b1c210cc3d3 only jobs that are not `completed` or `failed` will be removed from the `active`, `waiting` or `paused`, but since it is possible that the queue will try to process already processed jobs as documented here: https://github.com/OptimalBits/bull/issues/82, I think the queue should either:

1. Move the job out of `active` when #82 happens
2. `Job#remove` should remove from all sets as it was being done before the commit above, to avoid `Queue#processStalledJobs` from picking up jobs in `active` set when there is already no data in redis because `Job#remove` was called before. 

If you take a careful look at the function, it will actually remove the job from all sets when called twice.

Maybe we should do both.

Let me know your thoughts about the above, I'm working on adding tests for `Job#remove` and made sure no tests are broken because of this (I ran the tests manually, some tests fail but they are failing on `master` too, so not a regression)