### PR TITLE
Fix regression where lock where lock renewer wasn't stopped immediate…

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -686,7 +686,7 @@ Queue.prototype.processJob = function(job){
   // by another worker. See #308
   //
   var lockExtender = function(){
-    _this.timers.set('lockExtender', _this.LOCK_RENEW_TIME, function(){
+    lockRenewId = _this.timers.set('lockExtender', _this.LOCK_RENEW_TIME, function(){
       if(!timerStopped){
         scripts.extendLock(_this, job.id).then(function(lock){
           if(lock){

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -687,15 +687,13 @@ Queue.prototype.processJob = function(job){
   //
   var lockExtender = function(){
     lockRenewId = _this.timers.set('lockExtender', _this.LOCK_RENEW_TIME, function(){
-      if(!timerStopped){
-        scripts.extendLock(_this, job.id).then(function(lock){
-          if(lock){
-            lockExtender();
-          }
-        });
-      }
+      scripts.extendLock(_this, job.id).then(function(lock){
+        if(lock && !timerStopped){
+          lockExtender();
+        }
+      });
     });
-  }
+  };
 
   var timeoutMs = job.opts.timeout;
 


### PR DESCRIPTION
…ly when the job completed. This wasn't a functional regression though (hence why it didn't fail any tests) because `timerStopped` prevented the timer from running again.