### PR TITLE
onCompleted on job.finished should capture result from queue process

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -315,18 +315,16 @@ Job.prototype.remove = function(){
 Job.prototype.finished = function(){
   var _this = this;
 
-  function getFailed(){
-    return Job.fromId(_this.queue, _this.id).then(function(job){
-      throw new Error(job.failedReason);
-    });
-  }
-
   return scripts.isFinished(_this).then(function(status){
     var finished = status > 0;
     if(finished){
-      if(status == 2){
-        return getFailed();
-      }
+      return Job.fromId(_this.queue, _this.id).then(function(job){
+        if(status == 2){
+          throw new Error(job.failedReason);
+        } else {
+          return  JSON.parse(job.returnvalue); 
+        }
+      });      
     }else{
       return new Promise(function(resolve, reject){
         var interval;

--- a/lib/job.js
+++ b/lib/job.js
@@ -330,9 +330,16 @@ Job.prototype.finished = function(){
     }else{
       return new Promise(function(resolve, reject){
         var interval;
-        function onCompleted(job){
+        function onCompleted(job, resultValue){
           if(String(job.id) === String(_this.id)){
-            resolve();
+            var result = undefined;
+            try{
+              result = JSON.parse(resultValue);
+            }catch (e){
+              //swallow exception because the resultValue got corrupted somehow.
+              debuglog('corrupted resultValue: ' + resultValue, e);
+            }
+            resolve(result);
             removeListeners();
           }
         }

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -453,6 +453,36 @@ describe('Job', function(){
       }).then(done, done);
     });
 
+    it('should resolve when the job has been completed and return object', function(done){
+      queue.process(function (job) {
+        return Promise.delay(500).then(function() {
+          return { resultFoo: 'bar' };
+        });
+      });
+      queue.add({ foo: 'bar' }).then(function(job){
+        return job.finished();
+      }).then(function(jobResult) {
+        expect(jobResult).to.be.an('object');
+        expect(jobResult.resultFoo).equal('bar');
+        done();
+      });
+    });
+
+    it('should resolve when the job has been completed and return string', function(done){
+      queue.process(function (job) {
+        return Promise.delay(500).then(function() {
+          return 'a string';
+        });
+      });
+      queue.add({ foo: 'bar' }).then(function(job){
+        return job.finished();
+      }).then(function(jobResult) {
+        expect(jobResult).to.be.an('string');
+        expect(jobResult).equal('a string');
+        done();
+      });
+    });
+
     it('should reject when the job has been failed', function(done){
       queue.process(function () {
         return Promise.delay(500).then(function(){


### PR DESCRIPTION
The result of a .process(), when exists, is always passed  on 'completed' event, so it's make sense to capture that value on onCompleted handler.

Now this should works:
```
service1Queue.add({hello: 'world'}).then(function(job) {
    return job.finished();
}).then(function(result) {
   // do something with result...
}).catch(function(err) {
   // catch err
})
```