### PR TITLE
Cache Lua scripts

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -22,12 +22,20 @@ fs = Promise.promisifyAll(fs);
 // for some very strange reason, defining scripts with this code results in this error
 // when executing the scripts: ERR value is not an integer or out of range
 //
-module.exports = function(client){
-  return loadScripts(client, __dirname);
-};
+module.exports = (function (){
+  var scripts;
 
-function loadScripts(client, dir) {
-  return fs.readdirAsync(dir).filter(function (file) {
+  return function(client){
+    scripts = scripts || loadScripts(__dirname);
+
+    return scripts.each(function (command){
+      client.defineCommand(command.name, command.options);
+    });
+  };
+})();
+
+function loadScripts(dir) {
+  return fs.readdirAsync(dir).filter(function (file){
     return path.extname(file) === '.lua';
   })
   .map(function (file) {
@@ -35,8 +43,11 @@ function loadScripts(client, dir) {
     var name = longName.split('-')[0];
     var numberOfKeys = parseInt(longName.split('-')[1]);
 
-    return fs.readFileAsync(path.join(dir, file)).then(function(lua) {
-      client.defineCommand(name, { numberOfKeys: numberOfKeys, lua: lua.toString() });
+    return fs.readFileAsync(path.join(dir, file)).then(function(lua){
+      return {
+        name: name,
+        options: { numberOfKeys: numberOfKeys, lua: lua.toString() }
+      };
     });
   });
 }

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -55,7 +55,7 @@ describe('Queue', function () {
     });
 
     it('should resolve the promise when each client has disconnected', function () {
-      expect(testQueue.client.status).to.be('ready');
+      expect(testQueue.client.status).to.be('connecting');
       expect(testQueue.eclient.status).to.be('connecting');
 
       return testQueue.close().then(function () {
@@ -283,7 +283,7 @@ describe('Queue', function () {
 
       expect(queueFoo.client).to.be.equal(client);
       expect(queueFoo.eclient).to.be.equal(subscriber);
-      
+
       expect(queueQux.client).to.be.equal(client);
       expect(queueQux.eclient).to.be.equal(subscriber);
 
@@ -357,7 +357,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
       }).catch(done);
-      
+
       queue.add({ foo: 'bar' }, {removeOnComplete: true}).then(function (job) {
         expect(job.id).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -380,7 +380,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         throw Error('error');
       }).catch(done);
-      
+
       queue.add({ foo: 'bar' }, {removeOnFail: true}).then(function (job) {
         expect(job.id).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -447,7 +447,7 @@ describe('Queue', function () {
           var currentPriority = 1;
           var counter = 0;
           var total = 0;
-          
+
           queue.process(function(job, jobDone){
             expect(job.id).to.be.ok();
             expect(job.data.p).to.be(currentPriority);
@@ -803,7 +803,7 @@ describe('Queue', function () {
             lockRenewTime: 10
           }
         });
-        
+
         for (var j = 0; j < NUM_JOBS_PER_QUEUE; j++) {
           jobs.push(queueStalled2.add({ job: j }));
         }
@@ -1744,7 +1744,7 @@ describe('Queue', function () {
           if (job.attemptsMade < 2) {
             throw new Error('Not yet!');
           }
-          
+
           jobDone();
         });
 


### PR DESCRIPTION
As a followup to #589, this PR caches the Lua scripts in memory so that file system calls can be avoided when creating many subsequent `Queue` clients.