### PR TITLE
Fixes PriorityQueue Events and Local Worker Pause/Resume

### DIFF
--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -28,7 +28,7 @@ var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisO
 
   var groupEvents = ['ready', 'paused', 'resumed']
   groupEvents.forEach(function(event) {
-    Promise.map(this.queues, function(queue) {
+    Promise.map(_this.queues, function(queue) {
       return new Promise(function(resolve, reject) {
         queue.once(event, resolve);
       });

--- a/lib/priority-queue.js
+++ b/lib/priority-queue.js
@@ -26,28 +26,21 @@ var PriorityQueue = module.exports = function(name, redisPort, redisHost, redisO
     this.queues[PriorityQueue.priorities[key]] = queue;
   }
 
-  Promise.map(this.queues, function(queue) {
-    return new Promise(function(resolve, reject) {
-      queue.once('ready', resolve);
-    });
-  }).then(_this.emit.bind(_this, 'ready'))
-
-  this.queues.forEach(function(queue) {
-    queue.on('error', _this.emit.bind(_this, 'error'));
+  var groupEvents = ['ready', 'paused', 'resumed']
+  groupEvents.forEach(function(event) {
+    Promise.map(this.queues, function(queue) {
+      return new Promise(function(resolve, reject) {
+        queue.once(event, resolve);
+      });
+    }).then(_this.emit.bind(_this, event))    
   })
 
-  this.queues.forEach(function(queue) {
-    queue.on('progress', _this.emit.bind(_this, 'progress'));
+  var singleEvents = ['error', 'active', 'stalled', 'progress', 'completed', 'failed', 'cleaned']
+  singleEvents.forEach(function(event) {
+    _this.queues.forEach(function(queue) {
+      queue.on(event, _this.emit.bind(_this, event))
+    })
   })
-
-  this.queues.forEach(function(queue) {
-    queue.on('completed', _this.emit.bind(_this, 'completed'));
-  })
-
-  this.queues.forEach(function(queue) {
-    queue.on('failed', _this.emit.bind(_this, 'failed'));
-  })
-
 
   this.strategy = Strategy.exponential;
 }
@@ -164,21 +157,21 @@ PriorityQueue.prototype.empty = function() {
   });
 }
 
-PriorityQueue.prototype.pause = function() {
+PriorityQueue.prototype.pause = function(localOnly) {
   var _this = this;
-
+  
   _this.paused = Promise.map(this.queues, function(queue) {
-    return queue.pause();
+    return queue.pause(localOnly || false);
   }).then(_this.emit.bind(_this, 'paused'));
 
   return _this.paused;
 }
 
-PriorityQueue.prototype.resume = function() {
+PriorityQueue.prototype.resume = function(localOnly) {
   var _this = this;
   _this.paused = false;
   return Promise.map(this.queues, function(queue) {
-    return queue.resume();
+    return queue.resume(localOnly || false);
   }).then(_this.emit.bind(_this, 'resumed')).then(function() {
     if (_this.handler) {
       _this.run();


### PR DESCRIPTION
- Passes all events down, events like active, stalled, were not being passed down.
- Adds resume and pause events and promises it to ensure all queues return
- Allows for just the local worker to be paused and resumed for a PriorityQueue
