### PR TITLE
Dont publish tmpdir file in NPM package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+tmp
 
 *.rdb

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 node_modules
+tmp


### PR DESCRIPTION
Hello!

  I love the project - and have been working to cut back on the size of some of my more popularly used NPM modules! I've noticed bull has a `tmp` directory in the published version of bull version `1.0.0`. It contains:

```
ls -al node_modules/bull/tmp
-rw-r--r--   1 erulabs  users    13M 19 Jun 06:35 AMS.rar
-rw-r--r--   1 erulabs  users   3.2K 20 Jun 06:09 test.js
```

I'm not sure what AMS.rar is (seems to contain an AMS_clean.hdf file which encoded in a way I'm not familiar with).

Anyways, I scouted the codebase a bit and I get the feeling this was just a publishing mistake!

After removing `tmp/`, the bull module works fine and weighs just 256K :)

Thanks!!!