### PR TITLE
[fix] don't try to remove listeners if already removed

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -353,11 +353,13 @@ Job.prototype.finished = function(){
   return new Promise(function(resolve, reject){
     status(resolve, reject).then(function(finished){
       if(!finished){
+        var interval;
         function onCompleted(job){
           if(job.jobId === _this.jobId){
             resolve();
           }
           removeListeners();
+          clearInterval(interval);
         }
 
         function onFailed(job, err){
@@ -365,6 +367,7 @@ Job.prototype.finished = function(){
             reject(err);
           }
           removeListeners();
+          clearInterval(interval);
         }
 
         function removeListeners(){
@@ -378,7 +381,7 @@ Job.prototype.finished = function(){
         //
         // Watchdog
         //
-        var interval = setInterval(function(){
+        interval = setInterval(function(){
           status(resolve, reject).then(function(finished){
             if(finished){
               removeListeners();


### PR DESCRIPTION
Fixes unhandled rejection SISMEMBER errors as seen in build https://travis-ci.org/OptimalBits/bull/builds/174710354

#### Details
While working on #188 I noticed some errors in the test suite.  The `Job::finished` watchdog was running even when the listeners were already removed.  This PR clears the watchdog interval so that the watchdog is not run unnecessarily.