### PR TITLE
Rewrite the handling of process stalled jobs to be atomic so it doesn…

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -225,7 +225,6 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   // Bind these methods to avoid constant rebinding and/or creating closures
   // in processJobs etc.
   this.processStalledJobs = this.processStalledJobs.bind(this);
-  this.processStalledJob = this.processStalledJob.bind(this);
   this.getNextJob = this.getNextJob.bind(this);
   this.processJobs = this.processJobs.bind(this);
   this.processJob = this.processJob.bind(this);
@@ -528,41 +527,47 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
 };
 
 /**
-  Process jobs that have been added to the active list but are not being
-  processed properly.
+ * Process jobs that have been added to the active list but are not being
+ * processed properly. This can happen due to a process crash in the middle
+ * of processing a job, leaving it in 'active' but without a job lock.
+ * Note that there is no way to know for _certain_ if a job is "stalled"
+ * (since the process that moved it to active might just be slow to get the
+ * lock on it), so this function takes a grace period parameter to ignore
+ * jobs that were just created.
+ *
+ * @param {Number?} limit Only consider this number of jobs to process. Greater than 1, otherwise -1
+ * @param {Number?} grace Duration in milliseconds. Ignore jobs created since this many milliseconds ago.
+ *    Defaults to LOCK_RENEW_TIME.
 */
-Queue.prototype.processStalledJobs = function(){
+Queue.prototype.processStalledJobs = function(limit, grace){
   var _this = this;
+
+  if (_.isUndefined(limit)) limit = -1;
+  grace = grace || this.LOCK_RENEW_TIME;
+
+  if (limit === 0) return;
+
   if(this.closing){
     return this.closing;
   } else{
-    return this.client.lrangeAsync(this.toKey('active'), 0, -1).then(function(jobs){
-      return Promise.each(jobs, function(jobId) {
-        return Job.fromId(_this, jobId).then(_this.processStalledJob);
-      });
+    return scripts.getStalledJob(this, this.token, limit, grace).then(function(jobId){
+      if (!jobId) return;
+
+      return Job.fromId(_this, jobId)
+        .then(function(job){
+          _this.emit('stalled', job);
+          return _this.processJob(job, true /* Renew the lock */);
+        })
+        .then(function(){
+          // Run recursively.
+          return _this.processStalledJobs(--limit, grace);
+        });
     }).catch(function(err){
       console.error(err);
     });
   }
 };
 
-Queue.prototype.processStalledJob = function(job){
-  var _this = this;
-  if(this.closing){
-    return this.closing;
-  }
-
-  if(!job){
-    return Promise.resolve();
-  }else{
-    return scripts.getStalledJob(this, job, _this.token).then(function(isStalled){
-      if(isStalled){
-        _this.distEmit('stalled', job.toJSON());
-        return _this.processJob(job, true);
-      }
-    });
-  }
-};
 
 Queue.prototype.processJobs = function(resolve, reject){
   var _this = this;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -355,24 +355,30 @@ var scripts = {
   },
 
   /**
-   * Gets a stalled job by locking it and checking it is not already completed.
-   * Returns a "OK" if the job was locked and not in completed set.
+   * Returns the next (possible) stalled job in the queue.
    */
-  getStalledJob: function(queue, job, token){
+  getStalledJob: function(queue, token, grace){
     var script = [
-      'if redis.call("sismember", KEYS[1], ARGV[1]) == 0 then',
-      '  return redis.call("set", KEYS[2], ARGV[2], "PX", ARGV[3], "NX")',
+      'local activeJobs = redis.call("LRANGE", KEYS[1], 0, -1)',
+      'for _, job in ipairs(activeJobs) do',
+      '  local jobKey = ARGV[2] .. job',
+      '  local jobTS = redis.call("HGET", jobKey, "timestamp")',
+      '  if(jobTS and jobTS < ARGV[1]) then',
+      '    if(redis.call("SET", jobKey .. ":lock", ARGV[3], "PX", ARGV[4], "NX")) then',
+      '      return job',
+      '    end',
+      '  end',
       'end',
-      'return 0'].join('\n');
+    ].join('\n');
 
     var args = [
       queue.client,
       'getStalledJob',
       script,
-      2,
-      queue.toKey('completed'),
-      job.lockKey(),
-      job.jobId,
+      1,
+      queue.toKey('active'),
+      Date.now() - grace,
+      queue.toKey(''),
       token,
       queue.LOCK_RENEW_TIME
     ];


### PR DESCRIPTION
…'t double-process jobs. See https://github.com/OptimalBits/bull/issues/356 for more on how this can happen.

The change here is to use a LUA script to atomically iterate the active queue AND get the lock. This ensures that the job is actually in 'active' when it's being processed, which fixes #356. If a stalled job was found, it will continue to call itself recursively until all stalled jobs are processed. This strategy is also slightly more efficient than before because it iterates the jobs all within a script, reducing the back-and-forth with the Redis server.

Additionally, this addresses long-standing issue where a job can be considered "stalled" even though it was just moved to active and before a lock could be obtained by the worker that moved it (https://github.com/OptimalBits/bull/issues/258), by waiting a grace period (with a default of LOCK_RENEW_TIME) before considering a job as possibly stalled. This gives the (real) worker time to acquire its lock after moving it to active.