### PR TITLE
Fix promise not returned

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -783,6 +783,7 @@ Queue.prototype.processJob = function(job){
 
     return job.moveToCompleted(result).then(function(){
       _this.emit('completed', job, result, 'active');
+      return null;
     });
   }
 
@@ -791,6 +792,7 @@ Queue.prototype.processJob = function(job){
 
     return job.moveToFailed(err).then(function(){
       _this.emit('failed', job, error, 'active');
+      return null;
     });
   }
 


### PR DESCRIPTION
This is a suggested fix to the error: 
```
Warning: a promise was created in a handler at Users/juanborreguero/dev/UpdateStaticData-Dispatcher/node_modules/bull/lib/queue.js:779:13 but was not returned from it, see http://goo.gl/rRqMUw
```
I had that when handling the:
- .on('completed', ...);
- .on('failed', ...);
events.

Feel free to comment or to fix it otherwise.
Thanks for the great job, guys.