### PR TITLE
Releasing lock from processStalledJobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -505,7 +505,14 @@ Queue.prototype.processStalledJob = function(job){
           if(!isMember){
             _this.emit('stalled', job);
             return _this.processJob(job, true);
+          } else {
+            return job.releaseLock(_this.token);
           }
+        }).catch(function(err) {
+          // Any uncaught error will come here. We'll ensure that the job lock is released and rethrow
+          // the error so it bubbles normally
+          job.releaseLock(_this.token);
+          throw err;
         });
       }
     });


### PR DESCRIPTION
Currently, `Queue#processStalledJobs` can run into a state where it locks a `completed` job and doesn't unlock when it does the check to see if the job is `completed` by the time it actually attempts to process it.