### PR TITLE
Zset repeatable jobs

### DIFF
--- a/lib/commands/getOrSetRepeatKey-1.lua
+++ b/lib/commands/getOrSetRepeatKey-1.lua
@@ -1,0 +1,19 @@
+--[[
+  Gets or sets, if none defined, the repeat key next iteration.
+  Input: 
+    KEYS[1] repeat global key
+    
+    ARGV[1] repeat job key
+    ARGV[2] Date.now()
+
+  Output:
+    Milliseconds for next iteration.
+]]
+local millis = redis.call("ZSCORE", KEYS[1], ARGV[1])
+
+if(millis) then
+  return millis;
+end
+
+redis.call("ZADD", KEYS[1], ARGV[2], ARGV[1])
+return ARGV[2]

--- a/lib/getters.js
+++ b/lib/getters.js
@@ -1,0 +1,151 @@
+/*eslint-env node */
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = function(Queue){
+  
+  Queue.prototype.getJob = function(jobId){
+    return Job.fromId(this, jobId);
+  };
+
+  Queue.prototype._commandByType = function(types, count, callback) {
+    var _this = this;
+
+    return _.map(types, function(type) {
+      type = type === 'waiting' ? 'wait' : type; // alias
+
+      var key = _this.toKey(type);
+
+      switch(type) {
+        case 'completed':
+        case 'failed':
+        case 'delayed':
+        case 'repeat':
+          return callback(key, count ? 'zcard' : 'zrange');
+        case 'active':
+        case 'wait':
+        case 'paused':
+          return callback(key, count ? 'llen' : 'lrange');
+      }
+    });
+  };
+
+  // Job counts by type
+  // Queue#getJobCountByTypes('completed') => completed count
+  // Queue#getJobCountByTypes('completed,failed') => completed + failed count
+  // Queue#getJobCountByTypes('completed', 'failed') => completed + failed count
+  // Queue#getJobCountByTypes('completed,waiting', 'failed') => completed + waiting + failed count
+  Queue.prototype.getJobCountByTypes = function() {
+    return this.getJobCounts.apply(this, arguments).then(function(result){
+      return _.chain(result).values().sum().value();
+    });
+  };
+
+  /**
+   * Returns the job counts for each type specified or every list/set in the queue by default.
+   *
+   */
+  Queue.prototype.getJobCounts = function(){
+    var types = parseTypeArg(arguments);
+    var multi = this.multi();
+
+    this._commandByType(types, true, function(key, command){
+      multi[command](key);
+    });
+
+    return multi.exec().then(function(res){
+      var counts = {};
+      res.forEach(function(res, index){
+        counts[types[index]] = res[1] || 0;
+      });
+      return counts;
+    });
+  };
+
+  Queue.prototype.getCompletedCount = function() {
+    return this.getJobCountByTypes('completed');
+  };
+
+  Queue.prototype.getFailedCount = function() {
+    return this.getJobCountByTypes('failed');
+  };
+
+  Queue.prototype.getDelayedCount = function() {
+    return this.getJobCountByTypes('delayed');
+  };
+
+  Queue.prototype.getActiveCount = function() {
+    return this.getJobCountByTypes('active');
+  };
+
+  Queue.prototype.getWaitingCount = function() {
+    return this.getJobCountByTypes('wait');
+  };
+
+  Queue.prototype.getPausedCount = function() {
+    return this.getJobCountByTypes('paused');
+  };
+
+  Queue.prototype.getWaiting = function(start, end){
+    return this.getJobs([ 'wait', 'paused' ], start, end, true);
+  };
+
+  Queue.prototype.getActive = function(start, end){
+    return this.getJobs('active', start, end, true);
+  };
+
+  Queue.prototype.getDelayed = function(start, end){
+    return this.getJobs('delayed', start, end, true);
+  };
+
+  Queue.prototype.getCompleted = function(start, end){
+    return this.getJobs('completed', start, end, false);
+  };
+
+  Queue.prototype.getFailed = function(start, end){
+    return this.getJobs('failed', start, end, false);
+  };
+
+  Queue.prototype.getRanges = function(types, start, end, asc){
+    var _this = this;
+
+    start = _.isUndefined(start) ? 0 : start;
+    end = _.isUndefined(end) ? -1 : end;
+
+    var resultByType = _this._commandByType(parseTypeArg(types), false, function(key, command){
+      switch(command){
+        case 'lrange':
+          if(asc){
+            return _this.client.lrange(key, -(end + 1), -(start + 1)).then(function(result){
+              return result.reverse();
+            });
+          }else{
+            return _this.client.lrange(key, start, end);
+          }
+        case 'zrange':
+          return asc ? _this.client.zrange(key, start, end) : _this.client.zrevrange(key, start, end);
+      }
+    });
+
+    return Promise.all(resultByType).then(function(results){
+      return _.flatten(results);
+    });
+  };
+
+  Queue.prototype.getJobs = function(types, start, end, asc){
+    var _this = this;
+    return this.getRanges(types, start, end).then(function(jobIds){
+      return Promise.all(jobIds.map(_this.getJobFromId));
+    });
+  };
+};
+
+function parseTypeArg(args) {
+  var types = _.chain([]).concat(args).join(',').split(/\s*,\s*/g).compact().value();
+
+  return types.length
+    ? types
+    : ['waiting', 'active', 'completed', 'failed', 'delayed'];
+}
+

