### PR TITLE
Fix for max 24 day delay issue #244

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -230,7 +230,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   //
   // Init delay timestamp.
   //
-  this.delayedTimestamp = MAX_TIMEOUT_MS;
+  this.delayedTimestamp = Number.MAX_VALUE;
   scripts.updateDelaySet(this, Date.now()).then(function(timestamp){
     if(timestamp){
       _this.updateDelayTimer(timestamp);
@@ -557,7 +557,7 @@ Queue.prototype.run = function(concurrency){
 Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
   var _this = this;
 
-  if(newDelayedTimestamp < _this.delayedTimestamp){
+  if(newDelayedTimestamp < _this.delayedTimestamp && newDelayedTimestamp < (MAX_TIMEOUT_MS + Date.now())){
     clearTimeout(this.delayTimer);
     this.delayedTimestamp = newDelayedTimestamp;
 
@@ -569,13 +569,13 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
         if(nextTimestamp){
           nextTimestamp = nextTimestamp < Date.now() ? Date.now() : nextTimestamp;
         }else{
-          nextTimestamp = MAX_TIMEOUT_MS;
+          nextTimestamp = Number.MAX_VALUE;
         }
         _this.updateDelayTimer(nextTimestamp);
-      }).catch(function(err){
+      }).catch(function(err){ 
         console.error('Error updating the delay timer', err);
       });
-      _this.delayedTimestamp = MAX_TIMEOUT_MS;
+      _this.delayedTimestamp = Number.MAX_VALUE;
     }, nextDelayedJob);
   }
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -36,7 +36,7 @@ var debuglog = require('debuglog')('bull');
   Delayed jobs are jobs that cannot be executed until a certain time in
   ms has passed since they were added to the queue.
   The mechanism is simple, a delayedTimestamp variable holds the next
-  known timestamp that is on the delayed set (or MAX_INT if none).
+  known timestamp that is on the delayed set (or MAX_TIMEOUT_MS if none).
 
   When the current job has finalized the variable is checked, if
   no delayed job has to be executed yet a setTimeout is set so that a
@@ -58,6 +58,8 @@ var POLLING_INTERVAL = 5000;
 var REDLOCK_DRIFT_FACTOR = 0.01;
 var REDLOCK_RETRY_COUNT = 0;
 var REDLOCK_RETRY_DELAY = 200;
+
+var MAX_TIMEOUT_MS = Math.pow(2, 31) - 1; // 32 bit signed
 
 var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   if(!(this instanceof Queue)){
@@ -228,7 +230,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   //
   // Init delay timestamp.
   //
-  this.delayedTimestamp = Number.MAX_VALUE;
+  this.delayedTimestamp = MAX_TIMEOUT_MS;
   scripts.updateDelaySet(this, Date.now()).then(function(timestamp){
     if(timestamp){
       _this.updateDelayTimer(timestamp);
@@ -567,13 +569,13 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
         if(nextTimestamp){
           nextTimestamp = nextTimestamp < Date.now() ? Date.now() : nextTimestamp;
         }else{
-          nextTimestamp = Number.MAX_VALUE;
+          nextTimestamp = MAX_TIMEOUT_MS;
         }
         _this.updateDelayTimer(nextTimestamp);
       }).catch(function(err){
         console.error('Error updating the delay timer', err);
       });
-      _this.delayedTimestamp = Number.MAX_VALUE;
+      _this.delayedTimestamp = MAX_TIMEOUT_MS;
     }, nextDelayedJob);
   }
 };

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1118,7 +1118,7 @@ describe('Queue', function () {
           });
         }).then(function () {
           expect(publishHappened).to.be(true);
-          queue.close().then(done, done);
+          queue.close(true).then(done, done);
         });
       });
 


### PR DESCRIPTION
The implementation of setTimeout in Nodejs relies on a 32 bit integer for timeout values. The current default timeout in the delay timer is the max 64 bit integer which causes any possible delay values to start the delay timer. Delays longer than 2^31-1 ms (roughly 24 days) cause an integer overflow and the timeout triggers immediately.

This pull request replaces the default timeout with the max 32bit signed integer so that only valid ms values can start the timer. Anything longer than 24 days will be caught by the guardian timer.

To reproduce this issue clear anything in the delay set and create a new job with a delay > 2^31 ms. It will execute immediately.

https://nodejs.org/docs/latest/api/timers.html#timers_settimeout_callback_delay_args

#244 