### PR TITLE
Emit `drained` event when queue is empty

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -161,7 +161,8 @@ var Queue = function Queue(name, url, opts){
     stalledInterval: 30000,
     maxStalledCount: 1,
     guardInterval: 5000,
-    retryProcessDelay: 5000
+    retryProcessDelay: 5000,
+    drainDelay: 2000
   });
 
   this.settings.lockRenewTime = this.settings.lockRenewTime || this.settings.lockDuration / 2;
@@ -591,7 +592,7 @@ interface JobOptions
 */
 Queue.prototype.add = function(name, data, opts){
   if(opts && opts.repeat){
-    return nextRepeatableJob(this, name || DEFAULT_JOB_NAME, data, opts);
+    return nextRepeatableJob(this, name || Job.DEFAULT_JOB_NAME, data, opts);
   }else{
     return Job.create(this, name, data, opts);
   }
@@ -919,10 +920,8 @@ Queue.prototype.getNextJob = function() {
   //
   // Listen for new jobs, during moveToActive or after.
   //
-  var resolve;
-  var newJobs = new Promise(function(_resolve){
-    resolve = _resolve;
-    _this.on('newjobs', resolve);
+  var newJobs = new Promise(function(resolve){
+    _this.once('newjobs', resolve);
   });
 
   return scripts.moveToActive(this).spread(function(jobData, jobId){
@@ -935,10 +934,13 @@ Queue.prototype.getNextJob = function() {
       }
       return job;
     }else{
-      return newJobs;
+      return newJobs
+      .timeout(_this.settings.drainDelay)
+      .catch(Promise.TimeoutError, function(){
+        _this.emit('drained');
+        return newJobs;
+      });
     }
-  }).finally(function(){
-    _this.removeListener('newjobs', resolve);
   });
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -920,8 +920,10 @@ Queue.prototype.getNextJob = function() {
   //
   // Listen for new jobs, during moveToActive or after.
   //
+  var _resolve;
   var newJobs = new Promise(function(resolve){
-    _this.once('newjobs', resolve);
+    _resolve = resolve;
+    _this.once('newjobs', _resolve);
   });
 
   return scripts.moveToActive(this).spread(function(jobData, jobId){
@@ -941,6 +943,9 @@ Queue.prototype.getNextJob = function() {
         return newJobs;
       });
     }
+  })
+  .finally(function(){
+    _this.removeListener('newjobs', _resolve);
   });
 };
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -283,7 +283,7 @@ describe('Queue', function () {
 
       expect(queueFoo.client).to.be.equal(client);
       expect(queueFoo.eclient).to.be.equal(subscriber);
-      
+
       expect(queueQux.client).to.be.equal(client);
       expect(queueQux.eclient).to.be.equal(subscriber);
 
@@ -357,7 +357,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
       }).catch(done);
-      
+
       queue.add({ foo: 'bar' }, {removeOnComplete: true}).then(function (job) {
         expect(job.id).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -380,7 +380,7 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         throw Error('error');
       }).catch(done);
-      
+
       queue.add({ foo: 'bar' }, {removeOnFail: true}).then(function (job) {
         expect(job.id).to.be.ok();
         expect(job.data.foo).to.be('bar');
@@ -447,7 +447,7 @@ describe('Queue', function () {
           var currentPriority = 1;
           var counter = 0;
           var total = 0;
-          
+
           queue.process(function(job, jobDone){
             expect(job.id).to.be.ok();
             expect(job.data.p).to.be(currentPriority);
@@ -803,7 +803,7 @@ describe('Queue', function () {
             lockRenewTime: 10
           }
         });
-        
+
         for (var j = 0; j < NUM_JOBS_PER_QUEUE; j++) {
           jobs.push(queueStalled2.add({ job: j }));
         }
@@ -1112,6 +1112,24 @@ describe('Queue', function () {
     }).then(function(){
       queue.add({ foo: 'bar' });
     });
+  });
+
+  it('emits drained event when all jobs have been processed', function (done) {
+    var queue = utils.buildQueue();
+
+    queue.process(function (job, done) {
+      done();
+    });
+
+    queue.once('drained', function () {
+      queue.getJobCountByTypes('completed').then(function (completed) {
+        expect(completed).to.be.equal(2);
+        return queue.close().then(done);
+      });
+    });
+
+    queue.add({ foo: 'bar' });
+    queue.add({ foo: 'baz' });
   });
 
   describe('.pause', function () {
@@ -1744,7 +1762,7 @@ describe('Queue', function () {
           if (job.attemptsMade < 2) {
             throw new Error('Not yet!');
           }
-          
+
           jobDone();
         });
 


### PR DESCRIPTION
Fixes #595

I added a new `drainDelay` setting, which is the amount of time to wait (in milliseconds) for new jobs to be added to the queue before emitting the `drained` event.