### PR TITLE
Improvements for Job#retry

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -204,21 +204,26 @@ Job.prototype.promote = function(){
     });
 };
 
+/**
+ * Attempts to retry the job. Only a job that has failed can be retried.
+ *
+ * @return {Promise} If resolved and return code is 1, then the queue emits a waiting event
+ * otherwise the operation was not a success and throw the corresponding error. If the promise
+ * rejects, it indicates that the script failed to execute
+ */
 Job.prototype.retry = function(){
-  var key = this.queue.toKey('wait');
-  var failed = this.queue.toKey('failed');
-  var channel = this.queue.toKey('jobs');
-  var multi = this.queue.multi();
+  var queue = this.queue;
   var _this = this;
-
-  multi.srem(failed, this.jobId);
-  // if queue is LIFO use rpushAsync
-  multi[(this.opts.lifo ? 'r' : 'l') + 'push'](key, this.jobId);
-  multi.publish(channel, this.jobId);
-
-  return multi.execAsync().then(function(){
-    _this.queue.emit('waiting', _this);
-    return _this;
+  return scripts.retryJob(this).then(function(result) {
+    if (result === 1) {
+      queue.emit('waiting', _this);
+    } else if (result === 0) {
+      throw new Error('Couldn\'t retry job: The job doesn\'t exist');
+    } else if (result === -1) {
+      throw new Error('Couldn\'t retry job: The job is locked');
+    } else if (result === -2) {
+      throw new Error('Couldn\'t retry job: The job has been already retried or has not failed');
+    }
   });
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -214,7 +214,7 @@ Job.prototype.promote = function(){
 Job.prototype.retry = function(){
   var queue = this.queue;
   var _this = this;
-  return scripts.retryJob(this).then(function(result) {
+  return scripts.reprocessJob(this, { state: 'failed' }).then(function(result) {
     if (result === 1) {
       queue.emit('waiting', _this);
     } else if (result === 0) {

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -447,17 +447,20 @@ var scripts = {
   },
 
   /**
-   * Attempts to retry a job
+   * Attempts to reprocess a job
    *
    * @param {Job} job
+   * @param {Object} options
+   * @param {String} options.state The expected job state. If the job is not found
+   * on the provided state, then it's not reprocessed. Supported states: 'failed', 'completed'
    *
    * @return {Promise<Number>} Returns a promise that evaluates to a return code:
    * 1 means the operation was a success
    * 0 means the job does not exist
    * -1 means the job is currently locked and can't be retried.
-   * -2 means the job was not found in the `failed` set
+   * -2 means the job was not found in the expected set
    */
-  retryJob: function(job) {
+  reprocessJob: function(job, options) {
     var push = (job.opts.lifo ? 'R' : 'L') + 'PUSH';
 
     var script = [
@@ -483,7 +486,7 @@ var scripts = {
     var keys = [
       queue.toKey(job.jobId),
       queue.toKey(job.jobId) + ':lock',
-      queue.toKey('failed'),
+      queue.toKey(options.state),
       queue.toKey('wait'),
       queue.toKey('jobs')
     ];

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -444,6 +444,64 @@ var scripts = {
     ];
 
     return execScript.apply(scripts, args);
+  },
+
+  /**
+   * Attempts to retry a job
+   *
+   * @param {Job} job
+   *
+   * @return {Promise<Number>} Returns a promise that evaluates to a return code:
+   * 1 means the operation was a success
+   * 0 means the job does not exist
+   * -1 means the job is currently locked and can't be retried.
+   * -2 means the job was not found in the `failed` set
+   */
+  retryJob: function(job) {
+    var push = (job.opts.lifo ? 'R' : 'L') + 'PUSH';
+
+    var script = [
+      'if (redis.call("EXISTS", KEYS[1]) == 1) then',
+      '  if (redis.call("EXISTS", KEYS[2]) == 0) then',
+      '    if (redis.call("SREM", KEYS[3], ARGV[1]) == 1) then',
+      '      redis.call("' + push + '", KEYS[4], ARGV[1])',
+      '      redis.call("PUBLISH", KEYS[5], ARGV[1])',
+      '      return 1',
+      '    else',
+      '      return -2',
+      '    end',
+      '  else',
+      '    return -1',
+      '  end',
+      'else',
+      '  return 0',
+      'end'
+    ].join('\n');
+
+    var queue = job.queue;
+
+    var keys = [
+      queue.toKey(job.jobId),
+      queue.toKey(job.jobId) + ':lock',
+      queue.toKey('failed'),
+      queue.toKey('wait'),
+      queue.toKey('jobs')
+    ];
+
+    var args = [
+      queue.client,
+      'retryJob',
+      script,
+      5,
+      keys[0],
+      keys[1],
+      keys[2],
+      keys[3],
+      keys[4],
+      job.jobId
+    ];
+
+    return execScript.apply(scripts, args);
   }
 };
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1304,7 +1304,7 @@ describe('Queue', function () {
         queue.process(function (job, jobDone) {
           if(attempts === 0) {
             attempts++;
-            jobDone(new Error('failed'));
+            throw new Error('failed');
           } else {
             jobDone();
           }
@@ -1355,7 +1355,7 @@ describe('Queue', function () {
         queue.process(function (job, jobDone) {
           if(attempts === 0) {
             attempts++;
-            jobDone(new Error('failed'));
+            throw new Error('failed');
           } else {
             jobDone();
           }


### PR DESCRIPTION
This PR makes some improvements on the current `Job#retry` implementation:

* The retry operation is now implemented through a script, to follow suit with the other operations
* The retry operation does several checks while attempting to retry a job:
  * It checks if the job exists, so that a non-existent job can be accidentally retried
  * It checks if the job is currently locked, to avoid possible corruption on job data
  * It checks if the job is actually failed, so it avoids retrying job that are in any other state that is not failed.