### PR TITLE
Fixed #608

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -243,15 +243,15 @@ Queue.prototype.off = Queue.prototype.removeListener;
 var _on = Queue.prototype.on;
 
 Queue.prototype.on = function(eventName){
-  _on.apply(this, arguments);
-  return this._registerEvent(eventName);
+  this._registerEvent(eventName);
+  return _on.apply(this, arguments);
 };
 
 var _once = Queue.prototype.once;
 
 Queue.prototype.once = function(eventName){
-  _once.apply(this, arguments);
-  return this._registerEvent(eventName);
+  this._registerEvent(eventName);
+  return _once.apply(this, arguments);
 };
 
 Queue.prototype._initProcess = function(){
@@ -268,9 +268,13 @@ Queue.prototype._initProcess = function(){
     this._initializingProcess = this.isReady().then(function(){
       return Promise.join(
         _this._registerEvent('delayed'),
-        _this.on('added', newJobs),
-        _this.on('global:resumed', newJobs),
-        _this.on('wait-finished', newJobs));
+        _this._registerEvent('added'),
+        _this._registerEvent('global:resume'),
+        _this._registerEvent('wait-finished')).then(function(){
+          _this.on('added', newJobs);
+          _this.on('global:resumed', newJobs);
+          _this.on('wait-finished', newJobs);
+        });
     }).then(function(){
       //
       // Init delay timestamp.
@@ -370,19 +374,24 @@ Queue.prototype._registerEvent = function(eventName){
       this.registeredEvents = this.registeredEvents || {};
     }
 
-    eventName = eventName.replace('global:', '');
+    var _eventName = eventName.replace('global:', '');
 
-    if(eventName === 'waiting'){
-      eventName = 'added';
+    if(_eventName === 'waiting'){
+      _eventName = 'added';
     }
 
-    if(!this.registeredEvents[eventName]){
-      var channel = this.toKey(eventName);
-      if(eventName === 'added' || eventName === 'active'){
-        return this.registeredEvents[eventName] = this.eclient.psubscribe(channel + '*');
+    if(!this.registeredEvents[_eventName]){
+      var registering;
+      var _this = this;
+      var channel = this.toKey(_eventName);
+      if(_eventName === 'added' || _eventName === 'active'){
+        registering = this.registeredEvents[_eventName] = this.eclient.psubscribe(channel + '*');
       } else {
-        return this.registeredEvents[eventName] = this.eclient.subscribe(channel);
+        registering = this.registeredEvents[_eventName] = this.eclient.subscribe(channel);
       }
+      registering.then(function(){
+        _this.emit('registered:' + eventName);
+      });
     }
   }
   return Promise.resolve();

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1118,7 +1118,8 @@ describe('Queue', function () {
         expect(job.data.foo).to.be.equal('bar');
         queue.close().then(done);
       });
-    }).then(function(){
+    });
+    queue.once('registered:waiting', function(){
       queue.add({ foo: 'bar' });
     });
   });
@@ -1202,8 +1203,6 @@ describe('Queue', function () {
           queue.resume().catch(function(err){
             // Swallow error.
           });
-        }).catch(function(err){
-          // Swallow error
         });
 
         queue.on('resumed', function () {
@@ -1376,7 +1375,8 @@ describe('Queue', function () {
     queue.on('waiting', function(jobId){
       expect(parseInt(jobId, 10)).to.be.eql(1);
       done();
-    }).then(function(){
+    });
+    queue.once('registered:waiting', function(){
       queue.add({ test: 'stuff' });
     });
   });
@@ -1405,19 +1405,23 @@ describe('Queue', function () {
     queue2.on('global:waiting', function () {
       expect(state).to.be.undefined;
       state = 'waiting';
-    }).then(function(){
-      return queue2.once('global:active', function () {
+    });
+    queue2.once('registered:global:waiting', function(){
+      queue2.once('global:active', function () {
         expect(state).to.be.equal('waiting');
         state = 'active';
       });
-    }).then(function(){
-      return queue2.once('global:completed', function () {
+    });
+    queue2.once('registered:global:active', function(){
+      queue2.once('global:completed', function () {
         expect(state).to.be.equal('active');
         queue1.close().then(function(){
           queue2.close().then(done);
         });
       });
-    }).then(function(){
+    });
+
+    queue2.once('registered:global:completed', function(){
       queue1.add({});
     });
   });
@@ -2279,7 +2283,7 @@ describe('Queue', function () {
       queue.on('completed', _.after(2, function () {
         queue.pause();
         queue.getJobs(['completed','wait']).then(function (jobs) {
-          expect(jobs).to.be.an(Array);
+          expect(jobs).to.be.an('array');
           expect(jobs).to.have.length(3);
           done();
         }).catch(done);


### PR DESCRIPTION
Now events are chainable again. Events that require a registration in redis pubsub system will now emit an event ```registered:eventName```
