### PR TITLE
Fix duplicate return value parsing for already completed jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -351,7 +351,7 @@ Job.prototype.finished = function(){
         if(status == 2){
           throw new Error(job.failedReason);
         } else {
-          return job.returnvalue && JSON.parse(job.returnvalue);
+          return job.returnvalue;
         }
       });
     }else{


### PR DESCRIPTION
Calling `Job.finished()` on an already-completed job with a return value throws error, since the value is already parsed.