### PR TITLE
Added back Redis createClient option

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -98,7 +98,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   function createClient() {
     var client;
     if(_.isFunction(redisOptions.createClient)){
-      client = new redisOptions();
+      client = redisOptions.createClient();
     }else{
       client = new redis(redisPort, redisHost, redisOptions);
     }


### PR DESCRIPTION
This allows for Bull to be used with custom Redis clients including libs that use sentinels. 
For example:
`    return Queue('myqueue', {
        redis: {
            opts: {
                createClient: function() {
                    return new ioredis({
                       "name": "my-redis",
                       "sentinels": [
                          {
                               "host": "redis-a.xyz.com",
                               "port": 26379
                          },
                          {
                              "host": "redis-b.xyz.com",
                              "port": 26379
                          },
                          {
                               "host": "redis-c.xyz.com",
                               "port": 26379
                          }
                       ]
                    });
                }
            }
        }
    });`