### PR TITLE
Lazily initialize redis clients, reduce side effects of `Queue` instantiation

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,14 +1,14 @@
 /**
  * Load redis lua scripts.
  * The name of the script must have the following format:
- * 
+ *
  * cmdName-numKeys.lua
- * 
+ *
  * cmdName must be in camel case format.
- * 
+ *
  * For example:
  * moveToFinish-3.lua
- * 
+ *
  */
 'use strict';
 
@@ -27,19 +27,16 @@ module.exports = function(client){
 };
 
 function loadScripts(client, dir) {
-  return fs.readdirAsync(dir).then(function(files){
-    return Promise.all(files.filter(function (file) {
-      return path.extname(file) === '.lua';
-    }).map(function (file) {
-      var longName = path.basename(file, '.lua');
-      var name = longName.split('-')[0];
-      var numberOfKeys = parseInt(longName.split('-')[1]);
+  return fs.readdirAsync(dir).filter(function (file) {
+    return path.extname(file) === '.lua';
+  })
+  .map(function (file) {
+    var longName = path.basename(file, '.lua');
+    var name = longName.split('-')[0];
+    var numberOfKeys = parseInt(longName.split('-')[1]);
 
-      return fs.readFileAsync(path.join(dir, file)).then(function(lua){
-        client.defineCommand(name, { numberOfKeys: numberOfKeys, lua: lua.toString() });
-      }, function(err){
-        console.error('Error reading script file', err);
-      });
-    }));
+    return fs.readFileAsync(path.join(dir, file)).then(function(lua) {
+      client.defineCommand(name, { numberOfKeys: numberOfKeys, lua: lua.toString() });
+    });
   });
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -17,7 +17,7 @@ var semver = require('semver');
 var debuglog = require('debuglog')('bull');
 var uuid = require('uuid');
 
-var commands = require('./commands/');
+var commands = require('./commands');
 
 
 /**
@@ -92,55 +92,64 @@ var Queue = function Queue(name, url, opts){
     throw Error('Options must be a valid object');
   }
 
-  var redisOpts = opts.redis || {};
+  this.name = name;
+  this.token = uuid();
 
-  _.defaults(redisOpts, {
+  opts.redis = opts.redis || {};
+
+  _.defaults(opts.redis, {
     port: 6379,
     host: '127.0.0.1',
-    db: redisOpts.db || redisOpts.DB,
+    db: opts.redis.db || opts.redis.DB,
     retryStrategy: function (times) {
-      var delay = Math.min(Math.exp(times), 20000);
-      return delay;
+      return Math.min(Math.exp(times), 20000);
     }
   });
 
-  function createClient(type, redisOpts) {
-    var client;
-    if(_.isFunction(opts.createClient)){
-      client = opts.createClient(type, redisOpts);
-    }else{
-      client = new redis(redisOpts);
-    }
-    return client;
-  }
-
-  this.name = name;
-  this.keyPrefix = redisOpts.keyPrefix || opts.prefix || 'bull';
-  this.token = uuid();
+  this.keyPrefix = opts.redis.keyPrefix || opts.prefix || 'bull';
 
   //
   // We cannot use ioredis keyPrefix feature since we
   // create keys dynamically in lua scripts.
   //
-  delete redisOpts.keyPrefix;
+  delete opts.redis.keyPrefix;
 
-  //
-  // Create queue client (used to add jobs, pause queues, etc);
-  //
-  this.client = createClient('client', redisOpts);
+  var lazyClient = redisClientGetter(opts, function (type, client) {
+    // bubble up Redis error events
+    client.on('error', _this.emit.bind(_this, 'error'));
 
-  getRedisVersion(this.client).then(function(version){
-    if(semver.lt(version, MINIMUM_REDIS_VERSION)){
-      throw new Error('Redis version needs to be greater than ' + MINIMUM_REDIS_VERSION + '. Current: ' + version);
+    if (type === 'client') {
+      _this._initializing = commands(client).then(function(){
+        debuglog(name + ' queue ready');
+      }, function(err){
+        _this.emit('error', new Error('Error initializing Lua scripts'));
+        throw err;
+      });
     }
-  }).catch(function(err){
-    _this.emit('error', err);
   });
 
-  //
-  // Create event subscriber client (receive messages from other instance of the queue)
-  //
-  this.eclient = createClient('subscriber', redisOpts);
+  Object.defineProperties(this, {
+    //
+    // Queue client (used to add jobs, pause queues, etc);
+    //
+    client: {
+      get: lazyClient('client')
+    },
+    //
+    // Event subscriber client (receive messages from other instance of the queue)
+    //
+    eclient: {
+      get: lazyClient('subscriber')
+    }
+  });
+
+  if (opts.skipVersionCheck !== true) {
+    getRedisVersion(this.client).then(function(version){
+      if (semver.lt(version, MINIMUM_REDIS_VERSION)){
+        _this.emit('error', new Error('Redis version needs to be greater than ' + MINIMUM_REDIS_VERSION + '. Current: ' + version));
+      }
+    });
+  }
 
   this.handlers = {};
   this.delayTimer;
@@ -155,26 +164,16 @@ var Queue = function Queue(name, url, opts){
     retryProcessDelay: 5000
   });
 
-  this.settings.lockRenewTime = this.settings.lockRenewTime || this.settings.lockDuration / 2; 
-
-  // bubble up Redis error events
-  [this.client, this.eclient].forEach(function (client) {
-    client.on('error', _this.emit.bind(_this, 'error'));
-  });
+  this.settings.lockRenewTime = this.settings.lockRenewTime || this.settings.lockDuration / 2;
 
   this.on('error', function(){
     // Dummy handler to avoid process to exit with an unhandled exception.
   });
-    
+
   // keeps track of active timers. used by close() to
   // ensure that disconnect() is deferred until all
   // scheduled redis commands have been executed
   this.timers = new TimerManager();
-
-  //
-  // Init
-  //
-  this._init(name);
 
   // Bind these methods to avoid constant rebinding and/or creating closures
   // in processJobs etc.
@@ -182,6 +181,22 @@ var Queue = function Queue(name, url, opts){
   this.processJob = this.processJob.bind(this);
   this.getJobFromId = Job.fromId.bind(null, this);
 };
+
+function redisClientGetter(options, initCallback) {
+  var createClient = _.isFunction(options.createClient)
+      ? options.createClient
+      : function(type, config) { return new redis(config); };
+
+  var connections = {};
+
+  return function (type) {
+    return function() { // getter function
+      if (connections[type] != null) return connections[type];
+      var client = connections[type] = createClient(type, options.redis);
+      return initCallback(type, client), client;
+    };
+  };
+}
 
 function redisOptsFromUrl(urlString){
   var redisOpts = {};
@@ -234,17 +249,6 @@ Queue.prototype.once = function(eventName){
   return this._registerEvent(eventName);
 };
 
-Queue.prototype._init = function(name){
-  var _this = this;
-
-  _this._initializing = commands(_this.client).then(function(){
-    debuglog(name + ' queue ready');
-  }, function(err){
-    _this.emit('error', err, 'Error initializing queue');
-    throw err;
-  });
-};
-
 Queue.prototype._initProcess = function(){
   var _this = this;
   if(!this._initializingProcess){
@@ -254,7 +258,7 @@ Queue.prototype._initProcess = function(){
 
     //
     // Only setup listeners if .on/.addEventListener called, or process function defined.
-    // 
+    //
     this.delayedTimestamp = Number.MAX_VALUE;
     this._initializingProcess = this.isReady().then(function(){
       return Promise.join(
@@ -305,7 +309,7 @@ Queue.prototype._setupQueueEventListeners = function(){
     var keyAndToken = channel.split('@');
     var key = keyAndToken[0];
     var token = keyAndToken[1];
-    
+
     switch(key){
       case activeKey:
         _this.emit('global:active', message, 'waiting');
@@ -557,7 +561,7 @@ Queue.prototype.setHandler = function(name, handler){
   if(this.handlers[name]) {
     throw new Error('Cannot define the same handler twice ' + name);
   }
-  
+
   handler = handler.bind(this);
 
   if(handler.length > 1){
@@ -685,7 +689,7 @@ Queue.prototype.resume = function(isLocal /* Optional */){
         _this.resumeLocal();
       }
     }else{
-      return scripts.pause(_this, false); 
+      return scripts.pause(_this, false);
     }
   }).then(function(){
     _this.emit('resumed');
@@ -735,7 +739,7 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
           nextTimestamp = Number.MAX_VALUE;
         }
         _this.updateDelayTimer(nextTimestamp);
-      }).catch(function(err){ 
+      }).catch(function(err){
         _this.emit('error', err, 'Error updating the delay timer');
       });
       _this.delayedTimestamp = Number.MAX_VALUE;
@@ -975,13 +979,13 @@ Queue.prototype.getJobCountByTypes = function() {
       return v[1];
     }).reduce(function(a, b) {
       return a + b;
-    });	     
+    });
   }) || 0;
 };
 
 /**
  * Returns all the job counts for every list/set in the queue.
- * 
+ *
  */
 Queue.prototype.getJobCounts = function(){
   var types = ['waiting', 'active', 'completed', 'failed', 'delayed'];


### PR DESCRIPTION
Fixes #526

This PR ensures that the `client` and `eclient` redis connections are not instantiated until they are absolutely needed. This in turn reduces the number of bound event listeners by default.

Additionally, I have added a `skipVersionCheck` option which, when `true`, avoids creating a redis connection and sanity checking the `MINIMUM_REDIS_VERSION` in the constructor.