--- a/lib/getters.js
+++ b/lib/getters.js
@@ -2,6 +2,7 @@
 'use strict';
 
 var _ = require('lodash');
+var Job = require('./job');
 
 module.exports = function(Queue){
   
@@ -29,6 +30,13 @@ module.exports = function(Queue){
           return callback(key, count ? 'llen' : 'lrange');
       }
     });
+  };
+
+  /**
+    Returns the number of jobs waiting to be processed.
+  */
+  Queue.prototype.count = function(){
+    return this.getJobCountByTypes('wait', 'paused', 'delayed');
   };
 
   // Job counts by type
@@ -135,7 +143,7 @@ module.exports = function(Queue){
 
   Queue.prototype.getJobs = function(types, start, end, asc){
     var _this = this;
-    return this.getRanges(types, start, end).then(function(jobIds){
+    return this.getRanges(types, start, end, asc).then(function(jobIds){
       return Promise.all(jobIds.map(_this.getJobFromId));
     });
   };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -19,7 +19,6 @@ var debuglog = require('debuglog')('bull');
 var uuid = require('uuid');
 
 var commands = require('./commands/');
-var repeatable = require('./repeatable');
 
 /**
   Gets or creates a new Queue with the given name.
@@ -240,6 +239,7 @@ util.inherits(Queue, EventEmitter);
 //
 require('./getters')(Queue);
 require('./worker')(Queue);
+require('./repeatable')(Queue);
 
 // --
 Queue.prototype.off = Queue.prototype.removeListener;
@@ -558,18 +558,11 @@ Queue.prototype.add = function(name, data, opts){
   if(opts && opts.repeat){
     var _this = this;
     return this.isReady().then(function(){
-      return repeatable.nextJob(_this, name, data, opts);
+      return _this.nextRepeatableJob(name, data, opts);
     });
   }else{
     return Job.create(this, name, data, opts);
   }
-};
-
-/**
-  Returns the number of jobs waiting to be processed.
-*/
-Queue.prototype.count = function(){
-  return this.getJobCountByTypes('wait', 'paused', 'delayed');
 };
 
 /**
@@ -890,7 +883,7 @@ Queue.prototype.getNextJob = function() {
     if(jobData){
       var job = Job.fromJSON(_this, jobData, jobId);
       if(job.opts.repeat){
-        return repeatable.nextJob(_this, job.name, job.data, job.opts, true).then(function(){
+        return _this.nextRepeatableJob(job.name, job.data, job.opts, true).then(function(){
           return job;
         });
       }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -19,7 +19,6 @@ var debuglog = require('debuglog')('bull');
 var uuid = require('uuid');
 
 var commands = require('./commands/');
-var worker = require('./worker');
 var repeatable = require('./repeatable');
 
 /**
@@ -236,8 +235,13 @@ function setGuardianTimer(queue){
 
 util.inherits(Queue, EventEmitter);
 
-_.extend(Queue.prototype, worker);
+//
+// Extend Queue with "aspects"
+//
+require('./getters')(Queue);
+require('./worker')(Queue);
 
+// --
 Queue.prototype.off = Queue.prototype.removeListener;
 
 var _on = Queue.prototype.on;
@@ -546,8 +550,16 @@ interface JobOptions
   @param opts: JobOptions Options for this job.
 */
 Queue.prototype.add = function(name, data, opts){
+  if(typeof name !== 'string'){
+    opts = data;
+    data = name;
+    name = Job.DEFAULT_JOB_NAME;
+  }
   if(opts && opts.repeat){
-    return repeatable.nextJob(this, name || Job.DEFAULT_JOB_NAME, data, opts);
+    var _this = this;
+    return this.isReady().then(function(){
+      return repeatable.nextJob(_this, name, data, opts);
+    });
   }else{
     return Job.create(this, name, data, opts);
   }
@@ -897,134 +909,6 @@ Queue.prototype.getNextJob = function() {
   });
 };
 
-Queue.prototype.getJob = function(jobId){
-  return Job.fromId(this, jobId);
-};
-
-Queue.prototype._commandByType = function(types, count, callback) {
-  var _this = this;
-
-  return _.map(types, function(type) {
-    type = type === 'waiting' ? 'wait' : type; // alias
-
-    var key = _this.toKey(type);
-
-    switch(type) {
-      case 'completed':
-      case 'failed':
-      case 'delayed':
-        return callback(key, count ? 'zcard' : 'zrange');
-      case 'active':
-      case 'wait':
-      case 'paused':
-        return callback(key, count ? 'llen' : 'lrange');
-    }
-  });
-};
-
-// Job counts by type
-// Queue#getJobCountByTypes('completed') => completed count
-// Queue#getJobCountByTypes('completed,failed') => completed + failed count
-// Queue#getJobCountByTypes('completed', 'failed') => completed + failed count
-// Queue#getJobCountByTypes('completed,waiting', 'failed') => completed + waiting + failed count
-Queue.prototype.getJobCountByTypes = function() {
-  return this.getJobCounts.apply(this, arguments).then(function(result){
-    return _.chain(result).values().sum().value();
-  });
-};
-
-/**
- * Returns the job counts for each type specified or every list/set in the queue by default.
- *
- */
-Queue.prototype.getJobCounts = function(){
-  var types = parseTypeArg(arguments);
-  var multi = this.multi();
-
-  this._commandByType(types, true, function(key, command){
-    multi[command](key);
-  });
-
-  return multi.exec().then(function(res){
-    var counts = {};
-    res.forEach(function(res, index){
-      counts[types[index]] = res[1] || 0;
-    });
-    return counts;
-  });
-};
-
-Queue.prototype.getCompletedCount = function() {
-  return this.getJobCountByTypes('completed');
-};
-
-Queue.prototype.getFailedCount = function() {
-  return this.getJobCountByTypes('failed');
-};
-
-Queue.prototype.getDelayedCount = function() {
-  return this.getJobCountByTypes('delayed');
-};
-
-Queue.prototype.getActiveCount = function() {
-  return this.getJobCountByTypes('active');
-};
-
-Queue.prototype.getWaitingCount = function() {
-  return this.getJobCountByTypes('wait');
-};
-
-Queue.prototype.getPausedCount = function() {
-  return this.getJobCountByTypes('paused');
-};
-
-Queue.prototype.getWaiting = function(start, end){
-  return this.getJobs([ 'wait', 'paused' ], start, end, true);
-};
-
-Queue.prototype.getActive = function(start, end){
-  return this.getJobs('active', start, end, true);
-};
-
-Queue.prototype.getDelayed = function(start, end){
-  return this.getJobs('delayed', start, end, true);
-};
-
-Queue.prototype.getCompleted = function(start, end){
-  return this.getJobs('completed', start, end, false);
-};
-
-Queue.prototype.getFailed = function(start, end){
-  return this.getJobs('failed', start, end, false);
-};
-
-Queue.prototype.getJobs = function(types, start, end, asc){
-  var _this = this;
-
-  start = _.isUndefined(start) ? 0 : start;
-  end = _.isUndefined(end) ? -1 : end;
-
-  var resultByType = _this._commandByType(parseTypeArg(types), false, function(key, command){
-    switch(command){
-      case 'lrange':
-        if(asc){
-          return _this.client.lrange(key, -(end + 1), -(start + 1)).then(function(result){
-            return result.reverse();
-          });
-        }else{
-          return _this.client.lrange(key, start, end);
-        }
-      case 'zrange':
-        return asc ? _this.client.zrange(key, start, end) : _this.client.zrevrange(key, start, end);
-    }
-  });
-
-  return Promise.all(resultByType).then(function(results){
-    var jobs = _.flatten(results).map(_this.getJobFromId);
-    return Promise.all(jobs);
-  });
-};
-
 Queue.prototype.retryJob = function(job) {
   return job.retry();
 };
@@ -1091,13 +975,6 @@ Queue.prototype.whenCurrentJobsFinished = function(){
 //
 // Private local functions
 //
-function parseTypeArg(args) {
-  var types = _.chain([]).concat(args).join(',').split(/\s*,\s*/g).compact().value();
-
-  return types.length
-    ? types
-    : ['waiting', 'active', 'completed', 'failed', 'delayed'];
-}
 
 function getRedisVersion(client){
   return client.info().then(function(doc){

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -5,49 +5,80 @@ var _ = require('lodash');
 var parser = require('cron-parser');
 var Job = require('./job');
 
-function nextJob(queue, name, data, opts, isRepeat){
-  var repeat = opts.repeat;
-  if(!isRepeat && opts.jobId){
-    opts.repeat.jobId = opts.jobId;
-  }
-  var repeatJobId = opts.repeat.jobId ? opts.repeat.jobId + ':' : '';
-  var repeatJobKey = name + ':' + repeatJobId + repeat.cron;
+module.exports = function(Queue){
 
-  var millis = Date.now();
-  return queue.client.getOrSetRepeatKey(queue.toKey('repeat'), repeatJobKey, millis).then(function(millis){
-    millis = parseInt(millis);
-
-    var interval = parser.parseExpression(repeat.cron, _.defaults({
-      currentDate: new Date(millis)
-    }, repeat));
-    var nextMillis;
-    try{
-      nextMillis = interval.next();
-    } catch(e){
-      // Ignore error
+  Queue.prototype.nextRepeatableJob = function (name, data, opts, isRepeat){
+    var _this = this;
+    var repeat = opts.repeat;
+    if(!isRepeat && opts.jobId){
+      opts.repeat.jobId = opts.jobId;
     }
+    var repeatJobId = opts.repeat.jobId ? opts.repeat.jobId + ':' : ':';
+    var endDate = opts.repeat.endDate ? opts.repeat.endDate + ':' : ':';
+    var tz = opts.repeat.tz ? opts.repeat.tz + ':' : ':';
+    var repeatJobKey = name + ':' + repeatJobId + endDate + tz + repeat.cron;
 
-    if(nextMillis){
-      nextMillis = nextMillis.getTime();
-      var delay = nextMillis - Date.now();
+    var millis = Date.now();
+    return this.client.getOrSetRepeatKey(this.toKey('repeat'), repeatJobKey, millis).then(function(millis){
+      millis = parseInt(millis);
 
-      //
-      // Generate unique job id for this iteration.
-      //
-      var customId = 'repeat:' + name + ':' + repeatJobId + nextMillis;
+      var interval = parser.parseExpression(repeat.cron, _.defaults({
+        currentDate: new Date(millis)
+      }, repeat));
+      var nextMillis;
+      try{
+        nextMillis = interval.next();
+      } catch(e){
+        // Ignore error
+      }
 
-      //
-      // Set key and add job should be atomic.
-      //
-      return queue.client.zadd(queue.toKey('repeat'), nextMillis, repeatJobKey).then(function(){
-        return Job.create(queue, name, data, _.extend(_.clone(opts), {
-          jobId: customId,
-          delay: delay < 0 ? 0 : delay,
-          timestamp: Date.now()
-        }));
+      if(nextMillis){
+        nextMillis = nextMillis.getTime();
+        var delay = nextMillis - Date.now();
+
+        //
+        // Generate unique job id for this iteration.
+        //
+        var customId = 'repeat:' + name + ':' + repeatJobId + nextMillis;
+
+        //
+        // Set key and add job should be atomic.
+        //
+        return _this.client.zadd(_this.toKey('repeat'), nextMillis, repeatJobKey).then(function(){
+          return Job.create(_this, name, data, _.extend(_.clone(opts), {
+            jobId: customId,
+            delay: delay < 0 ? 0 : delay,
+            timestamp: Date.now()
+          }));
+        });
+      }
+    });
+  };
+
+  Queue.prototype.getRepeatableJobs = function (start, end, asc){
+    var key = this.toKey('repeat');
+    start = start || 0;
+    end = end || -1;
+    return (asc ?
+      this.client.zrange(key, start, end, 'WITHSCORES') :
+      this.client.zrevrange(key, start, end, 'WITHSCORES')).then(function(result){
+        var jobs = [];
+        for(var i=0; i<result.length; i+=2){
+          var data = result[i].split(':');
+          jobs.push({
+            name: data[0],
+            id: data[1] || null,
+            endDate: parseInt(data[2]) || null,
+            tz: data[3] || null,
+            cron: data[4],
+            next: parseInt(result[i+1])
+          });
+        }
+        return jobs;
       });
-    }
-  });
-};
+  };
 
-module.exports.nextJob = nextJob;
+  Queue.prototype.getRepeatableCount = function(){
+    return this.client.zcard(this.toKey('repeat'));
+  };
+};

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -1,6 +1,6 @@
-//
-// This code will be called everytime a job is going to be processed if the job has a repeat option. (from delay -> active).
-//
+/*eslint-env node */
+'use strict';
+
 var _ = require('lodash');
 var parser = require('cron-parser');
 var Job = require('./job');
@@ -11,20 +11,12 @@ function nextJob(queue, name, data, opts, isRepeat){
     opts.repeat.jobId = opts.jobId;
   }
   var repeatJobId = opts.repeat.jobId ? opts.repeat.jobId + ':' : '';
-  var repeatKey = queue.toKey('repeat') + ':' + name + ':' + repeatJobId + repeat.cron;
+  var repeatJobKey = name + ':' + repeatJobId + repeat.cron;
 
-  //
-  // Get millis for this repeatable job.
-  // Only use `millis` from the `repeatKey` when the job is a repeat, otherwise, we want
-  // `Date.now()` to ensure we try to add the next iteration only
-  //
-  return (isRepeat ? queue.client.get(repeatKey) : Promise.resolve(Date.now())).then(function(millis){
-    if(millis){
-      return parseInt(millis);
-    }else{
-      return Date.now();
-    }
-  }).then(function(millis){
+  var millis = Date.now();
+  return queue.client.getOrSetRepeatKey(queue.toKey('repeat'), repeatJobKey, millis).then(function(millis){
+    millis = parseInt(millis);
+
     var interval = parser.parseExpression(repeat.cron, _.defaults({
       currentDate: new Date(millis)
     }, repeat));
@@ -47,7 +39,7 @@ function nextJob(queue, name, data, opts, isRepeat){
       //
       // Set key and add job should be atomic.
       //
-      return queue.client.set(repeatKey, nextMillis).then(function(){
+      return queue.client.zadd(queue.toKey('repeat'), nextMillis, repeatJobKey).then(function(){
         return Job.create(queue, name, data, _.extend(_.clone(opts), {
           jobId: customId,
           delay: delay < 0 ? 0 : delay,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,22 +1,28 @@
+/*eslint-env node */
+'use strict';
 
-
-module.exports = {
-  setWorkerName: function(){
+module.exports = function(Queue){
+  
+  Queue.prototype.setWorkerName = function(){
     return this.client.client('setname', this.clientName());
-  },
-  getWorkers: function(){
+  };
+
+  Queue.prototype.getWorkers = function(){
     var _this = this;
     return this.client.client('list').then(function(clients){
       return _this.parseClientList(clients);
     });
-  },
-  base64Name: function(){
+  };
+
+  Queue.prototype.base64Name = function(){
     return (new Buffer(this.name)).toString('base64');
-  },
-  clientName: function(){
+  };
+
+  Queue.prototype.clientName = function(){
     return this.keyPrefix + ':' + this.base64Name();
-  },
-  parseClientList: function(list){
+  };
+
+  Queue.prototype.parseClientList = function(list){
     var _this = this;
     var lines = list.split('\n');
     var clients = [];
@@ -36,6 +42,6 @@ module.exports = {
     });
 
     return clients;
-  }
+  };
 };
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2279,7 +2279,7 @@ describe('Queue', function () {
       queue.on('completed', _.after(2, function () {
         queue.pause();
         queue.getJobs(['completed','wait']).then(function (jobs) {
-          expect(jobs).to.be.an(Array);
+          expect(jobs).to.be.an('array');
           expect(jobs).to.have.length(3);
           done();
         }).catch(done);


### PR DESCRIPTION
Store repeatable jobs into zsets instead of standalone keys. Helps to keep the key space less polluted and provides better querying. Also fixes #609 