### PR TITLE
Eliminate need for abstractions by exposing a better `getJobs` and `getJobCounts`

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -601,14 +601,7 @@ Queue.prototype.add = function(name, data, opts){
   Returns the number of jobs waiting to be processed.
 */
 Queue.prototype.count = function(){
-  var multi = this.multi();
-  multi.llen(this.toKey('wait'));
-  multi.llen(this.toKey('paused'));
-  multi.zcard(this.toKey('delayed'));
-
-  return multi.exec().then(function(res){
-    return Math.max(res[0][1], res[1][1]) + res[2][1];
-  });
+  return this.getJobCountByTypes('wait', 'paused', 'delayed');
 };
 
 /**
@@ -946,139 +939,127 @@ Queue.prototype.getJob = function(jobId){
   return Job.fromId(this, jobId);
 };
 
+Queue.prototype._commandByType = function(types, count, callback) {
+  var _this = this;
+
+  return _.map(types, function(type) {
+    type = type === 'waiting' ? 'wait' : type; // alias
+
+    var key = _this.toKey(type);
+
+    switch(type) {
+      case 'completed':
+      case 'failed':
+      case 'delayed':
+        return callback(key, count ? 'zcard' : 'zrange');
+      case 'active':
+      case 'wait':
+      case 'paused':
+        return callback(key, count ? 'llen' : 'lrange');
+    }
+  });
+};
+
 // Job counts by type
 // Queue#getJobCountByTypes('completed') => completed count
 // Queue#getJobCountByTypes('completed,failed') => completed + failed count
 // Queue#getJobCountByTypes('completed', 'failed') => completed + failed count
 // Queue#getJobCountByTypes('completed,waiting', 'failed') => completed + waiting + failed count
 Queue.prototype.getJobCountByTypes = function() {
-  var _this = this;
-  var args = _.compact(Array.prototype.slice.call(arguments));
-  var types = _.compact(args.join(',').replace(/ /g, '').split(','));
-
-  var multi = this.multi();
-
-  _.each(types, function(type) {
-    var key = _this.toKey(type);
-    switch(type) {
-      case 'completed':
-      case 'failed':
-      case 'delayed':
-        multi.zcard(key);
-        break;
-      case 'active':
-      case 'wait':
-      case 'paused':
-        multi.llen(key);
-        break;
-    }
+  return this.getJobCounts.apply(this, arguments).then(function(result){
+    return _.chain(result).values().sum().value();
   });
-
-  return multi.exec().then(function(res){
-    return res.map(function(v) {
-      return v[1];
-    }).reduce(function(a, b) {
-      return a + b;
-    });
-  }) || 0;
 };
 
 /**
- * Returns all the job counts for every list/set in the queue.
+ * Returns the job counts for each type specified or every list/set in the queue by default.
  *
  */
 Queue.prototype.getJobCounts = function(){
-  var types = ['waiting', 'active', 'completed', 'failed', 'delayed'];
-  var counts = {};
-  return this.client.multi()
-    .llen(this.toKey('wait'))
-    .llen(this.toKey('active'))
-    .zcard(this.toKey('completed'))
-    .zcard(this.toKey('failed'))
-    .zcard(this.toKey('delayed'))
-    .exec().then(function(result){
-      result.forEach(function(res, index){
-        counts[types[index]] = res[1] || 0;
-      });
-      return counts;
+  var types = parseTypeArg(arguments);
+  var multi = this.multi();
+
+  this._commandByType(types, true, function(key, command){
+    multi[command](key);
+  });
+
+  return multi.exec().then(function(res){
+    var counts = {};
+    res.forEach(function(res, index){
+      counts[types[index]] = res[1] || 0;
     });
+    return counts;
+  });
 };
 
 Queue.prototype.getCompletedCount = function() {
-  return this.client.zcard(this.toKey('completed'));
+  return this.getJobCountByTypes('completed');
 };
 
 Queue.prototype.getFailedCount = function() {
-  return this.client.zcard(this.toKey('failed'));
+  return this.getJobCountByTypes('failed');
 };
 
 Queue.prototype.getDelayedCount = function() {
-  return this.client.zcard(this.toKey('delayed'));
+  return this.getJobCountByTypes('delayed');
 };
 
 Queue.prototype.getActiveCount = function() {
-  return this.client.llen(this.toKey('active'));
+  return this.getJobCountByTypes('active');
 };
 
 Queue.prototype.getWaitingCount = function() {
-  return this.client.llen(this.toKey('wait'));
+  return this.getJobCountByTypes('wait');
 };
 
 Queue.prototype.getPausedCount = function() {
-  return this.client.llen(this.toKey('paused'));
+  return this.getJobCountByTypes('paused');
 };
 
 Queue.prototype.getWaiting = function(start, end){
-  return Promise.join(
-    this.getJobs('wait', 'LIST', true, start, end),
-    this.getJobs('paused', 'LIST', true, start, end)).spread(function(waiting, paused){
-      return _.concat(waiting, paused);
-    });
+  return this.getJobs([ 'wait', 'paused' ], start, end, true);
 };
 
 Queue.prototype.getActive = function(start, end){
-  return this.getJobs('active', 'LIST', true, start, end);
+  return this.getJobs('active', start, end, true);
 };
 
 Queue.prototype.getDelayed = function(start, end){
-  return this.getJobs('delayed', 'ZSET', true, start, end);
+  return this.getJobs('delayed', start, end, true);
 };
 
 Queue.prototype.getCompleted = function(start, end){
-  return this.getJobs('completed', 'ZSET', false, start, end);
+  return this.getJobs('completed', start, end, false);
 };
 
 Queue.prototype.getFailed = function(start, end){
-  return this.getJobs('failed', 'ZSET', false, start, end);
+  return this.getJobs('failed', start, end, false);
 };
 
-Queue.prototype.getJobs = function(queueType, type, asc, start, end){
+Queue.prototype.getJobs = function(types, start, end, asc){
   var _this = this;
-  var key = this.toKey(queueType);
-  var jobs;
 
   start = _.isUndefined(start) ? 0 : start;
   end = _.isUndefined(end) ? -1 : end;
 
-  switch(type){
-    case 'LIST':
-      if(asc){
-        jobs = this.client.lrange(key, -(end + 1), -(start + 1)).then(function(result){
-          return result.reverse();
-        });
-      }else{
-        jobs = this.client.lrange(key, start, end);
-      }
+  var resultByType = _this._commandByType(parseTypeArg(types), false, function(key, command){
+    switch(command){
+      case 'lrange':
+        if(asc){
+          return _this.client.lrange(key, -(end + 1), -(start + 1)).then(function(result){
+            return result.reverse();
+          });
+        }else{
+          return _this.client.lrange(key, start, end);
+        }
+      case 'zrange':
+        return asc ? _this.client.zrange(key, start, end) : _this.client.zrevrange(key, start, end);
+    }
+  });
 
-      break;
-    case 'ZSET':
-      jobs = asc ? this.client.zrange(key, start, end) : this.client.zrevrange(key, start, end);
-      break;
-  }
-
-  return jobs.then(function(jobIds){
-    var jobsFromId = jobIds.map(_this.getJobFromId);
-    return Promise.all(jobsFromId);
+  return Promise.all(resultByType).then(function(results){
+    var jobs = _.flatten(results).map(_this.getJobFromId);
+    return Promise.all(jobs);
   });
 };
 
@@ -1148,7 +1129,15 @@ Queue.prototype.whenCurrentJobsFinished = function(){
 //
 // Private local functions
 //
-var getRedisVersion = function getRedisVersion(client){
+function parseTypeArg(args) {
+  var types = _.chain([]).concat(args).join(',').split(/\s*,\s*/g).compact().value();
+
+  return types.length
+    ? types
+    : ['waiting', 'active', 'completed', 'failed', 'delayed'];
+}
+
+function getRedisVersion(client){
   return client.info().then(function(doc){
     var prefix = 'redis_version:';
     var lines = doc.split('\r\n');

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -283,7 +283,7 @@ describe('Queue', function () {
 
       expect(queueFoo.client).to.be.equal(client);
       expect(queueFoo.eclient).to.be.equal(subscriber);
-      
+
       expect(queueQux.client).to.be.equal(client);
       expect(queueQux.eclient).to.be.equal(subscriber);
 
@@ -357,7 +357,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
       }).catch(done);
-      
+
       queue.add({ foo: 'bar' }, {removeOnComplete: true}).then(function (job) {
         expect(job.id).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -380,7 +380,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         throw Error('error');
       }).catch(done);
-      
+
       queue.add({ foo: 'bar' }, {removeOnFail: true}).then(function (job) {
         expect(job.id).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -447,7 +447,7 @@ describe('Queue', function () {
           var currentPriority = 1;
           var counter = 0;
           var total = 0;
-          
+
           queue.process(function(job, jobDone){
             expect(job.id).to.be.ok();
             expect(job.data.p).to.be(currentPriority);
@@ -803,7 +803,7 @@ describe('Queue', function () {
             lockRenewTime: 10
           }
         });
-        
+
         for (var j = 0; j < NUM_JOBS_PER_QUEUE; j++) {
           jobs.push(queueStalled2.add({ job: j }));
         }
@@ -1249,7 +1249,7 @@ describe('Queue', function () {
               return null;
             });
 
-            var paused = queue.getJobCountByTypes(['paused','wait', 'delayed']).then(function (count) {
+            var paused = queue.getJobCountByTypes(['paused','wait','delayed']).then(function (count) {
               expect(count).to.be(10);
               return null;
             });
@@ -1744,7 +1744,7 @@ describe('Queue', function () {
           if (job.attemptsMade < 2) {
             throw new Error('Not yet!');
           }
-          
+
           jobDone();
         });
 
@@ -2133,7 +2133,7 @@ describe('Queue', function () {
       });
 
       queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', 'ZSET').then(function (jobs) {
+        queue.getJobs('completed').then(function (jobs) {
           expect(jobs).to.be.an(Array);
           expect(jobs).to.have.length(3);
           done();
@@ -2151,7 +2151,7 @@ describe('Queue', function () {
       });
 
       queue.on('failed', _.after(3, function () {
-        queue.getJobs('failed', 'ZSET').then(function (jobs) {
+        queue.getJobs('failed').then(function (jobs) {
           expect(jobs).to.be.an(Array);
           expect(jobs).to.have.length(3);
           done();
@@ -2169,7 +2169,7 @@ describe('Queue', function () {
       });
 
       queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', 'ZSET', true, 1, 2).then(function (jobs) {
+        queue.getJobs('completed', 1, 2, true).then(function (jobs) {
           expect(jobs).to.be.an(Array);
           expect(jobs).to.have.length(2);
           expect(jobs[0].data.foo).to.be.eql(2);
@@ -2191,7 +2191,7 @@ describe('Queue', function () {
       });
 
       queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', 'ZSET', true, -3, -1).then(function (jobs) {
+        queue.getJobs('completed', -3, -1, true).then(function (jobs) {
           expect(jobs).to.be.an(Array);
           expect(jobs).to.have.length(3);
           expect(jobs[0].data.foo).to.be.equal(1);
@@ -2212,12 +2212,31 @@ describe('Queue', function () {
       });
 
       queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', 'ZSET', true, -300, 99999).then(function (jobs) {
+        queue.getJobs('completed', -300, 99999, true).then(function (jobs) {
           expect(jobs).to.be.an(Array);
           expect(jobs).to.have.length(3);
           expect(jobs[0].data.foo).to.be.equal(1);
           expect(jobs[1].data.foo).to.be.eql(2);
           expect(jobs[2].data.foo).to.be.eql(3);
+          done();
+        }).catch(done);
+      }));
+
+      queue.add({ foo: 1 });
+      queue.add({ foo: 2 });
+      queue.add({ foo: 3 });
+    });
+
+    it('should return jobs for multiple types', function (done) {
+      queue.process(function (job, completed) {
+        completed();
+      });
+
+      queue.on('completed', _.after(2, function () {
+        queue.pause();
+        queue.getJobs(['completed','wait']).then(function (jobs) {
+          expect(jobs).to.be.an(Array);
+          expect(jobs).to.have.length(3);
           done();
         }).catch(done);
       }));


### PR DESCRIPTION
The goal of this PR is to consolidate all the logic for counting and listing various job sets. If this PR is merged, all the individual `getType()` and `getTypeCount()` can be considered deprecated as the user can now just use `getJobs([types])` and `getJobCounts(types...)` respectively.

The one breaking change is that the `asc` parameter of `getJobs()` is now the last optional parameter. This made more sense if `getJobs()` is to be considered a public API since most users won't care about the `asc` parameter.