### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/timer-manager.js
+++ b/lib/timer-manager.js
@@ -3,7 +3,7 @@
 
 var Promise = require('bluebird');
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 /**
   Timer Manager

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "disturbed": "^1.0.6",
     "ioredis": "^2.4.0",
     "lodash": "^4.16.6",
-    "node-uuid": "^1.4.7",
     "redlock": "^2.1.0",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -6,7 +6,7 @@ var Queue = require('../lib/queue');
 var expect = require('expect.js');
 var redis = require('ioredis');
 var Promise = require('bluebird');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var Redlock = require('redlock');
 
 

--- a/test/test_priority_queue.js
+++ b/test/test_priority_queue.js
@@ -7,7 +7,7 @@ var expect = require('expect.js');
 var Promise = require('bluebird');
 var sinon = require('sinon');
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var redis = require('ioredis');
 
 var STD_QUEUE_NAME = 'test queue';

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -7,7 +7,7 @@ var Promise = require('bluebird');
 var redis = require('ioredis');
 var sinon = require('sinon');
 var _ = require('lodash');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var utils = require('./utils');
 
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.