### PR TITLE
Implemented #190

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -180,7 +180,7 @@ Job.prototype.delayIfNeeded = function(){
 
 Job.prototype.moveToCompleted = function(returnValue){
   this.returnvalue = returnValue || 0;
-  return scripts.moveToCompleted(this, this.opts.removeOnComplete);
+  return scripts.moveToCompleted(this, this.returnvalue, this.opts.removeOnComplete);
 };
 
 Job.prototype.move = function(src, target, returnValue){
@@ -218,7 +218,7 @@ Job.prototype.moveToFailed = function(err, noReleaseLock){
       });
     } else {
       // If not, move to failed
-      promise = _this._moveToSet('failed');
+      promise = scripts.moveToFailed(_this, err.message, _this.opts.removeOnFail);
     }
     return promise.then(function(){
       if(!noReleaseLock){
@@ -437,8 +437,8 @@ Job.prototype.finished = function(){
 // -----------------------------------------------------------------------------
 Job.prototype._isDone = function(list){
   return this.queue.client
-    .sismember(this.queue.toKey(list), this.jobId).then(function(isMember){
-      return isMember === 1;
+    .zscore(this.queue.toKey(list), this.jobId).then(function(score){
+      return score !== null;
     });
 };
 
@@ -515,7 +515,6 @@ Job.prototype._saveAttempt = function(err){
 
   this.stacktrace.push(err.stack);
   params.stacktrace = JSON.stringify(this.stacktrace);
-
   params.failedReason = err.message;
 
   return this.queue.client.hmset(this.queue.toKey(this.jobId), params);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -726,7 +726,6 @@ Queue.prototype.processJob = function(job){
 
     stopTimer();
 
-    // TODO: Should moveToFailed ensure the lock atomically in one of its Lua scripts?
     // See https://github.com/OptimalBits/bull/pull/415#issuecomment-269744735
     job.takeLock(true /* renew */, false /* ensureActive */).then( function(/*lock*/) {
       return job.moveToFailed(err).finally(function(){
@@ -858,8 +857,6 @@ Queue.prototype.getJobCountByTypes = function() {
     switch(type) {
       case 'completed':
       case 'failed':
-        multi.scard(key);
-        break;
       case 'delayed':
         multi.zcard(key);
         break;
@@ -890,8 +887,8 @@ Queue.prototype.getJobCounts = function(){
   return this.client.multi()
     .llen(this.toKey('wait'))
     .llen(this.toKey('active'))
-    .scard(this.toKey('completed'))
-    .scard(this.toKey('failed'))
+    .zcard(this.toKey('completed'))
+    .zcard(this.toKey('failed'))
     .zcard(this.toKey('delayed'))
     .exec().then(function(result){
       result.forEach(function(res, index){
@@ -902,11 +899,11 @@ Queue.prototype.getJobCounts = function(){
 };
 
 Queue.prototype.getCompletedCount = function() {
-  return this.client.scard(this.toKey('completed'));
+  return this.client.zcard(this.toKey('completed'));
 };
 
 Queue.prototype.getFailedCount = function() {
-  return this.client.scard(this.toKey('failed'));
+  return this.client.zcard(this.toKey('failed'));
 };
 
 Queue.prototype.getDelayedCount = function() {
@@ -942,11 +939,11 @@ Queue.prototype.getDelayed = function(/*start, end*/){
 };
 
 Queue.prototype.getCompleted = function(){
-  return this.getJobs('completed', 'SET');
+  return this.getJobs('completed', 'ZSET');
 };
 
 Queue.prototype.getFailed = function(){
-  return this.getJobs('failed', 'SET');
+  return this.getJobs('failed', 'ZSET');
 };
 
 Queue.prototype.getJobs = function(queueType, type, start, end){
@@ -960,17 +957,6 @@ Queue.prototype.getJobs = function(queueType, type, start, end){
   switch(type){
     case 'LIST':
       jobs = this.client.lrange(key, start, end);
-      break;
-    case 'SET':
-      jobs = this.client.smembers(key).then(function(jobIds) {
-        // Can't set a range for smembers. So do the slice programatically instead.
-        // Note that redis ranges are inclusive, so handling for javascript accordingly
-        if (end === -1) {
-          return jobIds.slice(start);
-        }
-
-        return jobIds.slice(start, end + 1);
-      });
       break;
     case 'ZSET':
       jobs = this.client.zrange(key, start, end);
@@ -1004,32 +990,29 @@ Queue.prototype.toKey = function(queueType){
 Queue.prototype.clean = function (grace, type, limit) {
   var _this = this;
 
-  return new Promise(function (resolve, reject) {
-    if(grace === undefined || grace === null) {
-      return reject(new Error('You must define a grace period.'));
-    }
+  if(grace === undefined || grace === null) {
+    return Promise.reject(new Error('You must define a grace period.'));
+  }
 
-    if(!type) {
-      type = 'completed';
-    }
+  if(!type) {
+    type = 'completed';
+  }
 
-    if(_.indexOf([
-      'completed',
-      'wait',
-      'active',
-      'delayed',
-      'failed'], type) === -1){
-      return reject(new Error('Cannot clean unkown queue type'));
-    }
+  if(_.indexOf([
+    'completed',
+    'wait',
+    'active',
+    'delayed',
+    'failed'], type) === -1){
+    return Promise.reject(new Error('Cannot clean unkown queue type'));
+  }
 
-    return scripts.cleanJobsInSet(_this, type, Date.now() - grace, limit).then(function (jobs) {
-      _this.distEmit('cleaned', jobs, type);
-      resolve(jobs);
-      return null;
-    }).catch(function (err) {
-      _this.emit('error', err);
-      reject(err);
-    });
+  return scripts.cleanJobsInSet(_this, type, Date.now() - grace, limit).then(function (jobs) {
+    _this.distEmit('cleaned', jobs, type);
+    return jobs;
+  }).catch(function (err) {
+    _this.emit('error', err);
+    throw err;
   });
 };
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -15,9 +15,8 @@ var Redlock = require('bull-redlock');
 function execScript(client, hash, lua, numberOfKeys){
     var args = _.drop(arguments, 4);
 
-    debuglog(lua, args);
-
     if(!client[hash]){
+      debuglog(hash, lua, args);
       client.defineCommand(hash, { numberOfKeys: numberOfKeys, lua: lua });
     }
 
@@ -26,6 +25,14 @@ function execScript(client, hash, lua, numberOfKeys){
 
 function isCommandDefined(client, hash){
   return !!client[hash];
+}
+
+var path = require('path');
+var fs = require('fs');
+function loadScriptIfNeeded(queue, name){
+  if(!queue.client[name]){
+    return fs.readFileSync(path.join(__dirname, 'scripts/' + name + '.lua')).toString();
+  }
 }
 
 var scripts = {
@@ -164,7 +171,7 @@ var scripts = {
   // TODO: perfect this function so that it can be used instead
   // of all the specialized functions moveToComplete, etc.
   move: function(job, src, target){
-    // TODO: Depending on the source we should use LREM, SREM or ZREM.
+    // TODO: Depending on the source we should use LREM or ZREM.
     // TODO: Depending on the target we should use LPUSH, SADD, etc.
     var keys = _.map([
       src,
@@ -178,7 +185,7 @@ var scripts = {
     var deleteJob = 'redis.call("DEL", KEYS[3])';
 
     var moveJob = [
-      'redis.call("SADD", KEYS[2], ARGV[1])',
+      'redis.call("ZADD", KEYS[2], ARGV[3], ARGV[1])',
       'redis.call("HSET", KEYS[3], "returnvalue", ARGV[2])',
     ].join('\n');
 
@@ -201,7 +208,8 @@ var scripts = {
       keys[1],
       keys[2],
       job.jobId,
-      job.returnvalue ? JSON.stringify(job.returnvalue) : ''
+      job.returnvalue ? JSON.stringify(job.returnvalue) : '',
+      parseInt(job.timestamp)
     ];
 
     var returnLockOrErrorCode = function(lock) {
@@ -230,11 +238,57 @@ var scripts = {
         }
       });
   },
-  moveToCompleted: function(job, removeOnComplete){
+  _moveToCompleted: function(job, removeOnComplete){
     return scripts.move(job, 'active', removeOnComplete ? void 0 : 'completed');
   },
 
+  moveToFinished: function(job, val, propVal, shouldRemove, target, shouldLock){
+    var queue = job.queue;
+    var lua = loadScriptIfNeeded(queue, 'moveToFinished');
+
+     var keys = _.map([
+      'active',
+      target,
+      job.jobId], function(name){
+        return queue.toKey(name);
+      }
+    );
+
+    var args = [
+      queue.client,
+      'moveToFinished',
+      lua,
+      keys.length,
+      keys[0],
+      keys[1],
+      keys[2],
+      job.jobId,
+      Date.now(),
+      propVal,
+      val,
+      shouldRemove ? "1" : "0"
+    ];
+
+    if(shouldLock){
+      return wrapMove(job, function(){
+        return execScript.apply(scripts, args);
+      });
+    }else{
+      return execScript.apply(scripts, args);
+    }
+  },
+ 
+  moveToCompleted: function(job, returnvalue, removeOnComplete){
+    return scripts.moveToFinished(job, returnvalue, 'returnvalue', removeOnComplete, 'completed', true);
+  },
+
+  moveToFailed: function(job, failedReason, removeOnFailed){
+    return scripts.moveToFinished(job, failedReason, 'failedReason', removeOnFailed, 'failed');
+  },
+
   moveToSet: function(queue, set, jobId, context){
+    var lua = loadScriptIfNeeded(queue, 'moveToSet');
+
     //
     // Bake in the job id first 12 bits into the timestamp
     // to guarantee correct execution order of delayed jobs
@@ -264,7 +318,7 @@ var scripts = {
     var args = [
       queue.client,
       'moveToSet',
-      moveToSetScript,
+      lua,
       keys.length,
       keys[0],
       keys[1],
@@ -280,14 +334,8 @@ var scripts = {
     });
   },
   remove: function(queue, jobId){
-    var script = [
-      'redis.call("LREM", KEYS[1], 0, ARGV[1])',
-      'redis.call("LREM", KEYS[2], 0, ARGV[1])',
-      'redis.call("ZREM", KEYS[3], ARGV[1])',
-      'redis.call("LREM", KEYS[4], 0, ARGV[1])',
-      'redis.call("SREM", KEYS[5], ARGV[1])',
-      'redis.call("SREM", KEYS[6], ARGV[1])',
-      'redis.call("DEL", KEYS[7])'].join('\n');
+
+    var lua = loadScriptIfNeeded(queue, 'removeJob');
 
     var keys = _.map([
       'active',
@@ -303,8 +351,8 @@ var scripts = {
 
     var args = [
       queue.client,
-      'remove',
-      script,
+      'removeJob',
+      lua,
       keys.length,
       keys[0],
       keys[1],
@@ -384,27 +432,7 @@ var scripts = {
     top of the  wait queue (so that it will be processed as soon as possible)
   */
   updateDelaySet: function(queue, delayedTimestamp){
-    var script = [
-      'local RESULT = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")',
-      'local jobId = RESULT[1]',
-      'local score = RESULT[2]',
-      'if (score ~= nil) then',
-      ' score = score / 0x1000 ',
-      ' if (score <= tonumber(ARGV[2])) then',
-      '  redis.call("ZREM", KEYS[1], jobId)',
-      '  redis.call("LREM", KEYS[2], 0, jobId)',
-      '  redis.call("LPUSH", KEYS[3], jobId)',
-      '  redis.call("PUBLISH", KEYS[4], jobId)',
-      '  redis.call("HSET", ARGV[1] .. jobId, "delay", 0)',
-      '  local nextTimestamp = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")[2]',
-      '  if(nextTimestamp ~= nil) then',
-      '   nextTimestamp = nextTimestamp / 0x1000',
-      '   redis.call("PUBLISH", KEYS[1], nextTimestamp)',
-      '  end',
-      '  return nextTimestamp',
-      ' end',
-      ' return score',
-      'end'].join('\n');
+    var lua = loadScriptIfNeeded(queue, 'updateDelaySet');
 
     var keys = _.map([
       'delayed',
@@ -417,7 +445,7 @@ var scripts = {
     var args = [
       queue.client,
       'updateDelaySet',
-      script,
+      lua,
       keys.length,
       keys[0],
       keys[1],
@@ -447,49 +475,19 @@ var scripts = {
    *    timing window in which it must occur.
    */
   moveUnlockedJobsToWait: function(queue){
-    var script = [
-      'local MAX_STALLED_JOB_COUNT = tonumber(ARGV[1])',
-      'local activeJobs = redis.call("LRANGE", KEYS[1], 0, -1)',
-      'local stalled = {}',
-      'local failed = {}',
-      'for _, job in ipairs(activeJobs) do',
-      ' local jobKey = ARGV[2] .. job',
-      ' if(redis.call("EXISTS", jobKey .. ":lock") == 0) then',
-      //  Remove from the active queue.
-      '   redis.call("LREM", KEYS[1], 1, job)',
-      '   local lockAcquired = redis.call("HGET", jobKey, "lockAcquired")',
-      '   if(lockAcquired) then',
-      //    If it was previously locked then we consider it 'stalled' (Case A above). If this job
-      //    has been stalled too many times, such as if it crashes the worker, then fail it.
-      '     local stalledCount = redis.call("HINCRBY", jobKey, "stalledCounter", 1)',
-      '     if(stalledCount > MAX_STALLED_JOB_COUNT) then',
-      '       redis.call("SADD", KEYS[3], job)',
-      '       redis.call("HSET", jobKey, "failedReason", "job stalled more than allowable limit")',
-      '       table.insert(failed, job)',
-      '     else',
-      //      Move the job back to the wait queue, to immediately be picked up by a waiting worker.
-      '       redis.call("RPUSH", KEYS[2], job)',
-      '       table.insert(stalled, job)',
-      '     end',
-      '   else',
-      //    Move the job back to the wait queue, to immediately be picked up by a waiting worker.
-      '     redis.call("RPUSH", KEYS[2], job)',
-      '   end',
-      ' end',
-      'end',
-      'return {failed, stalled}'
-    ].join('\n');
-
+    var lua = loadScriptIfNeeded(queue, 'moveUnlockedJobsToWait');
+    
     var args = [
       queue.client,
       'moveUnlockedJobsToWait',
-      script,
+      lua,
       3,
       queue.toKey('active'),
       queue.toKey('wait'),
       queue.toKey('failed'),
       queue.MAX_STALLED_JOB_COUNT,
-      queue.toKey('')
+      queue.toKey(''),
+      Date.now()
     ];
 
     return execScript.apply(scripts, args);
@@ -503,12 +501,6 @@ var scripts = {
     limit = limit || 0;
 
     switch(set) {
-      case 'completed':
-      case 'failed':
-        command = 'local jobs = redis.call("SMEMBERS", KEYS[1])';
-        removeCommand = 'redis.call("SREM", KEYS[1], job)';
-        hash = 'cleanSet';
-        break;
       case 'wait':
       case 'active':
       case 'paused':
@@ -517,6 +509,8 @@ var scripts = {
         hash = 'cleanList';
         break;
       case 'delayed':
+      case 'completed':
+      case 'failed':
         command = 'local jobs = redis.call("ZRANGE", KEYS[1], 0, -1)';
         removeCommand = 'redis.call("ZREM", KEYS[1], job)';
         hash = 'cleanOSet';
@@ -589,7 +583,7 @@ var scripts = {
     var script = [
       'if (redis.call("EXISTS", KEYS[1]) == 1) then',
       '  if (redis.call("EXISTS", KEYS[2]) == 0) then',
-      '    if (redis.call("SREM", KEYS[3], ARGV[1]) == 1) then',
+      '    if (redis.call("ZREM", KEYS[3], ARGV[1]) == 1) then',
       '      redis.call("' + push + '", KEYS[4], ARGV[1])',
       '      redis.call("PUBLISH", KEYS[5], ARGV[1])',
       '      return 1',
@@ -668,47 +662,32 @@ var emptyScript = [
 
 ]
 
-  // this lua script takes three keys and two arguments
-  // keys:
-  //  - the expanded key for the active set
-  //  - the expanded key for the destination set
-  //  - the expanded key for the job
-  //
-  // arguments:
-  //  - json serialized context which is:
-  //     - delayedTimestamp when the destination set is 'delayed'
-  //     - stacktrace when the destination set is 'failed'
-  //     - returnvalue of the handler when the destination set is 'completed'
-  //  - the id of the job
-  //
-  // it checks whether KEYS[2] the destination set ends with 'delayed', 'completed'
-  // or 'failed'. And then adds the context to the jobhash and adds the job to
-  // the destination set. Finally it removes the job from the active list.
-  //
-  // it returns either 0 for success or -1 for failure.
-var moveToSetScript = [
-  'if redis.call("EXISTS", KEYS[3]) == 1 then',
-  ' if string.find(KEYS[2], "delayed$") ~= nil then',
-  ' local score = tonumber(ARGV[1])',
-  '  if score ~= 0 then',
-  '   redis.call("ZADD", KEYS[2], score, ARGV[2])',
-  '   redis.call("PUBLISH", KEYS[2], (score / 0x1000))',
-  '  else',
-  '   redis.call("SADD", KEYS[2], ARGV[2])',
-  '  end',
-  ' elseif string.find(KEYS[2], "completed$") ~= nil then',
-  '  redis.call("HSET", KEYS[3], "returnvalue", ARGV[1])',
-  '  redis.call("SADD", KEYS[2], ARGV[2])',
-  ' elseif string.find(KEYS[2], "failed$") ~= nil then',
-  '  redis.call("SADD", KEYS[2], ARGV[2])',
-  ' else',
-  '  return -1',
-  ' end',
-  ' redis.call("LREM", KEYS[1], 0, ARGV[2])',
-  ' return 0',
-  'else',
-  ' return -1',
-  'end'
-  ].join('\n');
-
 module.exports = scripts;
+
+function wrapMove(job, move){
+  var returnLockOrErrorCode = function(lock) {
+    return lock ? move() : -2;
+  };
+  var throwUnexpectedErrors = function(err) {
+    if (!(err instanceof Redlock.LockError)) {
+      throw err;
+    }
+  };
+
+  return job.takeLock(!!job.lock)
+    .then(returnLockOrErrorCode, throwUnexpectedErrors)
+    .then(function(result){
+      switch (result){
+        case -1:
+          if(src){
+            throw new Error('Missing Job ' + job.jobId + ' when trying to move from ' + src + ' to ' + target);
+          } else {
+            throw new Error('Missing Job ' + job.jobId + ' when trying to remove it from ' + src);
+          }
+        case -2:
+          throw new Error('Cannot get lock for job ' + job.jobId + ' when trying to move from ' + src);
+        default:
+          return job.releaseLock();
+      }
+    });
+}

--- a/lib/scripts/index.js
+++ b/lib/scripts/index.js
@@ -1,0 +1,36 @@
+/**
+ * Load redis lua scripts.
+ * The name of the script must have the following format:
+ * 
+ * cmdName-numKeys.lua
+ * 
+ * cmdName must be in camel case format.
+ * 
+ * For example:
+ * moveToFinish-3.lua
+ * 
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+//
+// for some very strange reason, defining scripts with this code results in this error
+// when executing the scripts: ERR value is not an integer or out of range
+//
+module.exports = function(client){
+  loadScripts(client, __dirname);
+}
+
+function loadScripts(client, dir) {
+  fs.readdirSync(dir).filter(function (file) {
+    return path.extname(file) === '.lua';
+  }).forEach(function (file) {
+    var longName = path.basename(file, '.lua');
+    var name = longName.split('-')[0];
+    var numberOfKeys = longName.split('-')[1];
+
+    var lua = fs.readFileSync(path.join(dir, file)).toString();
+    client.defineCommand(name, { numberOfKeys: numberOfKeys, lua: lua });
+  });
+};

--- a/lib/scripts/moveToFinished.lua
+++ b/lib/scripts/moveToFinished.lua
@@ -1,0 +1,41 @@
+--[[
+  Move job from active to a finished status (completed o failed)
+  A job can only be moved to completed if it was active.
+
+     Input:
+      KEYS[1] active key
+      KEYS[2] completed/failed key
+      KEYS[3] jobId key
+
+      ARGV[1]  jobId
+      ARGV[2]  timestamp
+      ARGV[3]  msg property
+      ARGV[4]  return value / failed reason
+      ARGV[5]  shouldRemove
+      ARGV[6]  event channel
+      ARGV[7]  event data (? maybe just send jobid).
+
+     Output:
+      0 OK
+      1 Missing key.
+
+     Events:
+      'completed'
+]]
+if redis.call("EXISTS", KEYS[3]) == 1 then -- // Make sure job exists
+  redis.call("LREM", KEYS[1], -1, ARGV[1])
+
+  -- Remove job?
+  if ARGV[5] == "1" then
+    redis.call("DEL", KEYS[3])
+  else
+    redis.call("ZADD", KEYS[2], ARGV[2], ARGV[1])
+    redis.call("HSET", KEYS[3], ARGV[3], ARGV[4]) -- "returnvalue" / "failedReason"
+  end
+
+  -- TODO PUBLISH EVENT, this is the most optimal way.
+  --redis.call("PUBLISH", ...)
+  return 0
+else
+  return -1
+end

--- a/lib/scripts/moveToSet.lua
+++ b/lib/scripts/moveToSet.lua
@@ -1,0 +1,42 @@
+--[[this lua script takes three keys and two arguments
+  // keys:
+  //  - the expanded key for the active set
+  //  - the expanded key for the destination set
+  //  - the expanded key for the job
+  //
+  // arguments:
+  //  ARGV[1] json serialized context which is:
+  //     - delayedTimestamp when the destination set is 'delayed'
+  //     - stacktrace when the destination set is 'failed'
+  //     - returnvalue of the handler when the destination set is 'completed'
+  //  ARGV[2] the id of the job
+  //  ARGV[3] timestamp
+  //
+  // it checks whether KEYS[2] the destination set ends with 'delayed', 'completed'
+  // or 'failed'. And then adds the context to the jobhash and adds the job to
+  // the destination set. Finally it removes the job from the active list.
+  //
+  // it returns either 0 for success or -1 for failure.
+]]
+if redis.call("EXISTS", KEYS[3]) == 1 then
+  if string.find(KEYS[2], "delayed$") ~= nil then
+    local score = tonumber(ARGV[1])
+    if score ~= 0 then
+      redis.call("ZADD", KEYS[2], score, ARGV[2])
+      redis.call("PUBLISH", KEYS[2], (score / 0x1000))
+    else
+      redis.call("ZADD", KEYS[2], ARGV[3], ARGV[2])
+    end
+  elseif string.find(KEYS[2], "completed$") ~= nil then
+    redis.call("HSET", KEYS[3], "returnvalue", ARGV[1])
+    redis.call("ZADD", KEYS[2], ARGV[3], ARGV[2])
+   elseif string.find(KEYS[2], "failed$") ~= nil then
+    redis.call("ZADD", KEYS[2], ARGV[3], ARGV[2])
+   else
+    return -1
+   end
+   redis.call("LREM", KEYS[1], 0, ARGV[2])
+   return 0
+  else
+   return -1
+end

--- a/lib/scripts/moveUnlockedJobsToWait.lua
+++ b/lib/scripts/moveUnlockedJobsToWait.lua
@@ -1,0 +1,56 @@
+--[[ 
+  Looks for unlocked jobs in the active queue. There are two circumstances in which a job
+   would be in 'active' but NOT have a job lock:
+   
+     Case A) The job was being worked on, but the worker process died and it failed to renew the lock.
+       We call these jobs 'stalled'. This is the most common case. We resolve these by moving them
+       back to wait to be re-processed. To prevent jobs from cycling endlessly between active and wait,
+       (e.g. if the job handler keeps crashing), we limit the number stalled job recoveries to MAX_STALLED_JOB_COUNT.
+
+     Case B) The job was just moved to 'active' from 'wait' and the worker that moved it hasn't gotten
+       a lock yet, or died immediately before getting the lock (note that due to Redis limitations, the
+       worker can't move the job and get the lock atomically - https://github.com/OptimalBits/bull/issues/258).
+       For this case we also move the job back to 'wait' for reprocessing, but don't consider it 'stalled'
+       since the job had never been started. This case is much rarer than Case A due to the very small
+       timing window in which it must occur.
+
+    Input:
+      KEYS[1] 'active',
+      KEYS[2] 'wait',
+      KEYS[3] 'failed',
+
+      ARGV[1]  Max stalled job count
+      ARGV[2]  queue.toKey('')
+      ARGV[3]  timestamp
+]]
+local MAX_STALLED_JOB_COUNT = tonumber(ARGV[1])
+local activeJobs = redis.call("LRANGE", KEYS[1], 0, -1)
+local stalled = {}
+local failed = {}
+for _, job in ipairs(activeJobs) do
+
+  local jobKey = ARGV[2] .. job
+  if(redis.call("EXISTS", jobKey .. ":lock") == 0) then
+      --  Remove from the active queue.
+    redis.call("LREM", KEYS[1], 1, job)
+    local lockAcquired = redis.call("HGET", jobKey, "lockAcquired")
+    if(lockAcquired) then
+      --    If it was previously locked then we consider it 'stalled' (Case A above). If this job
+      --    has been stalled too many times, such as if it crashes the worker, then fail it.
+      local stalledCount = redis.call("HINCRBY", jobKey, "stalledCounter", 1)
+      if(stalledCount > MAX_STALLED_JOB_COUNT) then
+        redis.call("ZADD", KEYS[3], ARGV[3], job)
+        redis.call("HSET", jobKey, "failedReason", "job stalled more than allowable limit")
+        table.insert(failed, job)
+      else
+      --      Move the job back to the wait queue, to immediately be picked up by a waiting worker.
+        redis.call("RPUSH", KEYS[2], job)
+        table.insert(stalled, job)
+      end
+    else
+    --    Move the job back to the wait queue, to immediately be picked up by a waiting worker.
+    redis.call("RPUSH", KEYS[2], job)
+    end
+  end
+end
+return {failed, stalled}

--- a/lib/scripts/removeJob.lua
+++ b/lib/scripts/removeJob.lua
@@ -1,0 +1,26 @@
+--[[
+  Move job from active to a finished status (completed o failed)
+  A job can only be moved to completed if it was active.
+
+     Input:
+      KEYS[1] 'active',
+      KEYS[2] 'wait',
+      KEYS[3] 'delayed',
+      KEYS[4] 'paused',
+      KEYS[5] 'completed',
+      KEYS[6] 'failed',
+      KEYS[7] jobId
+
+      ARGV[1]  jobId
+    
+     Events:
+      'removed'
+]]
+
+redis.call("LREM", KEYS[1], 0, ARGV[1])
+redis.call("LREM", KEYS[2], 0, ARGV[1])
+redis.call("ZREM", KEYS[3], ARGV[1])
+redis.call("LREM", KEYS[4], 0, ARGV[1])
+redis.call("ZREM", KEYS[5], ARGV[1])
+redis.call("ZREM", KEYS[6], ARGV[1])
+redis.call("DEL", KEYS[7])

--- a/lib/scripts/updateDelaySet.lua
+++ b/lib/scripts/updateDelaySet.lua
@@ -1,0 +1,35 @@
+--[[
+  Updates the delay set
+  
+     Input:
+      KEYS[1] 'delayed'
+      KEYS[2] 'active'
+      KEYS[3] 'wait'
+      KEYS[4] 'jobs' event channel
+
+      ARGV[1]  queue.toKey('')
+      ARGV[2]  delayed timestamp
+    
+     Events:
+      'removed'
+]]
+local RESULT = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")
+local jobId = RESULT[1]
+local score = RESULT[2]
+if (score ~= nil) then
+  score = score / 0x1000 
+  if (score <= tonumber(ARGV[2])) then
+    redis.call("ZREM", KEYS[1], jobId)
+    redis.call("LREM", KEYS[2], 0, jobId)
+    redis.call("LPUSH", KEYS[3], jobId)
+    redis.call("PUBLISH", KEYS[4], jobId)
+    redis.call("HSET", ARGV[1] .. jobId, "delay", 0)
+    local nextTimestamp = redis.call("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")[2]
+    if(nextTimestamp ~= nil) then
+      nextTimestamp = nextTimestamp / 0x1000
+      redis.call("PUBLISH", KEYS[1], nextTimestamp)
+    end
+    return nextTimestamp
+  end
+  return score
+end

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -399,7 +399,7 @@ describe('Job', function(){
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('completed');
-        return client.srem(queue.toKey('completed'), job.jobId);
+        return client.zrem(queue.toKey('completed'), job.jobId);
       }).then(function(){
         return job.moveToDelayed(Date.now() + 10000);
       }).then(function (){
@@ -419,7 +419,7 @@ describe('Job', function(){
         return job.getState();
       }).then(function(state) {
         expect(state).to.be('failed');
-        return client.srem(queue.toKey('failed'), job.jobId);
+        return client.zrem(queue.toKey('failed'), job.jobId);
       }).then(function(res) {
         expect(res).to.be(1);
         return job.getState();


### PR DESCRIPTION
This PR changes the completed and failed sets to be zsets. This allows us to efficiently get a subset of the completed or failed jobs, which is very useful for pagination on UIs, etc.
Along with this PR there are also some refactoring, for instance I started to move the LUA scripts to separate files, which is much more cleaner and convenient than what we have today.