### PR TITLE
Optimization: when removing from the wait list, start from the right …

### DIFF
--- a/lib/commands/moveToActive-4.lua
+++ b/lib/commands/moveToActive-4.lua
@@ -25,7 +25,7 @@ if jobId then
   
   -- get a the lock
   redis.call("SET", lockKey, ARGV[2], "PX", ARGV[3])
-  redis.call("LREM", KEYS[1], 1, jobId) -- remove from wait
+  redis.call("LREM", KEYS[1], -1, jobId) -- remove from wait
   redis.call("ZREM", KEYS[3], jobId) -- remove from priority
   redis.call("LPUSH", KEYS[2], jobId) -- push in active
 


### PR DESCRIPTION
…side where the job is. This should reduce Redis CPU.

We're using Bull 3.0 in production (working great so far!), but we're noticing that Redis CPU is proportional to the number of jobs in `wait` (below: BytesUsedForCache at 400MB is about 400k jobs in `wait`): 
![image](https://cloud.githubusercontent.com/assets/821706/26505732/c4602a32-41fe-11e7-8d38-ab3dc92c504a.png)

This hopefully fixes it. I can't think of any other place where were iterate the `wait` queue - can you?
