### PR TITLE
[proof of concept] eliminate duplicate moveToActive calls

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -118,6 +118,8 @@ var Queue = function Queue(name, url, opts){
   this.keyPrefix = redisOpts.keyPrefix || opts.prefix || 'bull';
   this.token = uuid();
 
+  this.numAdded = 0;
+
   //
   // We cannot use ioredis keyPrefix feature since we
   // create keys dynamically in lua scripts.
@@ -468,9 +470,39 @@ function nextRepeatableJob(queue, name, data, opts){
 
 Queue.prototype.start = function(concurrency){
   var _this = this;
-  return this.run(concurrency).catch(function(err){
-    _this.emit('error', err, 'error running queue');
-    throw err;
+
+  for (var i = 0; i < concurrency; i++) {
+    _this.maybeProcessJob(concurrency);
+  }
+
+  var addedListener = function() {
+    _this.maybeProcessJob(concurrency);
+  };
+
+  this.on('added', addedListener);
+};
+
+Queue.prototype.maybeProcessJob = function(concurrency){
+  var _this = this;
+
+  // if beyond concurrency, noop
+  if (_this.numAdded >= concurrency) {
+    return;
+  }
+
+  _this.numAdded++;
+
+  scripts.moveToActive(_this).spread(function(jobData, jobId){
+    if(jobData){
+      var job = Job.fromData(_this, jobData, jobId);
+      return _this.processJob(job).then(function() {
+        process.nextTick(function() {
+          _this.maybeProcessJob(concurrency);
+        });
+      });
+    }
+  }).finally(function() {
+    _this.numAdded--;
   });
 };
 


### PR DESCRIPTION
With regards to: https://github.com/OptimalBits/bull/issues/557

I took @bradvogel's idea of having the queue itself listen for added job events. This way, we do not have `moveToActive` called `concurrency` times on every `Job.process` call.