### PR TITLE
Improve Queue#clean performance

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -791,9 +791,10 @@ Queue.prototype.toKey = function(queueType){
  *
  * @param {int} grace - The grace period
  * @param {string} [type=completed] - The type of job to clean. Possible values
+ * @param {int} The max number of jobs to clean
  * are completed, waiting, active, delayed, failed. Defaults to completed.
  */
-Queue.prototype.clean = function (grace, type) {
+Queue.prototype.clean = function (grace, type, limit) {
   var _this = this;
 
   return new Promise(function (resolve, reject) {
@@ -814,7 +815,7 @@ Queue.prototype.clean = function (grace, type) {
       return reject(new Error('Cannot clean unkown queue type'));
     }
 
-    return scripts.cleanJobsInSet(_this, type, Date.now() - grace).then(function (jobs) {
+    return scripts.cleanJobsInSet(_this, type, Date.now() - grace, limit).then(function (jobs) {
       _this.emit('cleaned', jobs, type);
       resolve(jobs);
       return null;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -797,8 +797,6 @@ Queue.prototype.clean = function (grace, type) {
   var _this = this;
 
   return new Promise(function (resolve, reject) {
-    var getter;
-
     if(grace === undefined || grace === null) {
       return reject(new Error('You must define a grace period.'));
     }
@@ -809,26 +807,14 @@ Queue.prototype.clean = function (grace, type) {
 
     if(_.indexOf([
       'completed',
-      'waiting',
+      'wait',
       'active',
       'delayed',
       'failed'], type) === -1){
       return reject(new Error('Cannot clean unkown queue type'));
     }
 
-    getter = 'get' + type.charAt(0).toUpperCase() + type.slice(1);
-
-    _this[getter]().then(function (jobs) {
-      // take all jobs outside of the grace period
-      return Promise.filter(jobs, function (job) {
-        return job && ((!job.timestamp) || (job.timestamp < Date.now() - grace));
-      });
-    }).then(function (jobs) {
-      // remove those old jobs
-      return Promise.each(jobs, function (job) {
-        return job.remove(_this.token);
-      });
-    }).then(function (jobs) {
+    return scripts.cleanJobsInSet(_this, type, Date.now() - grace).then(function (jobs) {
       _this.emit('cleaned', jobs, type);
       resolve(jobs);
       return null;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -371,6 +371,68 @@ var scripts = {
 
     return execScript.apply(scripts, args);
   },
+
+  cleanJobsInSet: function(queue, set, ts) {
+    var command;
+    var hash;
+    switch(set) {
+      case 'completed':
+      case 'failed':
+        command = 'local JOBS = redis.call("SMEMBERS", KEYS[1])';
+        hash = 'cleanSet';
+        break;
+      case 'wait':
+      case 'active':
+      case 'paused':
+        command = 'local JOBS = redis.call("LRANGE", KEYS[1], 0, -1)';
+        hash = 'cleanList';
+        break;
+      case 'delayed':
+        command = 'local JOBS = redis.call("ZRANGE", KEYS[1], 0, -1)';
+        hash = 'cleanOSet';
+        break;
+    }
+
+    var script = [
+      command,
+      'local deleted = {}',
+      'local jobTS',
+      'for _, job in ipairs(JOBS) do',
+      '  if (redis.call("EXISTS", ARGV[1] .. job ..  ":lock") == 0) then',
+      '    jobTS = redis.call("HGET", ARGV[1] .. job, "timestamp")',
+      '    if(not jobTS or jobTS < ARGV[2]) then',
+      '      redis.call("LREM", ARGV[1] .. ARGV[3], 0, job)',
+      '      redis.call("LREM", ARGV[1] .. ARGV[4], 0, job)',
+      '      redis.call("ZREM", ARGV[1] .. ARGV[5], job)',
+      '      redis.call("LREM", ARGV[1] .. ARGV[6], 0, job)',
+      '      redis.call("SREM", ARGV[1] .. ARGV[7], job)',
+      '      redis.call("SREM", ARGV[1] .. ARGV[8], job)',
+      '      redis.call("DEL", ARGV[1] .. job)',
+      '      table.insert(deleted, job)',
+      '    end',
+      '  end',
+      'end',
+      'return deleted'
+    ].join('\n');
+
+    var args = [
+      queue.client,
+      hash,
+      script,
+      1,
+      queue.toKey(set),
+      queue.toKey(''),
+      ts,
+      'active',
+      'wait',
+      'delayed',
+      'paused',
+      'completed',
+      'failed',
+    ];
+
+    return execScript.apply(scripts, args);
+  }
 };
 
 /*

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -372,10 +372,13 @@ var scripts = {
     return execScript.apply(scripts, args);
   },
 
-  cleanJobsInSet: function(queue, set, ts) {
+  cleanJobsInSet: function(queue, set, ts, limit) {
     var command;
     var removeCommand;
+    var breakEarlyCommand = '';
     var hash;
+    limit = limit || 0;
+
     switch(set) {
       case 'completed':
       case 'failed':
@@ -397,17 +400,31 @@ var scripts = {
         break;
     }
 
+    if(limit > 0) {
+      breakEarlyCommand = [
+        'if deletedCount >= limit then',
+        '  break',
+        'end',
+      ].join('\n');
+
+      hash = hash + 'WithLimit';
+    }
+
     var script = [
       command,
       'local deleted = {}',
+      'local deletedCount = 0',
+      'local limit = tonumber(ARGV[3])',
       'local jobTS',
       'for _, job in ipairs(jobs) do',
+      breakEarlyCommand,
       '  local jobKey = ARGV[1] .. job',
       '  if (redis.call("EXISTS", jobKey ..  ":lock") == 0) then',
       '    jobTS = redis.call("HGET", jobKey, "timestamp")',
       '    if(not jobTS or jobTS < ARGV[2]) then',
       removeCommand,
       '      redis.call("DEL", jobKey)',
+      '      deletedCount = deletedCount + 1',
       '      table.insert(deleted, job)',
       '    end',
       '  end',
@@ -422,7 +439,8 @@ var scripts = {
       1,
       queue.toKey(set),
       queue.toKey(''),
-      ts
+      ts,
+      limit
     ];
 
     return execScript.apply(scripts, args);

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -374,21 +374,25 @@ var scripts = {
 
   cleanJobsInSet: function(queue, set, ts) {
     var command;
+    var removeCommand;
     var hash;
     switch(set) {
       case 'completed':
       case 'failed':
-        command = 'local JOBS = redis.call("SMEMBERS", KEYS[1])';
+        command = 'local jobs = redis.call("SMEMBERS", KEYS[1])';
+        removeCommand = 'redis.call("SREM", KEYS[1], job)';
         hash = 'cleanSet';
         break;
       case 'wait':
       case 'active':
       case 'paused':
-        command = 'local JOBS = redis.call("LRANGE", KEYS[1], 0, -1)';
+        command = 'local jobs = redis.call("LRANGE", KEYS[1], 0, -1)';
+        removeCommand = 'redis.call("LREM", KEYS[1], 0, job)';
         hash = 'cleanList';
         break;
       case 'delayed':
-        command = 'local JOBS = redis.call("ZRANGE", KEYS[1], 0, -1)';
+        command = 'local jobs = redis.call("ZRANGE", KEYS[1], 0, -1)';
+        removeCommand = 'redis.call("ZREM", KEYS[1], job)';
         hash = 'cleanOSet';
         break;
     }
@@ -397,17 +401,13 @@ var scripts = {
       command,
       'local deleted = {}',
       'local jobTS',
-      'for _, job in ipairs(JOBS) do',
-      '  if (redis.call("EXISTS", ARGV[1] .. job ..  ":lock") == 0) then',
-      '    jobTS = redis.call("HGET", ARGV[1] .. job, "timestamp")',
+      'for _, job in ipairs(jobs) do',
+      '  local jobKey = ARGV[1] .. job',
+      '  if (redis.call("EXISTS", jobKey ..  ":lock") == 0) then',
+      '    jobTS = redis.call("HGET", jobKey, "timestamp")',
       '    if(not jobTS or jobTS < ARGV[2]) then',
-      '      redis.call("LREM", ARGV[1] .. ARGV[3], 0, job)',
-      '      redis.call("LREM", ARGV[1] .. ARGV[4], 0, job)',
-      '      redis.call("ZREM", ARGV[1] .. ARGV[5], job)',
-      '      redis.call("LREM", ARGV[1] .. ARGV[6], 0, job)',
-      '      redis.call("SREM", ARGV[1] .. ARGV[7], job)',
-      '      redis.call("SREM", ARGV[1] .. ARGV[8], job)',
-      '      redis.call("DEL", ARGV[1] .. job)',
+      removeCommand,
+      '      redis.call("DEL", jobKey)',
       '      table.insert(deleted, job)',
       '    end',
       '  end',
@@ -422,13 +422,7 @@ var scripts = {
       1,
       queue.toKey(set),
       queue.toKey(''),
-      ts,
-      'active',
-      'wait',
-      'delayed',
-      'paused',
-      'completed',
-      'failed',
+      ts
     ];
 
     return execScript.apply(scripts, args);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1621,6 +1621,34 @@ describe('Queue', function () {
       });
     });
 
+    it('should clean all waiting jobs', function (done) {
+      queue.add({some: 'data'});
+      queue.add({some: 'data'});
+      Promise.delay(100).then(function () {
+        return queue.clean(0, 'wait');
+      }).then(function (jobs) {
+        expect(jobs.length).to.be(2);
+        return queue.count();
+      }).then(function(len) {
+        expect(len).to.be(0);
+        done();
+      });
+    });
+
+    it('should clean all delayed jobs', function (done) {
+      queue.add({some: 'data'}, { delay: 5000 });
+      queue.add({some: 'data'}, { delay: 5000 });
+      Promise.delay(100).then(function () {
+        return queue.clean(0, 'delayed');
+      }).then(function (jobs) {
+        expect(jobs.length).to.be(2);
+        return queue.count();
+      }).then(function(len) {
+        expect(len).to.be(0);
+        done();
+      });
+    });
+
     it('should clean a job without a timestamp', function (done) {
       var client = redis.createClient(6379, '127.0.0.1', {});
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1649,6 +1649,21 @@ describe('Queue', function () {
       });
     });
 
+    it('should clean the number of jobs requested', function (done) {
+      queue.add({some: 'data'});
+      queue.add({some: 'data'});
+      queue.add({some: 'data'});
+      Promise.delay(100).then(function () {
+        return queue.clean(0, 'wait', 1);
+      }).then(function (jobs) {
+        expect(jobs.length).to.be(1);
+        return queue.count();
+      }).then(function(len) {
+        expect(len).to.be(2);
+        done();
+      });
+    });
+
     it('should clean a job without a timestamp', function (done) {
       var client = redis.createClient(6379, '127.0.0.1', {});
 


### PR DESCRIPTION
This PR moves `Queue#clean` to a script for performance purposes.

The test case to measure performance was to create 20,000 jobs, then issue a regular `Queue#clean` call, I measured how long it took in my machine to add the jobs and then the cleaning, these are just one sample of the tests I ran

Current implementation:
adding-jobs: 2657ms
cleaning-jobs: 23515ms

With this PR
adding-jobs: 2658ms
cleaning-jobs: 3708ms

I wanted to keep the script as simple as possible, I'm not 100% well versed on redis lua scripts, so please review for any potential bug on it.

Thanks!

