### PR TITLE
Fix job.progress() to return the correct progress

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -84,6 +84,7 @@ Job.prototype.toData = function(){
 Job.prototype.progress = function(progress){
   if(progress){
     var _this = this;
+    this._progress = progress;
     return this.queue.client.hset(this.queue.toKey(this.jobId), 'progress', progress).then(function(){
       _this.queue.distEmit('progress', _this.toJSON(), progress);
     });


### PR DESCRIPTION
job.progress() will always return 0 even after running job.progress(50), this commit will fix that