### PR TITLE
fix(queue): fix calculation for next repeat job

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -419,14 +419,16 @@ Queue.prototype.process = function(name, concurrency, handler){
 //
 var parser = require('cron-parser');
 
-function nextRepeatableJob(queue, name, data, opts){
+function nextRepeatableJob(queue, name, data, opts, isRepeat){
   var repeat = opts.repeat;
   var repeatKey = queue.toKey('repeat') + ':' + name + ':' + repeat.cron;
 
   //
   // Get millis for this repeatable job.
+  // Only use `millis` from the `repeatKey` when the job is a repeat, otherwise, we want
+  // `Date.now()` to ensure we try to add the next iteration only
   //
-  return queue.client.get(repeatKey).then(function(millis){
+  return (isRepeat ? queue.client.get(repeatKey) : Promise.resolve(Date.now())).then(function(millis){
     if(millis){
       return parseInt(millis);
     }else{
@@ -442,10 +444,10 @@ function nextRepeatableJob(queue, name, data, opts){
     } catch(e){
       // Ignore error
     }
-    
+
     if(nextMillis){
       nextMillis = nextMillis.getTime();
-      var delay = nextMillis - millis;
+      var delay = nextMillis - Date.now();
 
       //
       // Generate unique job id for this iteration.
@@ -856,7 +858,7 @@ Queue.prototype.getNextJob = function() {
     if(jobData){
       var job = Job.fromData(_this, jobData, jobId);
       if(job.opts.repeat){
-        return nextRepeatableJob(_this, job.name, job.data, job.opts).then(function(){
+        return nextRepeatableJob(_this, job.name, job.data, job.opts, true).then(function(){
           return job;
         });
       }


### PR DESCRIPTION
Fix `delay` calculation. Previously, it would not work if `queue.add` was called multiple times, since the delay would always be the interval length instead of the amount of time from now to the next call.

Add `isRepeat` flag to change which iteration is calculated. Only calculate based on queue `millis` when we repeat to get the next job, otherwise use the current time so the immediate next interval is used.

Not sure if the `isRepeat` flag is the best way to handle this, but I think there needs to be a differentiation between calling `queue.add` and adding the next repetition of the job.

Addresses #558 