### PR TITLE
Restore old way of invoking custom createClient function

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -98,7 +98,7 @@ var Queue = function Queue(name, redisPort, redisHost, redisOptions){
   function createClient() {
     var client;
     if(_.isFunction(redisOptions.createClient)){
-      client = new redisOptions();
+      client = redisOptions.createClient();
     }else{
       client = new redis(redisPort, redisHost, redisOptions);
     }


### PR DESCRIPTION
It seems https://github.com/OptimalBits/bull/commit/dc5fac0d6b315fa8c387b1b8b7dba589ede3399b#diff-b68fbb0f945cdf9cddec65ddf0fbe456R98 unintentionally broke the use of a custom createClient function. I am guessing this was done via search/replace.