### PR TITLE
Fixes double-processing issue described in https://github.com/Optimal…

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -123,8 +123,8 @@ Job.prototype.lockKey = function(){
   Takes a lock for this job so that no other queue worker can process it at the
   same time.
 */
-Job.prototype.takeLock = function(token, renew){
-  return scripts.takeLock(this.queue, this, token, renew).then(function(res){
+Job.prototype.takeLock = function(token, renew, ensureActive){
+  return scripts.takeLock(this.queue, this, token, renew, ensureActive).then(function(res){
     return res === 1; // Indicates successful lock.
   });
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -619,6 +619,8 @@ Queue.prototype.processJob = function(job, renew){
         renew = true;
         lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
       }
+      // TODO: if we failed to re-acquire the lock while trying to renew, should we let the job
+      // handler know and cancel the timer?
       return locked;
     }, function(err){
       console.error('Error renewing lock ' + err);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -614,7 +614,10 @@ Queue.prototype.processJob = function(job, renew){
   // by another worker. See #308
   //
   var lockRenewer = function(){
-    return job.takeLock(_this.token, renew, true /* Ensure in active */).then(function(locked){
+    // The first call to lock the job should ensure that the job is in the 'active' state,
+    // because it might have gotten picked up already by another processor. We don't need
+    // to do this on subsequent calls.
+    return job.takeLock(_this.token, renew, !renew).then(function(locked){
       if(locked){
         renew = true;
         lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -614,7 +614,7 @@ Queue.prototype.processJob = function(job, renew){
   // by another worker. See #308
   //
   var lockRenewer = function(){
-    return job.takeLock(_this.token, renew).then(function(locked){
+    return job.takeLock(_this.token, renew, true /* Ensure in active */).then(function(locked){
       if(locked){
         renew = true;
         lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -596,7 +596,7 @@ Queue.prototype.processJobs = function(resolve, reject){
   }
 };
 
-Queue.prototype.processJob = function(job, renew){
+Queue.prototype.processJob = function(job){
   var _this = this;
   var lockRenewId;
 
@@ -613,6 +613,7 @@ Queue.prototype.processJob = function(job, renew){
   // jobs, so we can assume the job has been stalled and is already being processed
   // by another worker. See #308
   //
+  var renew = false;
   var lockRenewer = function(){
     // The first call to lock the job should ensure that the job is in the 'active' state,
     // because it might have gotten picked up already by another processor. We don't need

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -301,9 +301,36 @@ var scripts = {
   },
 
   /**
-   * Takes a lock
+   * Gets a lock for a job.
+   *
+   * @param {Queue} queue The queue for the job
+   * @param {Job} job The job
+   * @param {Boolean=false} renew Whether to renew to lock, meaning it will assume the job 
+   *    is already locked and just reset the lock expiration.
+   * @param {Boolean=false} ensureActive Ensures that the job is in the 'active' state.
    */
-  takeLock: function(queue, job, token, renew){
+  takeLock: function(queue, job, token, renew, ensureActive){
+    var ensureActiveCall = '';
+    if (ensureActive) {
+      ensureActiveCall = [
+        // Note that while this is inefficient to run a O(n) traversal of the 'active' queue,
+        // it's highly likely that the job is within the first few elements of the active
+        // list. The only time this isn't the case is if two workers learned of a job in the
+        // 'active' queue at the same time.
+        'local activeJobs = redis.call("LRANGE", KEYS[3], 0, -1)',
+        'local found = false',
+        'for _, job in ipairs(activeJobs) do',
+        '  if(job == ARGV[3]) then',
+        '     found = true',
+        '     break',
+        '  end',
+        'end',
+        'if (found == false) then',
+        '  return -1',
+        'end'
+      ].join('\n');
+    }
+
     var lockCall;
     if (renew){
       lockCall = 'redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])';
@@ -312,6 +339,7 @@ var scripts = {
     }
 
     var script = [
+      ensureActiveCall,
       'if(' + lockCall + ') then',
       // Mark the job as having been locked at least once. Used to determine if the job was stalled.
       ' redis.call("HSET", KEYS[2], "lockAcquired", "1")',
@@ -323,13 +351,15 @@ var scripts = {
 
     var args = [
       queue.client,
-      'takeLock' + (renew ? 'Renew' : ''),
+      'takeLock' + (renew ? 'Renew' : '') + (ensureActive ? 'EnsureActive' : ''),
       script,
-      2,
+      3,
       job.lockKey(),
       queue.toKey(job.jobId),
+      queue.toKey('active'),
       token,
-      queue.LOCK_RENEW_TIME
+      queue.LOCK_RENEW_TIME,
+      job.jobId
     ];
 
     return execScript.apply(scripts, args);

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -310,26 +310,31 @@ var scripts = {
    * @param {Boolean=false} ensureActive Ensures that the job is in the 'active' state.
    */
   takeLock: function(queue, job, token, renew, ensureActive){
-    var ensureActiveCall = '';
-    if (ensureActive) {
-      ensureActiveCall = [
-        // Note that while this is inefficient to run a O(n) traversal of the 'active' queue,
-        // it's highly likely that the job is within the first few elements of the active
-        // list. The only time this isn't the case is if two workers learned of a job in the
-        // 'active' queue at the same time.
-        'local activeJobs = redis.call("LRANGE", KEYS[3], 0, -1)',
-        'local found = false',
-        'for _, job in ipairs(activeJobs) do',
-        '  if(job == ARGV[3]) then',
-        '     found = true',
-        '     break',
-        '  end',
-        'end',
-        'if (found == false) then',
-        '  return -1',
-        'end'
-      ].join('\n');
-    }
+    // Ensures that the lock doesn't exist, or if it does, that we own it.
+    var ensureOwnershipCall = [
+      'local prevLock = redis.call("GET", KEYS[1])',
+      'if (prevLock and prevLock ~= ARGV[1]) then',
+      '  return 0',
+      'end'
+    ].join('\n');
+
+    // Ensures that the lock in the 'active' state.
+    var ensureActiveCall = [
+      // Note that while this is inefficient to run a O(n) traversal of the 'active' queue,
+      // it's highly likely that the job is within the first few elements of the active
+      // list at the time this call is used.
+      'local activeJobs = redis.call("LRANGE", KEYS[3], 0, -1)',
+      'local found = false',
+      'for _, job in ipairs(activeJobs) do',
+      '  if(job == ARGV[3]) then',
+      '     found = true',
+      '     break',
+      '  end',
+      'end',
+      'if (found == false) then',
+      '  return 0',
+      'end'
+    ].join('\n');
 
     var lockCall;
     if (renew){
@@ -339,7 +344,8 @@ var scripts = {
     }
 
     var script = [
-      ensureActiveCall,
+      (renew ? ensureOwnershipCall : ''),
+      (ensureActive ? ensureActiveCall : ''),
       'if(' + lockCall + ') then',
       // Mark the job as having been locked at least once. Used to determine if the job was stalled.
       ' redis.call("HSET", KEYS[2], "lockAcquired", "1")',

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -73,10 +73,11 @@ describe('Cluster', function () {
   it('should process each job once', function(done) {
     var jobs = [];
     queue = buildQueue();
+    var numJobs = 100;
 
     workerMessageHandler = function(job) {
       jobs.push(job.id);
-      if(jobs.length === 11) {
+      if(jobs.length === numJobs) {
         var counts = {};
         var j = 0;
         for(j; j < jobs.length; j++) {
@@ -88,7 +89,7 @@ describe('Cluster', function () {
     };
 
     var i = 0;
-    for(i; i < 11; i++) {
+    for(i; i < numJobs; i++) {
       queue.add({});
     }
   });


### PR DESCRIPTION
…Bits/bull/issues/371#issuecomment-260158407.

Double-processing happens when two workers find out about the same job at the same time via `getNextJob`. One worker is taking the lock, processing the job, and moving it to completed before the second worker can even try to get the lock. When the second worker finally gets around to trying to get the lock, the job is already in the completed state. But it processes it anyways since it got the lock.

So the fix here is for the takeLock script to ensure the job is in the active queue prior to taking the lock. That will make sure jobs that are in wait, completed, or even removed from the queue altogether don't get double processed. Per the discussion in #370 though, takeLock is parameterized to only require the job be in active when taking the lock while processing the job. There are other cases such as job.remove() that the job might be in a different state, but we still want to be able to lock it.

This fixes existing existing broken unit test "should process each job once".

This also prevents hazard https://github.com/OptimalBits/bull/issues/370.