### PR TITLE
Fix Lock Redis script to not be a different script for every Job ID #426

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -24,20 +24,26 @@ function execScript(client, hash, lua, numberOfKeys){
 
 var scripts = {
   _isJobInList: function(keyVar, argVar, operator) {
-    keyVar = keyVar || 'KEYS[1]';
-    argVar = argVar || 'ARGV[1]';
-    operator = operator || 'return';
-    return [
-      'local function item_in_list (list, item)',
-      '  for _, v in pairs(list) do',
-      '    if v == item then',
-      '      return 1',
-      '    end',
-      '  end',
-      '  return nil',
-      'end',
-      ['local items = redis.call("LRANGE",', keyVar, ' , 0, -1)'].join(''),
-      [operator, ' item_in_list(items, ', argVar, ')'].join('')
+   	keyVar = keyVar ? 'splitKey[1]..":"..splitKey[2]..":active"' : 'KEYS[1]';
+		argVar = argVar || 'ARGV[1]';
+		operator = operator || 'return';
+		return [
+			'local function item_in_list (list, item)',
+			'  for _, v in pairs(list) do',
+			'    if v == item then',
+			'      return 1',
+			'    end',
+			'  end',
+			'  return nil',
+			'end',
+			'local splitKey={}',
+			'local i=1',
+			'for str in string.gmatch(KEYS[1], "([^:]+)") do',
+					'splitKey[i] = str',
+					'i = i + 1',
+			'end',
+			[ 'local items = redis.call("LRANGE", ', keyVar, ' , 0, -1)' ].join(''),
+			[ operator, ' item_in_list(items, ', argVar, ')' ].join('')
     ].join('\n');
   },
   isJobInList: function(client, listKey, jobId){
@@ -300,7 +306,7 @@ var scripts = {
       var keyVar = ['"', job.queue.toKey('active'), '"'].join('');
       var argVar = ['"', job.jobId, '"'].join('');
       var isJobInList = this._isJobInList(keyVar, argVar, 'if');
-      var lockAcquired = ['and redis.call("HSET", "', queue.toKey(job.jobId), '", "lockAcquired", "1")'].join('');
+			var lockAcquired = 'and redis.call("HSET", splitKey[1]..":"..splitKey[2]..":"..splitKey[3], "lockAcquired", "1")';
       var success = 'then return 1 else return 0 end';
       var opts = {
         lockScript: function(lockScript) {


### PR DESCRIPTION
NOTES: this will still violate the redis cluster requirements that each script should explicitly define the keys it writes to in the KEYS array, however the current implementation also violates this. This pull request should fix the growing lua_memory_cache issues. #426 