### PR TITLE
Supresses possible memory leak warnings

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -79,6 +79,7 @@ var MAX_TIMEOUT_MS = Math.pow(2, 31) - 1; // 32 bit signed
 // Queue(name: string, url?, opts?)
 var Queue = function Queue(name, url, opts){
   var _this = this;
+  _this.setMaxListeners(0);
   if(!(this instanceof Queue)){
     return new Queue(name, url, opts);
   }


### PR DESCRIPTION
Since many listeners can be attached when calling job.finished() Bull should set the max listeners to unlimited

Otherwise you will get possible memory leak warnings like these:

> (node:592) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 global:completed listeners added. Use emitter.setMaxListeners() to increase limit
> (node:592) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 global:failed listeners added. Use emitter.setMaxListeners() to increase limit