### PR TITLE
Remove redudant locking

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -662,29 +662,24 @@ Queue.prototype.processJob = function(job){
   }
 
   function handleCompleted(data){
-    job.takeLock(true /* renwew */, false /* ensureActive */).then(function(lock) {
-      // This substraction is duplicate in handleCompleted and handleFailed because it have to be made before throwing any
-      // event completed or failed in order to allow pause() to work correctly without getting stuck.
-      _this.processing--;
-
-      if(_this.closed){
-        return;
-      }
-
-      clearTimer();
-      return job.moveToCompleted(data)
-        .then(function(){
-          return _this.distEmit('completed', job.toJSON(), data);
-        });
-    }, function(err){
-      console.error('failed ot obtain lock before marking completed, bailing', err)
-    } )
     try{
       JSON.stringify(data);
     }catch(err){
       return handleFailed(err);
     }
+    // This substraction is duplicate in handleCompleted and handleFailed because it have to be made before throwing any
+    // event completed or failed in order to allow pause() to work correctly without getting stuck.
+    _this.processing--;
 
+    if(_this.closed){
+      return;
+    }
+
+    clearTimer();
+    return job.moveToCompleted(data)
+      .then(function(){
+        return _this.distEmit('completed', job.toJSON(), data);
+      });
   }
 
   function handleFailed(err){

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -683,6 +683,8 @@ Queue.prototype.processJob = function(job){
   }
 
   function handleFailed(err){
+    // TODO: Should moveToFailed ensure the lock atomically in one of its Lua scripts?
+    // See https://github.com/OptimalBits/bull/pull/415#issuecomment-269744735
     job.takeLock(true /* renwew */, false /* ensureActive */).then( function(lock) {
       return clearTimer()
         .then(job.moveToFailed(err))

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -692,10 +692,10 @@ Queue.prototype.processJob = function(job){
         .then(function(){
           return _this.distEmit('failed', job.toJSON(), error);
         });
-    }, function (err){
+    }, function(err){
       console.error('failed to reobtain lock before moving to failed, bailing: ', err);
       clearTimer();
-    })
+    });
     _this.processing--;
     var error = err.cause || err; //Handle explicit rejection
 


### PR DESCRIPTION
Reverts redundant locking that was introduced in PR #415 but pointed out in #415 (comment) that moveToComplete is already taking a lock inside the move function.