### PR TITLE
Fix keyPrefix

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -39,7 +39,8 @@ var Job = function(queue, data, opts){
 function addJob(queue, job){
   var jobData = job.toData();
   var toKey = _.bind(queue.toKey, queue);
-  return scripts.addJob(queue.client, toKey, jobData, { lifo: job.opts.lifo, customJobId: job.opts.jobId });
+  var toPrefixedKey = _.bind(queue.toPrefixedKey, queue);
+  return scripts.addJob(queue.client, toKey, toPrefixedKey, jobData, { lifo: job.opts.lifo, customJobId: job.opts.jobId });
 }
 
 Job.create = function(queue, data, opts){

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -108,7 +108,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   var _this = this;
 
   this.name = name;
-  this.keyPrefix = redisOptions.keyPrefix || 'bull';
+  this.keyPrefix = redisOptions.keyPrefix;
 
   //
   // Create queue client (used to add jobs, pause queues, etc);
@@ -884,6 +884,11 @@ Queue.prototype.retryJob = function(job) {
 };
 
 Queue.prototype.toKey = function(queueType){
+  return [this.keyPrefix ? '' : 'bull', this.name, queueType].join(':');
+};
+
+Queue.prototype.toPrefixedKey = function(queueType){
+  if (!this.keyPrefix) return this.toKey(queueType);
   return [this.keyPrefix, this.name, queueType].join(':');
 };
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -70,7 +70,7 @@ var scripts = {
       return result === 1;
     });
   },
-  addJob: function(client, toKey, job, opts){
+  addJob: function(client, toKey, toPrefixedKey, job, opts){
     opts = opts || {};
     opts.lifo = !!(opts.lifo);
 
@@ -79,7 +79,7 @@ var scripts = {
     var keys = _.map(['wait', 'paused', 'meta-paused', 'jobs', 'id', 'delayed'], function(name){
       return toKey(name);
     });
-    var baseKey = toKey('');
+    var baseKey = toPrefixedKey('');
 
     var argvs = _.map(jobArgs, function(arg, index){
       return ', ARGV['+(index+3)+']';
@@ -322,10 +322,10 @@ var scripts = {
 
     var redlock;
     if (ensureActive) {
-      var keyVar = ['"', job.queue.toKey('active'), '"'].join('');
+      var keyVar = ['"', job.queue.toPrefixedKey('active'), '"'].join('');
       var argVar = ['"', job.jobId, '"'].join('');
       var isJobInList = this._isJobInList(keyVar, argVar, 'if');
-      var lockAcquired = ['and redis.call("HSET", "', queue.toKey(job.jobId), '", "lockAcquired", "1")'].join('');
+      var lockAcquired = ['and redis.call("HSET", "', queue.toPrefixedKey(job.jobId), '", "lockAcquired", "1")'].join('');
       var success = 'then return 1 else return 0 end';
       var opts = {
         lockScript: function(lockScript) {
@@ -341,7 +341,6 @@ var scripts = {
     } else {
       redlock = new Redlock(queue.clients, queue.redlock);
     }
-
     return redlock.lock(job.lockKey(), queue.LOCK_RENEW_TIME);
   },
 
@@ -396,7 +395,7 @@ var scripts = {
       keys[1],
       keys[2],
       keys[3],
-      queue.toKey(''),
+      queue.toPrefixedKey(''),
       delayedTimestamp
     ];
 
@@ -462,7 +461,7 @@ var scripts = {
       queue.toKey('wait'),
       queue.toKey('failed'),
       queue.MAX_STALLED_JOB_COUNT,
-      queue.toKey('')
+      queue.toPrefixedKey('')
     ];
 
     return execScript.apply(scripts, args);
@@ -534,7 +533,7 @@ var scripts = {
       script,
       1,
       queue.toKey(set),
-      queue.toKey(''),
+      queue.toPrefixedKey(''),
       ts,
       limit
     ];

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -11,15 +11,16 @@ var Redlock = require('redlock');
 
 
 describe('Job', function(){
-  var queue;
+  var queue, client, options;
 
   beforeEach(function(){
-    var client = redis.createClient();
+    options = { keyPrefix: 'bull-test' }
+    client = redis.createClient(options);
     return client.flushdb();
   });
 
   beforeEach(function(){
-    queue = new Queue('test-' + uuid(), 6379, '127.0.0.1');
+    queue = new Queue('test-' + uuid(), 6379, '127.0.0.1', options);
   });
 
   afterEach(function(){
@@ -35,7 +36,6 @@ describe('Job', function(){
     beforeEach(function () {
       data = {foo: 'bar'};
       opts = {testOpt: 'enabled'};
-
       return Job.create(queue, data, opts).then(function(createdJob){
         job = createdJob;
       });
@@ -380,7 +380,6 @@ describe('Job', function(){
   it('get job status', function() {
     this.timeout(12000);
 
-    var client = redis.createClient();
     return Job.create(queue, {foo: 'baz'}).then(function(job) {
       return job.isStuck().then(function(isStuck) {
         expect(isStuck).to.be(false);


### PR DESCRIPTION
This pr makes bull compatible with the ioredis keyPrefix option, which has a number of benefits:

- queues can be namespaced transparently to prevent conflicts
- people expecting the keyPrefix option to work for free will have a better time
- easier redis key grepping

When lua scripts are constructed with strings, keys must be manually prefixed. ioredis commands are transparently prefixed... even the key args to .evalsha