### PR TITLE
Pass a connection string instead of separate parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ listened by some other service that stores the results in a database.
 
 <a name="queue"/>
 ###Queue(queueName, redisPort, redisHost, [redisOpts])
+###Queue(queueName, redisConnectionString, [redisOpts])
 
 This is the Queue constructor. It creates a new Queue that is persisted in
 Redis. Everytime the same queue is instantiated it tries to process all the
@@ -329,6 +330,16 @@ __Arguments__
     queueName {String} A unique name for this Queue.
     redisPort {Number} A port where redis server is running.
     redisHost {String} A host specified as IP or domain where redis is running.
+    redisOptions {Object} Options to pass to the redis client. https://github.com/mranney/node_redis
+```
+
+Alternatively, it's possible to pass a connection string to create a new queue.
+
+__Arguments__
+
+```javascript
+    queueName {String} A unique name for this Queue.
+    redisConnectionString {String} A connection string containing the redis server host, port and (optional) authentication.
     redisOptions {Object} Options to pass to the redis client. https://github.com/mranney/node_redis
 ```
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -4,6 +4,8 @@
 var redis = require('redis');
 var events = require('events');
 var util = require('util');
+var assert = require('assert');
+var url = require('url');
 var Job = require('./job');
 var scripts = require('./scripts');
 var TimerManager = require('./timer-manager');
@@ -59,6 +61,19 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisHost = redisOpts.host;
     redisOptions = redisOpts.opts || {};
     redisOptions.db = redisOpts.DB;
+  }
+
+  if (_.isString(redisPort)) {
+    try {
+      var redisUrl = url.parse(redisPort);
+      assert(_.isObject(redisHost) || _.isUndefined(redisHost));
+      redisOptions =  redisHost || {};
+      redisPort = redisUrl.port;
+      redisHost = redisUrl.hostname;
+      redisOptions.password = redisUrl.auth? redisUrl.auth.split(':')[1]: void 0;
+    } catch (e) {
+      throw new Error('Malformed connection string');
+    }
   }
 
   redisOptions = redisOptions || {};

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -61,9 +61,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisHost = redisOpts.host;
     redisOptions = redisOpts.opts || {};
     redisOptions.db = redisOpts.DB;
-  }
-
-  if (!_.isObject(redisPort) && _.isString(redisPort)) {
+  } else if(_.isString(redisPort)) {
     try {
       var redisUrl = url.parse(redisPort);
       assert(_.isObject(redisHost) || _.isUndefined(redisHost),

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -63,16 +63,19 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisOptions.db = redisOpts.DB;
   }
 
-  if (_.isString(redisPort)) {
+  if (!_.isObject(redisPort) && _.isString(redisPort)) {
     try {
       var redisUrl = url.parse(redisPort);
-      assert(_.isObject(redisHost) || _.isUndefined(redisHost));
+      assert(_.isObject(redisHost) || _.isUndefined(redisHost),
+          'Expected an object as redis option');
       redisOptions =  redisHost || {};
       redisPort = redisUrl.port;
       redisHost = redisUrl.hostname;
-      redisOptions.password = redisUrl.auth? redisUrl.auth.split(':')[1]: void 0;
+      if (redisUrl.auth) {
+        redisOptions.password = redisUrl.auth.split(':')[1];
+      }
     } catch (e) {
-      throw new Error('Malformed connection string');
+      throw new Error(e.message);
     }
   }
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -151,6 +151,24 @@ describe('Queue', function () {
       });
     });
 
+    it('should create a queue with a redis connection string', function (done) {
+      var queue = new Queue('connstring', 'redis://127.0.0.1:6379');
+
+      queue.once('ready', function () {
+        expect(queue.client.connection_options.host).to.be('127.0.0.1');
+        expect(queue.bclient.connection_options.host).to.be('127.0.0.1');
+
+        expect(queue.client.connection_options.port).to.be(6379);
+        expect(queue.bclient.connection_options.port).to.be(6379);
+
+        expect(queue.client.selected_db).to.be(0);
+        expect(queue.bclient.selected_db).to.be(0);
+
+        queue.close().then(done);
+
+      });
+    });
+
     it('creates a queue using the supplied redis DB', function (done) {
       var queue = new Queue('custom', { redis: { DB: 1 } });
 


### PR DESCRIPTION
Fixes #306 

It's very convenient to pass the environment variable for the Redis connection than parsing the URL everytime you want to create a connection. Saves some effort in parsing and passing authentication separately.

I haven't written any test for authentication since I'm unsure how to spawn a Redis server with authentication for running this test. Any help in that regard will be appreciated.