### PR TITLE
ioredis; atomic locking with redlock; support Node 6.x [Fixes #185, Fixes #370]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 # test on node.js versions
 node_js:
+  - '6'
   - '4'
 
 services:

--- a/lib/job.js
+++ b/lib/job.js
@@ -405,22 +405,7 @@ Job.prototype._isDone = function(list){
 };
 
 Job.prototype._isInList = function(list) {
-  var script = [
-    'local function item_in_list (list, item)',
-    '  for _, v in pairs(list) do',
-    '    if v == item then',
-    '      return 1',
-    '    end',
-    '  end',
-    '  return nil',
-    'end',
-    'local items = redis.call("LRANGE", KEYS[1], 0, -1)',
-    'return item_in_list(items, ARGV[1])'
-  ].join('\n');
-
-  return this.queue.client.eval(script, 1, this.queue.toKey(list), this.jobId).then(function(result){
-    return result === 1;
-  });
+  return scripts.isJobInList(this.queue.client, this.queue.toKey(list), this.jobId);
 };
 
 Job.prototype._moveToSet = function(set, context){

--- a/lib/job.js
+++ b/lib/job.js
@@ -5,7 +5,6 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 var scripts = require('./scripts');
 var debuglog = require('debuglog')('bull');
-var uuid = require('node-uuid');
 
 /**
 interface JobOptions
@@ -123,24 +122,29 @@ Job.prototype.lockKey = function(){
   Takes a lock for this job so that no other queue worker can process it at the
   same time.
 */
-Job.prototype.takeLock = function(token, renew, ensureActive){
-  return scripts.takeLock(this.queue, this, token, renew, ensureActive).then(function(res){
-    return res === 1; // Indicates successful lock.
+Job.prototype.takeLock = function(renew, ensureActive){
+  var _this = this;
+  return scripts.takeLock(this.queue, this, renew, ensureActive)
+  .then(function(lock) {
+    if (lock) _this.lock = lock;
+    return lock || false;
   });
 };
 
 /**
   Renews a lock so that it gets some more time before expiring.
 */
-Job.prototype.renewLock = function(token){
-  return this.takeLock(token, true /* Renew */);
+Job.prototype.renewLock = function(){
+  return this.takeLock(true /* Renew */);
 };
 
 /**
   Releases the lock. Only locks owned by the queue instance can be released.
 */
-Job.prototype.releaseLock = function(token){
-  return scripts.releaseLock(this, token);
+Job.prototype.releaseLock = function(){
+  var _this = this;
+  return scripts.releaseLock(this)
+  .then(function() { _this.lock = null; });
 };
 
 Job.prototype.delayIfNeeded = function(){
@@ -155,19 +159,19 @@ Job.prototype.delayIfNeeded = function(){
   return Promise.resolve(false);
 };
 
-Job.prototype.moveToCompleted = function(returnValue, token){
+Job.prototype.moveToCompleted = function(returnValue){
   this.returnvalue = returnValue || 0;
-  return scripts.moveToCompleted(this, token || 0, this.opts.removeOnComplete);
+  return scripts.moveToCompleted(this || 0, this.opts.removeOnComplete);
 };
 
-Job.prototype.move = function(src, target, token, returnValue){
+Job.prototype.move = function(src, target, returnValue){
   if(target === 'completed'){
     this.returnvalue = returnValue || 0;
     if(this.opts.removeOnComplete){
       target = void 0;
     }
   }
-  return scripts.move(this, token || 0, src, target);
+  return scripts.move(this || 0, src, target);
 }
 
 Job.prototype.moveToFailed = function(err){
@@ -305,13 +309,11 @@ Job.prototype.getState = function() {
 /**
   Removes a job from the queue and from all the lists where it may be stored.
 */
-Job.prototype.remove = function(token){
+Job.prototype.remove = function(){
   var queue = this.queue;
   var job = this;
 
-  var token = token || uuid();
-
-  return job.takeLock(token).then(function(lock) {
+  return job.takeLock().then(function(lock) {
     if (!lock) {
       throw new Error('Could not get lock for job: ' + job.jobId + '. Cannot remove job.');
     }
@@ -320,7 +322,7 @@ Job.prototype.remove = function(token){
         queue.emit('removed', job.toJSON());
       })
       .finally(function () {
-        return job.releaseLock(token);
+        return job.releaseLock();
       });
   });
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -59,11 +59,11 @@ Job.fromId = function(queue, jobId){
   if(!jobId) {
     return Promise.resolve();
   }
-  return queue.client.hgetallAsync(queue.toKey(jobId)).then(function(jobData){
-    if(jobData){
+  return queue.client.hgetall(queue.toKey(jobId)).then(function(jobData){
+    if(!_.isEmpty(jobData)){
       return Job.fromData(queue, jobId, jobData);
     }else{
-      return jobData;
+      return null;
     }
   });
 };
@@ -85,7 +85,7 @@ Job.prototype.toData = function(){
 Job.prototype.progress = function(progress){
   if(progress){
     var _this = this;
-    return this.queue.client.hsetAsync(this.queue.toKey(this.jobId), 'progress', progress).then(function(){
+    return this.queue.client.hset(this.queue.toKey(this.jobId), 'progress', progress).then(function(){
       _this.queue.distEmit('progress', _this.toJSON(), progress);
     });
   }else{
@@ -211,7 +211,7 @@ Job.prototype.promote = function(){
     return queue.toKey(name);
   });
 
-  return queue.client.evalAsync(
+  return queue.client.eval(
     script,
     keys.length,
     keys[0],
@@ -256,7 +256,7 @@ Job.prototype.isFailed = function(){
 
 Job.prototype.isDelayed = function() {
   return this.queue.client
-    .zrankAsync(this.queue.toKey('delayed'), this.jobId).then(function(rank) {
+    .zrank(this.queue.toKey('delayed'), this.jobId).then(function(rank) {
       return rank !== null;
     });
 };
@@ -399,7 +399,7 @@ Job.prototype.finished = function(){
 // -----------------------------------------------------------------------------
 Job.prototype._isDone = function(list){
   return this.queue.client
-    .sismemberAsync(this.queue.toKey(list), this.jobId).then(function(isMember){
+    .sismember(this.queue.toKey(list), this.jobId).then(function(isMember){
       return isMember === 1;
     });
 };
@@ -418,7 +418,7 @@ Job.prototype._isInList = function(list) {
     'return item_in_list(items, ARGV[1])'
   ].join('\n');
 
-  return this.queue.client.evalAsync(script, 1, this.queue.toKey(list), this.jobId).then(function(result){
+  return this.queue.client.eval(script, 1, this.queue.toKey(list), this.jobId).then(function(result){
     return result === 1;
   });
 };
@@ -466,7 +466,7 @@ Job.prototype._retryAtOnce = function(){
 
   var pushCmd = (this.opts.lifo ? 'R' : 'L') + 'PUSH';
 
-  return queue.client.evalAsync(
+  return queue.client.eval(
     script,
     keys.length,
     keys[0],
@@ -495,7 +495,7 @@ Job.prototype._saveAttempt = function(err){
 
   params.failedReason = err.message;
 
-  return this.queue.client.hmsetAsync(this.queue.toKey(this.jobId), params);
+  return this.queue.client.hmset(this.queue.toKey(this.jobId), params);
 };
 
 /**

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,7 +1,7 @@
 /*eslint-env node */
 'use strict';
 
-var redis = require('redis');
+var redis = require('ioredis');
 var Disturbed = require('disturbed');
 var util = require('util');
 var assert = require('assert');
@@ -15,8 +15,6 @@ var uuid = require('node-uuid');
 var semver = require('semver');
 var debuglog = require('debuglog')('bull');
 
-Promise.promisifyAll(redis.RedisClient.prototype);
-Promise.promisifyAll(redis.Multi.prototype);
 
 /**
   Gets or creates a new Queue with the given name.
@@ -71,7 +69,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     redisPort = redisOpts.port;
     redisHost = redisOpts.host;
     redisOptions = redisOpts.opts || {};
-    redisOptions.db = redisOpts.DB;
+    redisOptions.db = redisOpts.db || redisOpts.DB;
   } else if(_.isString(redisPort)) {
     try {
       var redisUrl = url.parse(redisPort);
@@ -386,8 +384,8 @@ Queue.prototype.count = function(){
   multi.llen(this.toKey('paused'));
   multi.zcard(this.toKey('delayed'));
 
-  return multi.execAsync().then(function(res){
-    return Math.max(res[0], res[1]) + res[2];
+  return multi.exec().then(function(res){
+    return Math.max(res[0][1], res[1][1]) + res[2][1];
   });
 };
 
@@ -415,7 +413,9 @@ Queue.prototype.empty = function(){
   multi.del(this.toKey('meta-paused'));
   multi.del(this.toKey('delayed'));
 
-  return multi.execAsync().spread(function(waiting, paused){
+  return multi.exec().spread(function(waiting, paused){
+    waiting = waiting[1];
+    paused = paused[1];
     var jobKeys = (paused.concat(waiting)).map(_this.toKey, _this);
 
     if(jobKeys.length){
@@ -696,9 +696,7 @@ Queue.prototype.getNextJob = function(opts){
 };
 
 Queue.prototype.multi = function(){
-  var multi = this.client.multi();
-  multi.execAsync = Promise.promisify(multi.exec);
-  return multi;
+  return this.client.multi();
 };
 
 /**
@@ -765,8 +763,8 @@ Queue.prototype.getJobCountByTypes = function() {
     }
   });
 
-  return multi.execAsync().then(function(res){
-    return _.reduce(res, function(total, n) {
+  return multi.exec().then(function(res){
+    return _.reduce(res[0], function(total, n) {
       return total + n;
     }) || 0;
   });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -256,7 +256,9 @@ Queue.prototype.distEmit = function(){
 
 Queue.prototype.on = function(){
   var args = Array.prototype.slice.call(arguments);
-  Disturbed.prototype.on.apply(this, args);
+  var promise = Disturbed.prototype.on.apply(this, args);
+  var _this = this;
+  promise.catch(function(err){ _this.emit('error', err); });
   return this;
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -524,11 +524,7 @@ Queue.prototype.run = function(concurrency){
       promises.push(new Promise(_this.processJobs));
     }
 
-    if (_this.STALLED_JOB_CHECK_INTERVAL > 0){
-      clearInterval(_this.moveUnlockedJobsToWaitInterval);
-      _this.moveUnlockedJobsToWaitInterval =
-        setInterval(_this.moveUnlockedJobsToWait, _this.STALLED_JOB_CHECK_INTERVAL);
-    }
+    _this.startMoveUnlockedJobsToWait();
 
     return Promise.all(promises);
   });
@@ -576,26 +572,30 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
 Queue.prototype.moveUnlockedJobsToWait = function(){
   var _this = this;
 
-  if(this.closing){
-    return this.closing;
-  } else{
-    return scripts.moveUnlockedJobsToWait(this).then(function(responses){
-      var handleFailedJobs = responses[0].map(function(jobId){
-        return _this.getJobFromId(jobId).then(function(job){
-          _this.distEmit('failed', job.toJSON(), new Error('job stalled more than allowable limit'));
-          return null;
-        });
+  return scripts.moveUnlockedJobsToWait(this).then(function(responses){
+    var handleFailedJobs = responses[0].map(function(jobId){
+      return _this.getJobFromId(jobId).then(function(job){
+        _this.distEmit('failed', job.toJSON(), new Error('job stalled more than allowable limit'));
+        return null;
       });
-      var handleStalledJobs = responses[1].map(function(jobId){
-        return _this.getJobFromId(jobId).then(function(job){
-          _this.distEmit('stalled', job.toJSON());
-          return null;
-        });
-      });
-      return Promise.all(handleFailedJobs.concat(handleStalledJobs));
-    }).catch(function(err){
-      console.error('Failed to handle unlocked job in active:', err);
     });
+    var handleStalledJobs = responses[1].map(function(jobId){
+      return _this.getJobFromId(jobId).then(function(job){
+        _this.distEmit('stalled', job.toJSON());
+        return null;
+      });
+    });
+    return Promise.all(handleFailedJobs.concat(handleStalledJobs));
+  }).catch(function(err){
+    console.error('Failed to handle unlocked job in active:', err);
+  });
+};
+
+Queue.prototype.startMoveUnlockedJobsToWait = function() {
+  if (this.STALLED_JOB_CHECK_INTERVAL > 0){
+    clearInterval(this.moveUnlockedJobsToWaitInterval);
+    this.moveUnlockedJobsToWaitInterval =
+      setInterval(this.moveUnlockedJobsToWait, this.STALLED_JOB_CHECK_INTERVAL);
   }
 };
 
@@ -707,7 +707,11 @@ Queue.prototype.processJob = function(job){
   Returns a promise that resolves to the next job in queue.
 */
 Queue.prototype.getNextJob = function(opts){
-  return this.moveJob('wait', 'active', opts).then(this.getJobFromId);
+  if(!this.closing){
+    return this.moveJob('wait', 'active', opts).then(this.getJobFromId);
+  }else{
+    return Promise.reject();
+  }
 };
 
 Queue.prototype.multi = function(){
@@ -927,13 +931,18 @@ Queue.prototype.whenCurrentJobsFinished = function(){
         resolve();
       }else{
         resolver = _.after(count, function(){
+          _this.removeListener('stalled', resolver);
           _this.removeListener('completed', resolver);
           _this.removeListener('failed', resolver);
+          clearInterval(_this.moveUnlockedJobsToWaitInterval);
           resolve();
         });
 
+        _this.on('stalled', resolver);
         _this.on('completed', resolver);
         _this.on('failed', resolver);
+
+        _this.startMoveUnlockedJobsToWait();
       }
     }, reject);
   });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -87,7 +87,6 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   }
 
   redisOptions = redisOptions || {};
-  var redisDB = redisOptions.db || 0;
 
   function createClient() {
     var client;
@@ -149,14 +148,17 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   this.timers = new TimerManager();
 
   // emit ready when redis connections ready
-  this._initializing = Promise.join(
-    this.client.selectAsync(redisDB),
-    this.bclient.selectAsync(redisDB),
-    this.eclient.selectAsync(redisDB)
-  ).then(function(){
+  var initializers = [this.client, this.bclient, this.eclient].map(function (client) {
+    return new Promise(function(resolve) {
+      client.once('ready', resolve);
+    });
+  });
+
+  this._initializing = Promise.all(initializers)
+  .then(function(){
     return Promise.join(
-      _this.eclient.subscribeAsync(_this.toKey('delayed')),
-      _this.eclient.subscribeAsync(_this.toKey('paused'))
+      _this.eclient.subscribe(_this.toKey('delayed')),
+      _this.eclient.subscribe(_this.toKey('paused'))
     );
   }).then(function(){
     debuglog(name + ' queue ready');
@@ -282,8 +284,8 @@ Queue.prototype.disconnect = function(){
   }
 
   return Promise.join(
-    _this.client.quitAsync(),
-    _this.eclient.quitAsync()
+    _this.client.quit(),
+    _this.eclient.quit()
   ).then(endClients, endClients);
 };
 
@@ -422,7 +424,7 @@ Queue.prototype.empty = function(){
       multi = _this.multi();
 
       multi.del.apply(multi, jobKeys);
-      return multi.execAsync();
+      return multi.exec();
     }
   });
 };
@@ -491,7 +493,7 @@ function pauseResumeGlobal(queue, pause){
     return queue.toKey(name);
   });
 
-  return queue.client.evalAsync(script, keys.length, keys[0], keys[1], keys[2], keys[3], pause ? 'paused' : 'resumed');
+  return queue.client.eval(script, keys.length, keys[0], keys[1], keys[2], keys[3], pause ? 'paused' : 'resumed');
 }
 
 Queue.prototype.run = function(concurrency){
@@ -708,12 +710,12 @@ Queue.prototype.moveJob = function(src, dst, opts) {
   var _this = this;
   if(opts && opts.block === false){
     if(!this.closing){
-      return this.bclient.rpoplpushAsync(this.toKey(src), this.toKey(dst));
+      return this.bclient.rpoplpush(this.toKey(src), this.toKey(dst));
     }else{
       return Promise.reject();
     }
   }else{
-    return this.bclient.brpoplpushAsync(
+    return this.bclient.brpoplpush(
       this.toKey(src),
       this.toKey(dst),
       Math.floor(this.LOCK_RENEW_TIME / 1000)).then(function(jobId) {
@@ -771,27 +773,27 @@ Queue.prototype.getJobCountByTypes = function() {
 };
 
 Queue.prototype.getCompletedCount = function() {
-  return this.client.scardAsync(this.toKey('completed'));
+  return this.client.scard(this.toKey('completed'));
 };
 
 Queue.prototype.getFailedCount = function() {
-  return this.client.scardAsync(this.toKey('failed'));
+  return this.client.scard(this.toKey('failed'));
 };
 
 Queue.prototype.getDelayedCount = function() {
-  return this.client.zcardAsync(this.toKey('delayed'));
+  return this.client.zcard(this.toKey('delayed'));
 };
 
 Queue.prototype.getActiveCount = function() {
-  return this.client.llenAsync(this.toKey('active'));
+  return this.client.llen(this.toKey('active'));
 };
 
 Queue.prototype.getWaitingCount = function() {
-  return this.client.llenAsync(this.toKey('wait'));
+  return this.client.llen(this.toKey('wait'));
 };
 
 Queue.prototype.getPausedCount = function() {
-  return this.client.llenAsync(this.toKey('paused'));
+  return this.client.llen(this.toKey('paused'));
 };
 
 Queue.prototype.getWaiting = function(/*start, end*/){
@@ -824,10 +826,10 @@ Queue.prototype.getJobs = function(queueType, type, start, end){
 
   switch(type){
     case 'LIST':
-      jobs = this.client.lrangeAsync(key, start, end);
+      jobs = this.client.lrange(key, start, end);
       break;
     case 'SET':
-      jobs = this.client.smembersAsync(key).then(function(jobIds) {
+      jobs = this.client.smembers(key).then(function(jobIds) {
         // Can't set a range for smembers. So do the slice programatically instead.
         // Note that redis ranges are inclusive, so handling for javascript accordingly
         if (end === -1) {
@@ -838,7 +840,7 @@ Queue.prototype.getJobs = function(queueType, type, start, end){
       });
       break;
     case 'ZSET':
-      jobs = this.client.zrangeAsync(key, start, end);
+      jobs = this.client.zrange(key, start, end);
       break;
   }
 
@@ -928,7 +930,7 @@ Queue.prototype.whenCurrentJobsFinished = function(){
 // Private local functions
 //
 var getRedisVersion = function getRedisVersion(client){
-  return client.infoAsync().then(function(doc){
+  return client.info().then(function(doc){
     var prefix = 'redis_version:';
     var lines = doc.split('\r\n');
     for(var i = 0; i < lines.length; i++){

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -11,7 +11,6 @@ var scripts = require('./scripts');
 var TimerManager = require('./timer-manager');
 var _ = require('lodash');
 var Promise = require('bluebird');
-var uuid = require('node-uuid');
 var semver = require('semver');
 var debuglog = require('debuglog')('bull');
 
@@ -55,6 +54,10 @@ var MAX_STALLED_JOB_COUNT = 1;
 
 var CLIENT_CLOSE_TIMEOUT_MS = 5000;
 var POLLING_INTERVAL = 5000;
+
+var REDLOCK_DRIFT_FACTOR = 0.01;
+var REDLOCK_RETRY_COUNT = 0;
+var REDLOCK_RETRY_DELAY = 200;
 
 var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   if(!(this instanceof Queue)){
@@ -120,6 +123,20 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   });
 
   //
+  // Keep track of cluster clients for redlock
+  //
+  this.clients = [this.client];
+  if (redisOptions.clients) {
+    this.clients.push.apply(this.clients, redisOptions.clients);
+  }
+  this.redlock = {
+    driftFactor: REDLOCK_DRIFT_FACTOR,
+    retryCount: REDLOCK_RETRY_COUNT,
+    retryDelay: REDLOCK_RETRY_DELAY
+  };
+  _.extend(this.redlock, redisOptions.redlock || {});
+
+  //
   // Create blocking client (used to wait for jobs)
   //
   this.bclient = createClient();
@@ -132,7 +149,6 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   this.delayTimer = null;
   this.processing = 0;
 
-  this.token = uuid();
   this.LOCK_RENEW_TIME = LOCK_RENEW_TIME;
   this.STALLED_JOB_CHECK_INTERVAL = STALLED_JOB_CHECK_INTERVAL;
   this.MAX_STALLED_JOB_COUNT = MAX_STALLED_JOB_COUNT;
@@ -621,17 +637,14 @@ Queue.prototype.processJob = function(job){
   //
   var renew = false;
   var lockRenewer = function(){
-    // The first call to lock the job should ensure that the job is in the 'active' state,
-    // because it might have gotten picked up already by another processor. We don't need
-    // to do this on subsequent calls.
-    return job.takeLock(_this.token, renew, !renew).then(function(locked){
-      if(locked){
+    return job.takeLock(renew, true).then(function(lock){
+      if(lock){
         renew = true;
         lockRenewId = _this.timers.set('lockRenewer', _this.LOCK_RENEW_TIME / 2, lockRenewer);
       }
       // TODO: if we failed to re-acquire the lock while trying to renew, should we let the job
       // handler know and cancel the timer?
-      return locked;
+      return lock;
     }, function(err){
       console.error('Error renewing lock ' + err);
     });
@@ -653,7 +666,7 @@ Queue.prototype.processJob = function(job){
       return;
     }
 
-    return job.moveToCompleted(data, _this.token)
+    return job.moveToCompleted(data)
       .then(function(){
         return _this.distEmit('completed', job.toJSON(), data);
       });
@@ -663,7 +676,7 @@ Queue.prototype.processJob = function(job){
     _this.processing--;
     var error = err.cause || err; //Handle explicit rejection
     return job.moveToFailed(err)
-      .then(job.releaseLock.bind(job, _this.token))
+      .then(job.releaseLock.bind(job))
       .then(function(){
         return _this.distEmit('failed', job.toJSON(), error);
       });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -653,8 +653,7 @@ Queue.prototype.processJob = function(job){
 
     return job.moveToCompleted(data, _this.token)
       .then(function(){
-        _this.distEmit('completed', job.toJSON(), data);
-        return null; // Fixes #253
+        return _this.distEmit('completed', job.toJSON(), data);
       });
   }
 
@@ -664,8 +663,7 @@ Queue.prototype.processJob = function(job){
     return job.moveToFailed(err)
       .then(job.releaseLock.bind(job, _this.token))
       .then(function(){
-        _this.distEmit('failed', job.toJSON(), error);
-        return null; // Fixes #253
+        return _this.distEmit('failed', job.toJSON(), error);
       });
   }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -185,7 +185,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
     _this.on(_eventName, function(){
       var args = Array.prototype.slice.call(arguments);
 
-      if(eventName !== 'cleaned'){
+      if(eventName !== 'cleaned' && eventName !== 'error'){
         args[0] = Job.fromJSON(_this, args[0]);
       }
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -10,6 +10,7 @@
 var Promise = require('bluebird');
 var _ = require('lodash');
 var debuglog = require('debuglog')('bull');
+var Redlock = require('redlock');
 
 var cache = {};
 
@@ -47,20 +48,25 @@ function cacheScript(client, hash, script){
 }
 
 var scripts = {
-  _isJobInList: [
-    'local function item_in_list (list, item)',
-    '  for _, v in pairs(list) do',
-    '    if v == item then',
-    '      return 1',
-    '    end',
-    '  end',
-    '  return nil',
-    'end',
-    'local items = redis.call("LRANGE", KEYS[1], 0, -1)',
-    'return item_in_list(items, ARGV[1])'
-  ].join('\n'),
+  _isJobInList: function(keyVar, argVar, operator) {
+    keyVar = keyVar || 'KEYS[1]';
+    argVar = argVar || 'ARGV[1]';
+    operator = operator || 'return';
+    return [
+      'local function item_in_list (list, item)',
+      '  for _, v in pairs(list) do',
+      '    if v == item then',
+      '      return 1',
+      '    end',
+      '  end',
+      '  return nil',
+      'end',
+      ['local items = redis.call("LRANGE",', keyVar, ' , 0, -1)'].join(''),
+      [operator, ' item_in_list(items, ', argVar, ')'].join('')
+    ].join('\n');
+  },
   isJobInList: function(client, listKey, jobId){
-    return execScript(client, 'isJobInList', this._isJobInList, 1, listKey, jobId).then(function(result){
+    return execScript(client, 'isJobInList', this._isJobInList(), 1, listKey, jobId).then(function(result){
       return result === 1;
     });
   },
@@ -135,7 +141,7 @@ var scripts = {
   },
   // TODO: perfect this function so that it can be used instead
   // of all the specialized functions moveToComplete, etc.
-  move: function(job, token, src, target){
+  move: function(job, src, target){
     // TODO: Depending on the source we should use LREM, SREM or ZREM.
     // TODO: Depending on the target we should use LPUSH, SADD, etc.
     var keys = _.map([
@@ -157,15 +163,9 @@ var scripts = {
 
     var script = [
       'if redis.call("EXISTS", KEYS[3]) == 1 then', // Make sure job exists
-      ' local lock = redis.call("GET", KEYS[4])',
-      ' if (not lock) or (lock == ARGV[3]) then', // Makes sure we own the lock
-      '  redis.call("LREM", KEYS[1], -1, ARGV[1])',
+      ' redis.call("LREM", KEYS[1], -1, ARGV[1])',
       target ? moveJob : deleteJob,
-      '  redis.call("DEL", KEYS[4])',
-      '  return 0',
-      ' else',
-      '  return -2',
-      ' end',
+      ' return 0',
       'else',
       ' return -1',
       'end'
@@ -181,11 +181,21 @@ var scripts = {
       keys[2],
       keys[3],
       job.jobId,
-      job.returnvalue ? JSON.stringify(job.returnvalue) : '',
-      token
+      job.returnvalue ? JSON.stringify(job.returnvalue) : ''
     ];
 
-    return execScript.apply(scripts, args).then(function(result){
+    var returnLockOrErrorCode = function(lock) {
+      return lock ? execScript.apply(scripts, args) : -2;
+    };
+    var throwUnexpectedErrors = function(err) {
+      if (!(err instanceof Redlock.LockError)) {
+        throw err;
+      }
+    };
+
+    return job.takeLock(!!job.lock)
+    .then(returnLockOrErrorCode, throwUnexpectedErrors)
+    .then(function(result){
       switch (result){
         case -1:
           if(src){
@@ -195,12 +205,13 @@ var scripts = {
           }
         case -2:
           throw new Error('Cannot get lock for job ' + job.jobId + ' when trying to move from ' + src);
+        default:
+          return job.releaseLock()
       }
     });
   },
-
-  moveToCompleted: function(job, token, removeOnComplete){
-    return scripts.move(job, token, 'active', removeOnComplete ? void 0 : 'completed');
+  moveToCompleted: function(job, removeOnComplete){
+    return scripts.move(job, 'active', removeOnComplete ? void 0 : 'completed');
   },
 
   moveToSet: function(queue, set, jobId, context){
@@ -297,89 +308,49 @@ var scripts = {
    *    is already locked and just reset the lock expiration.
    * @param {Boolean=false} ensureActive Ensures that the job is in the 'active' state.
    */
-  takeLock: function(queue, job, token, renew, ensureActive){
-    // Ensures that the lock doesn't exist, or if it does, that we own it.
-    var ensureOwnershipCall = [
-      'local prevLock = redis.call("GET", KEYS[1])',
-      'if (prevLock and prevLock ~= ARGV[1]) then',
-      '  return 0',
-      'end'
-    ].join('\n');
-
-    // Ensures that the lock in the 'active' state.
-    var ensureActiveCall = [
-      // Note that while this is inefficient to run a O(n) traversal of the 'active' queue,
-      // it's highly likely that the job is within the first few elements of the active
-      // list at the time this call is used.
-      'local activeJobs = redis.call("LRANGE", KEYS[3], 0, -1)',
-      'local found = false',
-      'for _, job in ipairs(activeJobs) do',
-      '  if(job == ARGV[3]) then',
-      '     found = true',
-      '     break',
-      '  end',
-      'end',
-      'if (found == false) then',
-      '  return 0',
-      'end'
-    ].join('\n');
-
-    var lockCall;
-    if (renew){
-      lockCall = 'redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2])';
-    } else {
-      lockCall = 'redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2], "NX")';
+  takeLock: function(queue, job, renew, ensureActive){
+    var lock = job.lock;
+    if (renew && !lock) {
+      throw new Error('Unable to renew nonexisting lock');
+    }
+    if (renew) {
+      return lock.extend(queue.LOCK_RENEW_TIME);
+    }
+    if (lock) {
+      return Promise.resolve(null);
     }
 
-    var script = [
-      (renew ? ensureOwnershipCall : ''),
-      (ensureActive ? ensureActiveCall : ''),
-      'if(' + lockCall + ') then',
-      // Mark the job as having been locked at least once. Used to determine if the job was stalled.
-      ' redis.call("HSET", KEYS[2], "lockAcquired", "1")',
-      ' return 1',
-      'else',
-      ' return 0',
-      'end'
-    ].join('\n');
+    var redlock;
+    if (ensureActive) {
+      var keyVar = ['"', job.queue.toKey('active'), '"'].join('');
+      var argVar = ['"', job.jobId, '"'].join('');
+      var isJobInList = this._isJobInList(keyVar, argVar, 'if');
+      var lockAcquired = ['and redis.call("HSET", "', queue.toKey(job.jobId), '", "lockAcquired", "1")'].join('');
+      var success = 'then return 1 else return 0 end';
+      var opts = {
+        lockScript: function(lockScript) {
+          return [
+            isJobInList,
+            lockScript.replace('return', 'and'),
+            lockAcquired,
+            success
+          ].join('\n');
+        }
+      };
+      redlock = new Redlock(queue.clients, _.extend(opts, queue.redlock));
+    } else {
+      redlock = new Redlock(queue.clients, queue.redlock);
+    }
 
-    var args = [
-      queue.client,
-      'takeLock' + (renew ? 'Renew' : '') + (ensureActive ? 'EnsureActive' : ''),
-      script,
-      3,
-      job.lockKey(),
-      queue.toKey(job.jobId),
-      queue.toKey('active'),
-      token,
-      queue.LOCK_RENEW_TIME,
-      job.jobId
-    ];
-
-    return execScript.apply(scripts, args);
+    return redlock.lock(job.lockKey(), queue.LOCK_RENEW_TIME);
   },
 
-  releaseLock: function(job, token){
-    var script = [
-      'if redis.call("get", KEYS[1]) == ARGV[1]',
-      'then',
-      ' return redis.call("del", KEYS[1])',
-      'else',
-      ' return 0',
-      'end'].join('\n');
-
-    var args = [
-      job.queue.client,
-      'releaseLock',
-      script,
-      1,
-      job.lockKey(),
-      token
-    ];
-
-    return execScript.apply(scripts, args).then(function(result){
-      return result === 1;
-    });
+  releaseLock: function(job){
+    var lock = job.lock;
+    if (!lock) {
+      throw new Error('Unable to release nonexisting lock');
+    }
+    return lock.unlock()
   },
   /**
     It checks if the job in the top of the delay set should be moved back to the

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -47,21 +47,20 @@ function cacheScript(client, hash, script){
 }
 
 var scripts = {
+  _isJobInList: [
+    'local function item_in_list (list, item)',
+    '  for _, v in pairs(list) do',
+    '    if v == item then',
+    '      return 1',
+    '    end',
+    '  end',
+    '  return nil',
+    'end',
+    'local items = redis.call("LRANGE", KEYS[1], 0, -1)',
+    'return item_in_list(items, ARGV[1])'
+  ].join('\n'),
   isJobInList: function(client, listKey, jobId){
-    var script = [
-      'local function item_in_list (list, item)',
-      '  for _, v in pairs(list) do',
-      '    if v == item then',
-      '      return 1',
-      '    end',
-      '  end',
-      '  return nil',
-      'end',
-      'local items = redis.call("LRANGE", KEYS[1], 0, -1)',
-      'return item_in_list(items, ARGV[1])'
-    ].join('\n');
-
-    return execScript(client, 'isJobInList', script, 1, listKey, jobId).then(function(result){
+    return execScript(client, 'isJobInList', this._isJobInList, 1, listKey, jobId).then(function(result){
       return result === 1;
     });
   },

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -25,7 +25,7 @@ function execScript(client, hash, script){
 
   return cached.then(function(sha){
     args.unshift(sha);
-    return client.evalshaAsync.apply(client, args).catch(function(err){
+    return client.evalsha.apply(client, args).catch(function(err){
       debuglog(err, script, err.stack);
       if(err.code === 'NOSCRIPT'){
         delete cache[hash];
@@ -42,7 +42,7 @@ function execScript(client, hash, script){
 }
 
 function cacheScript(client, hash, script){
-  cache[hash] = client.scriptAsync('LOAD', script);
+  cache[hash] = client.script('LOAD', script);
   return cache[hash];
 }
 
@@ -294,7 +294,7 @@ var scripts = {
    *
    * @param {Queue} queue The queue for the job
    * @param {Job} job The job
-   * @param {Boolean=false} renew Whether to renew to lock, meaning it will assume the job 
+   * @param {Boolean=false} renew Whether to renew to lock, meaning it will assume the job
    *    is already locked and just reset the lock expiration.
    * @param {Boolean=false} ensureActive Ensures that the job is in the 'active' state.
    */
@@ -648,14 +648,14 @@ Queue.prototype.empty = function(){
   multi.del(this.toKey('meta-paused'));
   multi.del(this.toKey('delayed'));
 
-  return multi.execAsync().spread(function(waiting, paused){
+  return multi.exec().spread(function(waiting, paused){
     var jobKeys = (paused.concat(waiting)).map(_this.toKey, _this);
 
     if(jobKeys.length){
       multi = _this.multi();
 
       multi.del.apply(multi, jobKeys);
-      return multi.execAsync();
+      return multi.exec();
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lodash": "^4.16.6",
     "mocha": "^3.1.2",
     "node-uuid": "^1.4.7",
+    "redlock": "^2.1.0",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "bluebird": "^3.4.6",
     "debuglog": "^1.0.0",
     "disturbed": "^1.0.3",
+    "ioredis": "^2.4.0",
     "lodash": "^4.16.6",
     "mocha": "^3.1.2",
     "node-uuid": "^1.4.7",
-    "redis": "^2.6.3",
     "semver": "^5.3.0"
   },
   "devDependencies": {

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -6,8 +6,7 @@ var os = require('os');
 var path = require('path');
 var Queue = require('../');
 var expect = require('expect.js');
-var Promise = require('bluebird');
-var redis = require('redis');
+var redis = require('ioredis');
 
 var STD_QUEUE_NAME = 'cluster test queue';
 
@@ -20,15 +19,14 @@ function purgeQueue(queue) {
   // Since workers spawned only listen to the default queue,
   // we need to purge all keys after each test
   var client = redis.createClient(6379, '127.0.0.1', {});
-  client = Promise.promisifyAll(client);
-  client.selectAsync(0);
+  client.select(0);
 
   var script = [
     'local KS = redis.call("KEYS", ARGV[1])',
     'local result = redis.call("DEL", unpack(KS))',
     'return'].join('\n');
 
-  return queue.client.evalAsync(
+  return queue.client.eval(
     script,
     0,
     queue.toKey('*'));

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -76,6 +76,10 @@ describe('Cluster', function () {
     queue = buildQueue();
     var numJobs = 100;
 
+    queue.on('stalled', function(job){
+      jobs.splice(jobs.indexOf(job.jobId), 1);
+    });
+
     workerMessageHandler = function(job) {
       jobs.push(job.id);
       if(jobs.length === numJobs) {

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -43,17 +43,20 @@ function workerMessageHandlerWrapper(message) {
   }
 }
 
-var workers = [];
-var worker;
-var _i = 0;
-for(_i; _i < os.cpus().length - 1; _i++) {
-  worker = cluster.fork();
-  worker.on('message', workerMessageHandlerWrapper);
-  workers.push(worker);
-  console.log('Worker spawned: #', worker.id);
-}
-
 describe('Cluster', function () {
+
+  var workers = [];
+
+  before(function() {
+    var worker;
+    var _i = 0;
+    for(_i; _i < os.cpus().length - 1; _i++) {
+      worker = cluster.fork();
+      worker.on('message', workerMessageHandlerWrapper);
+      workers.push(worker);
+      console.log('Worker spawned: #', worker.id);
+    }
+  });
 
   var queue;
 
@@ -154,7 +157,7 @@ describe('Cluster', function () {
   });
 
   after(function() {
-    _i = 0;
+    var _i = 0;
     for(_i; _i < workers.length; _i++) {
       workers[_i].kill();
     }

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -24,8 +24,8 @@ describe('connection', function () {
     }).process(function (job, jobDone) {
       expect(job.data.foo).to.be.equal('bar');
       jobDone();
-      // We do not wait since this close is expected to fail...
       queue.close();
+    }).then(function() {
       done();
     }).catch(function(err){
       console.log(err);

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -4,10 +4,8 @@
 var expect = require('expect.js');
 var utils = require('./utils');
 var sinon = require('sinon');
-var redis = require('redis');
-var Promise = require('bluebird');
+var redis = require('ioredis');
 
-Promise.promisifyAll(redis.RedisClient.prototype);
 
 describe('connection', function () {
   var sandbox = sinon.sandbox.create();
@@ -15,7 +13,7 @@ describe('connection', function () {
 
   beforeEach(function(){
     var client = redis.createClient();
-    return client.flushdbAsync().then(function(){
+    return client.flushdb().then(function(){
       queue = utils.buildQueue();
     });
   });

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -4,19 +4,17 @@
 var Job = require('../lib/job');
 var Queue = require('../lib/queue');
 var expect = require('expect.js');
-var redis = require('redis');
+var redis = require('ioredis');
 var Promise = require('bluebird');
 var uuid = require('node-uuid');
 
-Promise.promisifyAll(redis.RedisClient.prototype);
-Promise.promisifyAll(redis.Multi.prototype);
 
 describe('Job', function(){
   var queue;
 
   beforeEach(function(){
     var client = redis.createClient();
-    return client.flushdbAsync();
+    return client.flushdb();
   });
 
   beforeEach(function(){
@@ -381,7 +379,7 @@ describe('Job', function(){
   it('get job status', function() {
     this.timeout(12000);
 
-    var client = Promise.promisifyAll(redis.createClient());
+    var client = redis.createClient();
     return Job.create(queue, {foo: 'baz'}).then(function(job) {
       return job.isStuck().then(function(isStuck) {
         expect(isStuck).to.be(false);
@@ -396,7 +394,7 @@ describe('Job', function(){
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('completed');
-        return client.sremAsync(queue.toKey('completed'), job.jobId);
+        return client.srem(queue.toKey('completed'), job.jobId);
       }).then(function(){
         return job.moveToDelayed(Date.now() + 10000);
       }).then(function (){
@@ -406,7 +404,7 @@ describe('Job', function(){
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('delayed');
-        return client.zremAsync(queue.toKey('delayed'), job.jobId);
+        return client.zrem(queue.toKey('delayed'), job.jobId);
       }).then(function() {
         return job.moveToFailed(new Error('test'));
       }).then(function (){
@@ -416,15 +414,15 @@ describe('Job', function(){
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('failed');
-        return client.sremAsync(queue.toKey('failed'), job.jobId);
+        return client.srem(queue.toKey('failed'), job.jobId);
       }).then(function(res) {
         expect(res).to.be(1);
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('stuck');
-        return client.rpopAsync(queue.toKey('wait'));
+        return client.rpop(queue.toKey('wait'));
       }).then(function(){
-        return client.lpushAsync(queue.toKey('paused'), job.jobId);
+        return client.lpush(queue.toKey('paused'), job.jobId);
       }).then(function() {
         return job.isPaused();
       }).then(function (isPaused) {
@@ -432,9 +430,9 @@ describe('Job', function(){
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('paused');
-        return client.rpopAsync(queue.toKey('paused'));
+        return client.rpop(queue.toKey('paused'));
       }).then(function() {
-        return client.lpushAsync(queue.toKey('wait'), job.jobId);
+        return client.lpush(queue.toKey('wait'), job.jobId);
       }).then(function() {
         return job.isWaiting();
       }).then(function (isWaiting) {

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -7,6 +7,7 @@ var expect = require('expect.js');
 var redis = require('ioredis');
 var Promise = require('bluebird');
 var uuid = require('node-uuid');
+var Redlock = require('redlock');
 
 
 describe('Job', function(){
@@ -93,12 +94,11 @@ describe('Job', function(){
     });
 
     it('fails to remove a locked job', function() {
-      var token = uuid();
       return Job.create(queue, 1, {foo: 'bar'}).then(function(job) {
-        return job.takeLock(token).then(function(lock) {
-          expect(lock).to.be(true);
+        return job.takeLock().then(function(lock) {
+          expect(lock).to.be.a(Redlock.Lock);
         }).then(function() {
-          return job.remove(token);
+          return job.remove();
         }).then(function() {
           throw new Error('Should not be able to remove a locked job');
         }).catch(function(err) {
@@ -191,45 +191,41 @@ describe('Job', function(){
     });
 
     it('can take a lock', function(){
-      return job.takeLock('423').then(function(lockTaken){
-        expect(lockTaken).to.be(true);
+      return job.takeLock().then(function(lockTaken){
+        expect(lockTaken).to.be.a(Redlock.Lock);
       }).then(function(){
-        return job.releaseLock('321').then(function(lockReleased){
-          expect(lockReleased).to.be(false);
+        return job.releaseLock().then(function(lockReleased){
+          expect(lockReleased).to.not.exist;
         });
       });
     });
 
     it('cannot take an already taken lock', function(){
-      return job.takeLock('1234').then(function(lockTaken){
-        expect(lockTaken).to.be(true);
+      return job.takeLock().then(function(lockTaken){
+        expect(lockTaken).to.be.a(Redlock.Lock);
       }).then(function(){
-        return job.takeLock('1234').then(function(lockTaken){
+        return job.takeLock().then(function(lockTaken){
           expect(lockTaken).to.be(false);
         });
       });
     });
 
     it('can renew a previously taken lock', function(){
-      return job.takeLock('1235').then(function(lockTaken){
-        expect(lockTaken).to.be(true);
+      return job.takeLock().then(function(lockTaken){
+        expect(lockTaken).to.be.a(Redlock.Lock);
       }).then(function(){
-        return job.renewLock('1235').then(function(lockRenewed){
-          expect(lockRenewed).to.be(true);
+        return job.renewLock().then(function(lockRenewed){
+          expect(lockRenewed).to.be.a(Redlock.Lock);
         });
       });
     });
 
     it('can release a lock', function(){
-      return job.takeLock('1237').then(function(lockTaken){
-        expect(lockTaken).to.be(true);
+      return job.takeLock().then(function(lockTaken){
+        expect(lockTaken).to.be.a(Redlock.Lock);
       }).then(function(){
-        return job.releaseLock('321').then(function(lockReleased){
-          expect(lockReleased).to.be(false);
-        });
-      }).then(function(){
-        return job.releaseLock('1237').then(function(lockReleased){
-          expect(lockReleased).to.be(true);
+        return job.releaseLock().then(function(lockReleased){
+          expect(lockReleased).to.not.exist;
         });
       });
     });

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -23,6 +23,7 @@ describe('Job', function(){
   });
 
   afterEach(function(){
+    this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
     return queue.close();
   });
 

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -8,7 +8,7 @@ var Promise = require('bluebird');
 var sinon = require('sinon');
 var _ = require('lodash');
 var uuid = require('node-uuid');
-var redis = require('redis');
+var redis = require('ioredis');
 
 var STD_QUEUE_NAME = 'test queue';
 
@@ -27,7 +27,7 @@ describe.skip('Priority queue', function(){
 
   beforeEach(function(){
     var client = redis.createClient();
-    return client.flushdbAsync();
+    return client.flushdb();
   });
 
   afterEach(function(){

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -86,6 +86,7 @@ describe('Queue', function () {
     });
 
     it('should close if the job expires after the LOCK_RENEW_TIME', function (done) {
+      this.timeout(testQueue.STALLED_JOB_CHECK_INTERVAL * 2);
       testQueue.LOCK_RENEW_TIME = 10;
       testQueue.process(function () {
         return Promise.delay(40);
@@ -245,6 +246,7 @@ describe('Queue', function () {
     });
 
     afterEach(function () {
+      this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
       return utils.cleanupQueues();
     });
 
@@ -1121,6 +1123,7 @@ describe('Queue', function () {
     });
 
     afterEach(function () {
+      this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
       return queue.close();
     });
 
@@ -1226,6 +1229,7 @@ describe('Queue', function () {
     var queue;
 
     afterEach(function () {
+      this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
       return queue.close();
     });
 
@@ -1462,6 +1466,7 @@ describe('Queue', function () {
     });
 
     afterEach(function () {
+      this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
       return queue.close();
     });
 
@@ -1579,6 +1584,7 @@ describe('Queue', function () {
     });
 
     afterEach(function () {
+      this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
       return queue.close();
     });
 
@@ -1690,6 +1696,7 @@ describe('Queue', function () {
     });
 
     afterEach(function () {
+      this.timeout(queue.STALLED_JOB_CHECK_INTERVAL * (1 + queue.MAX_STALLED_JOB_COUNT));
       return queue.close();
     });
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -437,11 +437,15 @@ describe('Queue', function () {
             var stalledCallback = sandbox.spy();
 
             return queueStalled.close(true).then(function () {
-              return new Promise(function (resolve) {
+              return new Promise(function (resolve, reject) {
                 utils.newQueue('test queue stalled').then(function (queue2) {
                   queue2.LOCK_RENEW_TIME = 100;
                   var doneAfterFour = _.after(4, function () {
-                    expect(stalledCallback.calledOnce).to.be(true);
+                    try {
+                      expect(stalledCallback.calledOnce).to.be(true);
+                    } catch (e) {
+                      reject(e);
+                    }
                     resolve();
                   });
                   queue2.on('completed', doneAfterFour);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -69,14 +69,14 @@ describe('Queue', function () {
     });
 
     it('should resolve the promise when each client has disconnected', function () {
-      expect(testQueue.client.connected).to.be(true);
-      expect(testQueue.bclient.connected).to.be(true);
-      expect(testQueue.eclient.connected).to.be(true);
+      expect(testQueue.client.status).to.be('ready');
+      expect(testQueue.bclient.status).to.be('ready');
+      expect(testQueue.eclient.status).to.be('ready');
 
       return testQueue.close().then(function () {
-        expect(testQueue.client.connected).to.be(false);
-        expect(testQueue.bclient.connected).to.be(false);
-        expect(testQueue.eclient.connected).to.be(false);
+        expect(testQueue.client.status).to.be('end');
+        expect(testQueue.bclient.status).to.be('end');
+        expect(testQueue.eclient.status).to.be('end');
       });
     });
 
@@ -138,14 +138,14 @@ describe('Queue', function () {
       var queue = new Queue('standard');
 
       queue.once('ready', function () {
-        expect(queue.client.connection_options.host).to.be('127.0.0.1');
-        expect(queue.bclient.connection_options.host).to.be('127.0.0.1');
+        expect(queue.client.options.host).to.be('127.0.0.1');
+        expect(queue.bclient.options.host).to.be('127.0.0.1');
 
-        expect(queue.client.connection_options.port).to.be(6379);
-        expect(queue.bclient.connection_options.port).to.be(6379);
+        expect(queue.client.options.port).to.be(6379);
+        expect(queue.bclient.options.port).to.be(6379);
 
-        expect(queue.client.selected_db).to.be(0);
-        expect(queue.bclient.selected_db).to.be(0);
+        expect(queue.client.options.db).to.be(0);
+        expect(queue.bclient.options.db).to.be(0);
 
         queue.close().then(done);
       });
@@ -155,14 +155,14 @@ describe('Queue', function () {
       var queue = new Queue('connstring', 'redis://127.0.0.1:6379');
 
       queue.once('ready', function () {
-        expect(queue.client.connection_options.host).to.be('127.0.0.1');
-        expect(queue.bclient.connection_options.host).to.be('127.0.0.1');
+        expect(queue.client.options.host).to.be('127.0.0.1');
+        expect(queue.bclient.options.host).to.be('127.0.0.1');
 
-        expect(queue.client.connection_options.port).to.be(6379);
-        expect(queue.bclient.connection_options.port).to.be(6379);
+        expect(queue.client.options.port).to.be(6379);
+        expect(queue.bclient.options.port).to.be(6379);
 
-        expect(queue.client.selected_db).to.be(0);
-        expect(queue.bclient.selected_db).to.be(0);
+        expect(queue.client.options.db).to.be(0);
+        expect(queue.bclient.options.db).to.be(0);
 
         queue.close().then(done);
 
@@ -173,14 +173,14 @@ describe('Queue', function () {
       var queue = new Queue('custom', { redis: { DB: 1 } });
 
       queue.once('ready', function () {
-        expect(queue.client.connection_options.host).to.be('127.0.0.1');
-        expect(queue.bclient.connection_options.host).to.be('127.0.0.1');
+        expect(queue.client.options.host).to.be('127.0.0.1');
+        expect(queue.bclient.options.host).to.be('127.0.0.1');
 
-        expect(queue.client.connection_options.port).to.be(6379);
-        expect(queue.bclient.connection_options.port).to.be(6379);
+        expect(queue.client.options.port).to.be(6379);
+        expect(queue.bclient.options.port).to.be(6379);
 
-        expect(queue.client.selected_db).to.be(1);
-        expect(queue.bclient.selected_db).to.be(1);
+        expect(queue.client.options.db).to.be(1);
+        expect(queue.bclient.options.db).to.be(1);
 
         queue.close().then(done);
       });
@@ -190,11 +190,11 @@ describe('Queue', function () {
       var queue = new Queue('custom', { redis: { host: 'localhost' } });
 
       queue.once('ready', function () {
-        expect(queue.client.connection_options.host).to.be('localhost');
-        expect(queue.bclient.connection_options.host).to.be('localhost');
+        expect(queue.client.options.host).to.be('localhost');
+        expect(queue.bclient.options.host).to.be('localhost');
 
-        expect(queue.client.selected_db).to.be(0);
-        expect(queue.bclient.selected_db).to.be(0);
+        expect(queue.client.options.db).to.be(0);
+        expect(queue.bclient.options.db).to.be(0);
 
         queue.close().then(done);
       });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -846,7 +846,7 @@ describe('Queue', function () {
 
       var queue = utils.buildQueue();
 
-      queue.pause(true /* Local */).then(function () {
+      queue.pause(true /* Local */).tap(function () {
         // Add the worker after the queue is in paused mode since the normal behavior is to pause
         // it after the current lock expires. This way, we can ensure there isn't a lock already
         // to test that pausing behavior works.

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -999,7 +999,8 @@ describe('Queue', function () {
       var order = 0;
       queue = new Queue('delayed queue multiple');
 
-      queue.on('failed', function (err) {
+      queue.on('failed', function (job, err) {
+        err.job = job;
         done(err);
       });
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -4,14 +4,12 @@
 var Queue = require('../');
 var expect = require('expect.js');
 var Promise = require('bluebird');
-var redis = require('redis');
+var redis = require('ioredis');
 var sinon = require('sinon');
 var _ = require('lodash');
 var uuid = require('node-uuid');
 var utils = require('./utils');
 
-Promise.promisifyAll(redis.RedisClient.prototype);
-Promise.promisifyAll(redis.Multi.prototype);
 
 /*
 console.error = function(){
@@ -32,7 +30,7 @@ describe('Queue', function () {
 
   beforeEach(function () {
     var client = redis.createClient();
-    return client.flushdbAsync();
+    return client.flushdb();
   });
 
   afterEach(function () {
@@ -239,7 +237,7 @@ describe('Queue', function () {
 
     beforeEach(function () {
       var client = redis.createClient();
-      return client.flushdbAsync().then(function () {
+      return client.flushdb().then(function () {
         return utils.newQueue();
       }).then(function (_queue) {
         queue = _queue;
@@ -362,7 +360,7 @@ describe('Queue', function () {
         expect(job).to.be.ok();
         expect(data).to.be.eql(37);
         expect(job.returnvalue).to.be.eql(37);
-        queue.client.hgetAsync(queue.toKey(job.jobId), 'returnvalue').then(function (retval) {
+        queue.client.hget(queue.toKey(job.jobId), 'returnvalue').then(function (retval) {
           expect(JSON.parse(retval)).to.be.eql(37);
           done();
         });
@@ -779,7 +777,7 @@ describe('Queue', function () {
   describe('.pause', function () {
     beforeEach(function () {
       var client = redis.createClient();
-      return client.flushdbAsync();
+      return client.flushdb();
     });
 
     it.skip('should pause a queue until resumed', function () {
@@ -953,7 +951,7 @@ describe('Queue', function () {
 
     beforeEach(function () {
       var client = redis.createClient();
-      return client.flushdbAsync();
+      return client.flushdb();
     });
 
     it('should process a delayed job only after delayed time', function (done) {
@@ -1114,7 +1112,7 @@ describe('Queue', function () {
     beforeEach(function () {
       var client = redis.createClient();
       queue = utils.buildQueue();
-      return client.flushdbAsync();
+      return client.flushdb();
     });
 
     afterEach(function () {

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -253,7 +253,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
         done();
-      });
+      }).catch(done);
       queue.add({ foo: 'bar' }).then(function (job) {
         expect(job.jobId).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -562,7 +562,7 @@ describe('Queue', function () {
             err = new Error('Processed job id does not match that of added job');
           }
           setTimeout(jobDone, 500);
-        });
+        }).catch(done);
 
         utils.newQueue().then(function (_anotherQueue) {
           anotherQueue = _anotherQueue;
@@ -841,7 +841,7 @@ describe('Queue', function () {
       });
     });
 
-    it('should pause the queue locally', function (testDone) {
+    it('should pause the queue locally', function (done) {
       var counter = 2;
 
       var queue = utils.buildQueue();
@@ -850,14 +850,14 @@ describe('Queue', function () {
         // Add the worker after the queue is in paused mode since the normal behavior is to pause
         // it after the current lock expires. This way, we can ensure there isn't a lock already
         // to test that pausing behavior works.
-        queue.process(function (job, done) {
+        queue.process(function (job, jobDone) {
           expect(queue.paused).not.to.be.ok();
-          done();
+          jobDone();
           counter--;
           if (counter === 0) {
-            queue.close().then(testDone);
+            queue.close().then(done);
           }
-        });
+        }).catch(done);
       }).then(function () {
         return queue.add({ foo: 'paused' });
       }).then(function () {
@@ -866,7 +866,7 @@ describe('Queue', function () {
         expect(counter).to.be(2);
         expect(queue.paused).to.be.ok(); // Parameter should exist.
         return queue.resume(true /* Local */);
-      });
+      }).catch(done);
     });
 
     it('should wait until active jobs are finished before resolving pause', function (done) {
@@ -881,7 +881,7 @@ describe('Queue', function () {
           jobs.push(queue.add(i));
         }
         Promise.all(jobs).then(function () {
-          queue.pause(true).then(function () {
+          return queue.pause(true).then(function () {
             var active = queue.getJobCountByTypes(['active']).then(function (count) {
               expect(count).to.be(0);
               expect(queue.paused).to.be.ok();
@@ -913,7 +913,7 @@ describe('Queue', function () {
           }).then(function () {
             return queue.close().then(done, done);
           });
-        });
+        }).catch(done);
       });
     });
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,6 +34,7 @@ function cleanupQueue(queue) {
 
 function cleanupQueues() {
   return Promise.map(queues, function(queue){
+    queue.on('error', function() {});
     return queue.close();
   }).then(function(){
     queues = [];

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,8 +34,9 @@ function cleanupQueue(queue) {
 
 function cleanupQueues() {
   return Promise.map(queues, function(queue){
-    queue.on('error', function() {});
-    return queue.close();
+    var errHandler = function() {};
+    queue.on('error', errHandler);
+    return queue.close().catch(errHandler);
   }).then(function(){
     queues = [];
   });


### PR DESCRIPTION
Hello,

This PR changes the redis dependency from **node_redis** to **ioredis**, fixing #185 (and completing PR #188).  **ioredis** uses promises "all-the-way-down", exposing errors in the test suite.  These tests are fixed and passing, including the race condition described in #370.

There are several commits here, to demonstrate the bugs and fixes made to the test suite.  I am happy to squash this down, but right now each commit contains a description of the issues solved with the updated tests.

As part of solving #370, [**node-redlock**](https://github.com/mike-marcacci/node-redlock) is now used to implement atomic locking with a guaranteed owner.  **node-redlock** is a promise-based lib which keeps track of its own secret token/value for each job/resource, which makes node-redlock valuable whether or not it's used with redis clustering.

Thanks for your work, looking forward to your feedback.