### PR TITLE
Allow for multiple repeatable jobs with same cron

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -506,7 +506,8 @@ var parser = require('cron-parser');
 
 function nextRepeatableJob(queue, name, data, opts, isRepeat){
   var repeat = opts.repeat;
-  var repeatKey = queue.toKey('repeat') + ':' + name + ':' + repeat.cron;
+  var jobId = isRepeat ? opts.userCustomId : opts.jobId;
+  var repeatKey = queue.toKey('repeat') + ':' + name + ':' + (jobId ? jobId + ':' : '') + repeat.cron;
 
   //
   // Get millis for this repeatable job.
@@ -537,7 +538,7 @@ function nextRepeatableJob(queue, name, data, opts, isRepeat){
       //
       // Generate unique job id for this iteration.
       //
-      var customId = 'repeat:' + name + ':' + nextMillis;
+      var customId = 'repeat:' + name + ':' + (jobId ? jobId + ':' : '') + nextMillis;
 
       //
       // Set key and add job should be atomic.
@@ -545,6 +546,7 @@ function nextRepeatableJob(queue, name, data, opts, isRepeat){
       return queue.client.set(repeatKey, nextMillis).then(function(){
         return Job.create(queue, name, data, _.extend(_.clone(opts), {
           jobId: customId,
+          userCustomId: isRepeat ? opts.userCustomId : opts.jobId,
           delay: delay < 0 ? 0 : delay,
           timestamp: Date.now()
         }));

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -506,8 +506,11 @@ var parser = require('cron-parser');
 
 function nextRepeatableJob(queue, name, data, opts, isRepeat){
   var repeat = opts.repeat;
-  var jobId = isRepeat ? opts.userCustomId : opts.jobId;
-  var repeatKey = queue.toKey('repeat') + ':' + name + ':' + (jobId ? jobId + ':' : '') + repeat.cron;
+  if(!isRepeat && opts.jobId){
+    opts.repeat.jobId = opts.jobId;
+  }
+  var repeatJobId = opts.repeat.jobId ? opts.repeat.jobId + ':' : '';
+  var repeatKey = queue.toKey('repeat') + ':' + name + ':' + repeatJobId + repeat.cron;
 
   //
   // Get millis for this repeatable job.
@@ -538,7 +541,7 @@ function nextRepeatableJob(queue, name, data, opts, isRepeat){
       //
       // Generate unique job id for this iteration.
       //
-      var customId = 'repeat:' + name + ':' + (jobId ? jobId + ':' : '') + nextMillis;
+      var customId = 'repeat:' + name + ':' + repeatJobId + nextMillis;
 
       //
       // Set key and add job should be atomic.
@@ -546,7 +549,6 @@ function nextRepeatableJob(queue, name, data, opts, isRepeat){
       return queue.client.set(repeatKey, nextMillis).then(function(){
         return Job.create(queue, name, data, _.extend(_.clone(opts), {
           jobId: customId,
-          userCustomId: isRepeat ? opts.userCustomId : opts.jobId,
           delay: delay < 0 ? 0 : delay,
           timestamp: Date.now()
         }));

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -83,6 +83,23 @@ describe('Job', function(){
     });
   });
 
+  describe('repeatable jobs', function() {
+    it('should create multiple jobs if they have the same cron pattern', function(done) {
+      var cron = '*/10 * * * * *';
+      var customJobIds = ['customjobone', 'customjobtwo'];
+
+      Promise.all([
+        queue.add(undefined, {}, { jobId: customJobIds[0], repeat: { cron: cron }}),
+        queue.add(undefined, {}, { jobId: customJobIds[1], repeat: { cron: cron }})
+      ]).then(function() {
+        return queue.count();
+      }).then(function(count) {
+        expect(count).to.be(2);
+        done();
+      }).catch(done);
+    });
+  });
+
   describe('.remove', function () {
     it('removes the job from redis', function(){
       return Job.create(queue, {foo: 'bar'})


### PR DESCRIPTION
Fixes #601 

It was a bit tricky to do becase here https://github.com/OptimalBits/bull/blob/master/lib/queue.js#L547 the jobId is overwritten so if you use opts.jobId for the repeatKey/customId you're going to end up with a key that looks like this: `repeat:__default__:repeat:__default__:LHjHbS8qDxXEzpqQQPAH4m:1499171120000:1499171130000`

I came up with a solution to store the initial jobId provided by the user in a separate variable on the opts object. Let me know what you think.