### PR TITLE
fix job finished promise return value parsing when already complete

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -327,7 +327,7 @@ Job.prototype.finished = function(){
         if(status == 2){
           throw new Error(job.failedReason);
         } else {
-          return  JSON.parse(job.returnvalue); 
+          return job.returnvalue; 
         }
       });      
     }else{


### PR DESCRIPTION
Fixes Job.prototype.finished promise when job is already complete as determined by scripts.isFinished

returnvalue was already JSON.parse()'d during Job.prototype.fromJSON

this should address https://github.com/OptimalBits/bull/issues/614
