### PR TITLE
replace manual caching with ioredis.defineCommand

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -12,39 +12,14 @@ var _ = require('lodash');
 var debuglog = require('debuglog')('bull');
 var Redlock = require('redlock');
 
-var cache = {};
+function execScript(client, hash, lua, numberOfKeys){
+    var args = _.drop(arguments, 4);
 
-function execScript(client, hash, script){
-  var cached = cache[hash];
-  var args = _.drop(arguments, 3);
+    debuglog(lua, args);
 
-  debuglog(script, args);
+    client.defineCommand(hash, { numberOfKeys: numberOfKeys, lua: lua });
 
-  if(!cached){
-    cached = cacheScript(client, hash, script);
-  }
-
-  return cached.then(function(sha){
-    args.unshift(sha);
-    return client.evalsha.apply(client, args).catch(function(err){
-      debuglog(err, script, err.stack);
-      if(err.code === 'NOSCRIPT'){
-        delete cache[hash];
-        args = [
-          client, hash, script
-        ];
-        args.push.apply(args, arguments);
-        return execScript.apply(null, args);
-      }else{
-        throw err;
-      }
-    })
-  });
-}
-
-function cacheScript(client, hash, script){
-  cache[hash] = client.script('LOAD', script);
-  return cache[hash];
+    return client[hash](args);
 }
 
 var scripts = {


### PR DESCRIPTION
Really is very simple. 
This has two benefits: 
1. uses ioredis's internal caching - less code, less for bull to do
2. its makes bull compatible with newrelic's transaction monitoring (tbh im not sure what was incompatible - im just happy it's working)

what say you?