### PR TITLE
Failing test: Process after exit

### DIFF
--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -5,59 +5,63 @@ var path = require('path');
 var Promise = require('bluebird');
 var _ = require('lodash');
 
-module.exports = function ChildPool() {
+module.exports = ChildPool;
+
+function ChildPool() {
   if(!(this instanceof ChildPool)){
     return new ChildPool();
   }
 
   this.retained = {};
   this.free = [];
+};
 
-  this.retain = Promise.method(function(processFile){
-    var child = this.free.pop();
+ChildPool.prototype.retain = Promise.method(function(processFile){
+  var child = this.free.pop();
 
-    if (child) {
-      return child;
-    }
+  if (child) {
+    return child;
+  }
 
-    child = fork(path.join(__dirname, './master.js'));
+  child = fork(path.join(__dirname, './master.js'));
 
-    this.retained[child.pid] = child;
+  this.retained[child.pid] = child;
 
-    child.on('exit', this.remove.bind(this, child));
+  child.on('exit', this.remove.bind(this, child));
 
-    var send = function(msg) {
-      return new Promise(function(resolve){
-        child.send(msg, resolve);
-      });
-    };
-
-    return send({ cmd: 'init', value: processFile }).return(child);
-  });
-
-  this.release = function(child){
-    delete this.retained[child.pid];
-    this.free.push(child);
+  var send = function(msg) {
+    return new Promise(function(resolve){
+      child.send(msg, resolve);
+    });
   };
 
-  this.remove = function(child){
-    delete this.retained[child.pid];
-    var childIndex = this.free.indexOf(child);
-    if (childIndex > -1) {
-      this.free.splice(childIndex, 1);
-    }
-  };
+  return send({ cmd: 'init', value: processFile }).return(child);
+});
 
-  this.kill = function(child, signal){
-    child.kill(signal);
-    this.remove(child);
-  };
 
-  this.clean = function(){
-    var children = _.values(this.retained).concat(this.free);
-    children.forEach(this.kill.bind(this));
 
-    this.retained = {};
-    this.free = [];
-  };
+ChildPool.prototype.release = function(child){
+  delete this.retained[child.pid];
+  this.free.push(child);
+};
+
+ChildPool.prototype.remove = function(child){
+  delete this.retained[child.pid];
+  var childIndex = this.free.indexOf(child);
+  if (childIndex > -1) {
+    this.free.splice(childIndex, 1);
+  }
+};
+
+ChildPool.prototype.kill = function(child, signal){
+  child.kill(signal);
+  this.remove(child);
+};
+
+ChildPool.prototype.clean = function(){
+  var children = _.values(this.retained).concat(this.free);
+  children.forEach(this.kill.bind(this));
+
+  this.retained = {};
+  this.free = [];
 };

--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -3,65 +3,76 @@
 var fork = require('child_process').fork;
 var path = require('path');
 var Promise = require('bluebird');
-var _ = require('lodash');
+var createPool = require('generic-pool').createPool;
 
 module.exports = ChildPool;
 
-function ChildPool() {
+function ChildPool(concurrency) {
   if(!(this instanceof ChildPool)){
-    return new ChildPool();
+    return new ChildPool(concurrency);
   }
 
-  this.retained = {};
-  this.free = [];
+  var factory = {
+    create: function () {
+      var child = fork(path.join(__dirname, './master.js'));
+      return Promise.resolve(child);
+    },
+    destroy: function (child) {
+      child.kill();
+      return Promise.resolve();
+    },
+    validate: function (child) {
+      var token = Math.random().toString();
+
+      var response = new Promise(function (resolve) {
+        var handler = function(msg) {
+          if (msg.cmd === 'pong' && msg.value === token) {
+            child.removeListener('message', handler);
+            resolve();
+          }
+        };
+
+        child.on('message', handler);
+      });
+
+      child.send({
+        cmd:'ping',
+        value: token
+      });
+
+      return response.timeout(100).return(true).catchReturn(false);
+    }
+  };
+
+  this.pool = createPool(factory, {
+    testOnBorrow: true,
+    evictionRunIntervalMillis: 500,
+    max: concurrency || 1
+  });
 };
 
 ChildPool.prototype.retain = Promise.method(function(processFile){
-  var child = this.free.pop();
-
-  if (child) {
-    return child;
-  }
-
-  child = fork(path.join(__dirname, './master.js'));
-
-  this.retained[child.pid] = child;
-
-  child.on('exit', this.remove.bind(this, child));
-
-  var send = function(msg) {
-    return new Promise(function(resolve){
-      child.send(msg, resolve);
+  return this.pool.acquire().then(function(child){
+    child.send({
+      cmd: 'init',
+      value: processFile
     });
-  };
 
-  return send({ cmd: 'init', value: processFile }).return(child);
+    return child;
+  });
 });
 
-
-
 ChildPool.prototype.release = function(child){
-  delete this.retained[child.pid];
-  this.free.push(child);
+  return this.pool.release(child);
 };
 
-ChildPool.prototype.remove = function(child){
-  delete this.retained[child.pid];
-  var childIndex = this.free.indexOf(child);
-  if (childIndex > -1) {
-    this.free.splice(childIndex, 1);
-  }
-};
-
-ChildPool.prototype.kill = function(child, signal){
-  child.kill(signal);
-  this.remove(child);
+ChildPool.prototype.kill = function(child){
+  return this.pool.destroy(child);
 };
 
 ChildPool.prototype.clean = function(){
-  var children = _.values(this.retained).concat(this.free);
-  children.forEach(this.kill.bind(this));
-
-  this.retained = {};
-  this.free = [];
+  var pool = this.pool;
+  return pool.drain().then(function(){
+    return pool.clear();
+  });
 };

--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -61,6 +61,12 @@ process.on('message', function(msg) {
       break;
     case 'stop':
       break;
+    case 'ping':
+      process.send({
+        cmd: 'pong',
+        value: msg.value
+      });
+      break;
   }
 });
 

--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -41,7 +41,7 @@ process.on('message', function(msg) {
       if(status !== 'IDLE'){
         return process.send({
           cmd: 'error',
-          err: new Error('cannot start a not idling child process')
+          value: new Error('cannot start a not idling child process')
         });
       }
       status = 'STARTED';

--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -5,22 +5,24 @@ var Promise = require('bluebird');
 module.exports = function(processFile, childPool, killOnComplete){
   return function process(job){
     return childPool.retain(processFile).then(function(child){
-
       child.send({
         cmd: 'start',
         job: job
       });
 
+
       var done = new Promise(function(resolve, reject) {
-        function handler(msg){
+        function handleMessage(msg){
           switch(msg.cmd){
             case 'completed':
-              child.removeListener('message', handler);
+              child.removeListener('message', handleMessage);
+              child.removeListener('exit', handleExit);
               resolve(msg.value);
               break;
             case 'failed':
             case 'error':
-              child.removeListener('message', handler);
+              child.removeListener('message', handleMessage);
+              child.removeListener('exit', handleExit);
               reject(msg.value);
               break;
             case 'progress':
@@ -29,14 +31,19 @@ module.exports = function(processFile, childPool, killOnComplete){
           }
         }
 
-        child.on('message', handler);
+        function handleExit(){
+          handleMessage({ cmd: 'error', value: 'child process exited' });
+        }
+
+        child.on('message', handleMessage);
+        child.on('exit', handleExit);
       });
 
-      return done.finally( function(){
+      return done.finally(function(){
         if (killOnComplete) {
-          childPool.kill(child);
+          return childPool.kill(child);
         } else {
-          childPool.release(child);
+          return childPool.release(child);
         }
       });
     });

--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -2,7 +2,7 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(processFile, childPool){
+module.exports = function(processFile, childPool, killOnComplete){
   return function process(job){
     return childPool.retain(processFile).then(function(child){
 
@@ -33,7 +33,11 @@ module.exports = function(processFile, childPool){
       });
 
       return done.finally( function(){
-        childPool.release(child);
+        if (killOnComplete) {
+          childPool.kill(child);
+        } else {
+          childPool.release(child);
+        }
       });
     });
   };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -527,6 +527,7 @@ Queue.prototype.process = function(name, concurrency, handler, killOnComplete){
   }
 
   if(typeof name !== 'string'){
+    killOnComplete = handler;
     handler = concurrency;
     concurrency = name;
     name = Job.DEFAULT_JOB_NAME;
@@ -537,7 +538,7 @@ Queue.prototype.process = function(name, concurrency, handler, killOnComplete){
     concurrency = 1;
   }
 
-  this.setHandler(name, handler, killOnComplete);
+  this.setHandler(name, handler, killOnComplete, concurrency);
 
   var _this = this;
   return this._initProcess().then(function(){
@@ -556,7 +557,7 @@ Queue.prototype.start = function(concurrency){
 };
 
 
-Queue.prototype.setHandler = function(name, handler, killOnComplete){
+Queue.prototype.setHandler = function(name, handler, killOnComplete, concurrency){
   if(this.handlers[name]) {
     throw new Error('Cannot define the same handler twice ' + name);
   }
@@ -564,7 +565,7 @@ Queue.prototype.setHandler = function(name, handler, killOnComplete){
   this.setWorkerName();
 
   if(typeof handler === 'string'){
-    this.childPool = this.childPool || require('./process/child-pool')();
+    this.childPool = this.childPool || require('./process/child-pool')(concurrency);
     var sandbox = require('./process/sandbox');
     this.handlers[name] = sandbox(handler, this.childPool, killOnComplete).bind(this);
   } else {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -517,9 +517,10 @@ Queue.prototype._clearTimers = function(){
 
   @method process
 */
-Queue.prototype.process = function(name, concurrency, handler){
+Queue.prototype.process = function(name, concurrency, handler, killOnComplete){
 
-  if(arguments.length === 1){
+  if(arguments.length === 1 || arguments.length === 2 && typeof concurrency === 'boolean'){
+    killOnComplete = concurrency;
     handler = name;
     concurrency = 1;
     name = Job.DEFAULT_JOB_NAME;
@@ -536,7 +537,7 @@ Queue.prototype.process = function(name, concurrency, handler){
     concurrency = 1;
   }
 
-  this.setHandler(name, handler);
+  this.setHandler(name, handler, killOnComplete);
 
   var _this = this;
   return this._initProcess().then(function(){
@@ -555,7 +556,7 @@ Queue.prototype.start = function(concurrency){
 };
 
 
-Queue.prototype.setHandler = function(name, handler){
+Queue.prototype.setHandler = function(name, handler, killOnComplete){
   if(this.handlers[name]) {
     throw new Error('Cannot define the same handler twice ' + name);
   }
@@ -565,7 +566,7 @@ Queue.prototype.setHandler = function(name, handler){
   if(typeof handler === 'string'){
     this.childPool = this.childPool || require('./process/child-pool')();
     var sandbox = require('./process/sandbox');
-    this.handlers[name] = sandbox(handler, this.childPool).bind(this);
+    this.handlers[name] = sandbox(handler, this.childPool, killOnComplete).bind(this);
   } else {
     handler = handler.bind(this);
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "bluebird": "^3.5.0",
     "cron-parser": "^2.4.1",
     "debuglog": "^1.0.0",
+    "generic-pool": "^3.2.0",
     "ioredis": "^3.1.4",
     "lodash": "^4.17.4",
     "semver": "^5.4.1",

--- a/test/fixtures/fixture_processor_leaky.js
+++ b/test/fixtures/fixture_processor_leaky.js
@@ -1,0 +1,14 @@
+/**
+ * A processor file to be used in tests.
+ *
+ */
+
+var Promise = require('bluebird');
+
+var count = 0;
+
+module.exports = function(/*job*/){
+  return Promise.delay(100).then(function(){
+    return count++;
+  });
+};

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -5,6 +5,8 @@ var Promise = require('bluebird');
 var expect = require('chai').expect;
 var utils = require('./utils');
 var redis = require('ioredis');
+var sinon = require('sinon');
+var _ = require('lodash');
 
 describe('sandboxed process', function () {
   var queue;
@@ -144,5 +146,18 @@ describe('sandboxed process', function () {
     });
 
     queue.add({foo:'bar'});
+  });
+
+  it('should process after exit', function () {
+    queue.process(__dirname + '/fixtures/fixture_processor_exit.js');
+
+    var completed = sinon.spy();
+    queue.on('completed', completed);
+
+    _.times(5, queue.add.bind(queue, {foo:'bar'}));
+
+    return Promise.delay(4000).then(function(){
+      expect(completed.callCount).to.equal(5);
+    });
   });
 });

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -23,10 +23,11 @@ describe('sandboxed process', function () {
   });
 
   afterEach(function(){
-    return queue.close().then(function(){
-      var client = new redis();
-      return client.flushall();
-    });
+    return queue.close(true)
+      .then(function(){
+        var client = new redis();
+        return client.flushall();
+      });
   });
 
   it('should process and complete', function (done) {
@@ -36,8 +37,8 @@ describe('sandboxed process', function () {
       try {
         expect(job.data).to.be.eql({foo:'bar'});
         expect(value).to.be.eql(42);
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-        expect(queue.childPool.free).to.have.lengthOf(1);
+        expect(queue.childPool.pool.borrowed).to.equal(0);
+        expect(queue.childPool.pool.available).to.equal(1);
         done();
       } catch (err) {
         done(err);
@@ -54,8 +55,8 @@ describe('sandboxed process', function () {
       try {
         expect(job.data).to.be.eql({foo:'bar'});
         expect(value).to.be.eql(42);
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-        expect(queue.childPool.free).to.have.lengthOf(1);
+        expect(queue.childPool.pool.borrowed).to.equal(0);
+        expect(queue.childPool.pool.available).to.equal(1);
         done();
       } catch (err) {
         done(err);
@@ -74,8 +75,8 @@ describe('sandboxed process', function () {
         expect(value).to.be.eql(37);
         expect(job.progress()).to.be.eql(100);
         expect(progresses).to.be.eql([10, 27, 78, 100]);
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-        expect(queue.childPool.free).to.have.lengthOf(1);
+        expect(queue.childPool.pool.borrowed).to.equal(0);
+        expect(queue.childPool.pool.available).to.equal(1);
         done();
       } catch (err) {
         done(err);
@@ -98,8 +99,8 @@ describe('sandboxed process', function () {
         expect(job.data).eql({foo:'bar'});
         expect(job.failedReason).eql('Manually failed processor');
         expect(err.message).eql('Manually failed processor');
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-        expect(queue.childPool.free).to.have.lengthOf(1);
+        expect(queue.childPool.pool.borrowed).to.equal(0);
+        expect(queue.childPool.pool.available).to.equal(1);
         done();
       } catch (err) {
         done(err);
@@ -117,8 +118,8 @@ describe('sandboxed process', function () {
         expect(job.data).eql({foo:'bar'});
         expect(job.failedReason).eql('Manually failed processor');
         expect(err.message).eql('Manually failed processor');
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-        expect(queue.childPool.free).to.have.lengthOf(1);
+        expect(queue.childPool.pool.borrowed).to.equal(0);
+        expect(queue.childPool.pool.available).to.equal(1);
         done();
       } catch (err) {
         done(err);
@@ -133,11 +134,11 @@ describe('sandboxed process', function () {
 
     queue.on('completed', function(){
       try {
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-        expect(queue.childPool.free).to.have.lengthOf(1);
+        expect(queue.childPool.pool.borrowed).to.equal(0);
+        expect(queue.childPool.pool.available).to.equal(1);
         Promise.delay(500).then(function(){
-          expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-          expect(queue.childPool.free).to.have.lengthOf(0);
+          expect(queue.childPool.pool.borrowed).to.equal(0);
+          expect(queue.childPool.pool.available).to.equal(0);
         })
           .asCallback(done);
       } catch (err) {
@@ -193,12 +194,33 @@ describe('sandboxed process', function () {
     queue.process(__dirname + '/fixtures/fixture_processor_exit.js');
 
     var completed = sinon.spy();
-    queue.on('completed', completed);
+    var failed = sinon.spy();
 
-    _.times(5, queue.add.bind(queue, {foo:'bar'}));
+    queue.on('completed', completed);
+    queue.on('failed', failed);
+
+    _.times(2, queue.add.bind(queue, {foo:'bar'}));
 
     return Promise.delay(4000).then(function(){
       expect(completed.callCount).to.equal(1);
+      expect(failed.callCount).to.equal(1);
+    });
+  });
+
+  it('should respect concurrency option with killOnComplete: true', function () {
+    queue.process(5, __dirname + '/fixtures/fixture_processor.js', true);
+
+    var completed = sinon.spy();
+    queue.on('completed', completed);
+
+    _.times(15, queue.add.bind(queue, {foo:'bar'}));
+
+    return Promise.delay(1000).then(function(){
+      expect(completed.callCount).to.equal(5);
+    }).delay(1000).then(function(){
+      expect(completed.callCount).to.equal(10);
+    }).delay(1000).then(function(){
+      expect(completed.callCount).to.equal(15);
     });
   });
 });


### PR DESCRIPTION
This PR includes a test for processes being run sequentially after a job has been killed. It's failing right now because the same process thread is retained for queued jobs despite the previous iteration calling `process.exit()` within an async callback, causing subsequent jobs to die ungracefully and without warning. Possible solutions:
- Add a handler to restart jobs that exit in the middle of processing on a new thread
- Add a feature to kill jobs automatically upon completion, forcing a new thread to be retained every time

Depends on https://github.com/OptimalBits/bull/pull/749.