### PR TITLE
Fixed JobCounts interface description in REFERENCE docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -341,7 +341,7 @@ Returns a promise that will return the job counts for the given queue.
 
 ```typescript{
   interface JobCounts {
-    wait: number,
+    waiting: number,
     active: number,
     completed: number,
     failed: number,


### PR DESCRIPTION
Number of waiting jobs contains in "waiting" property. There is no "wait" property.