### PR TITLE
simplified calls to redis.call

### DIFF
--- a/lib/commands/extendLock-2.lua
+++ b/lib/commands/extendLock-2.lua
@@ -12,9 +12,10 @@
   Output:
     "1" if lock extented succesfully.
 ]]
-if redis.call("GET", KEYS[1]) == ARGV[1] then
-  if redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2]) then
-    redis.call("SREM", KEYS[2], ARGV[3])
+local rcall = redis.call
+if rcall("GET", KEYS[1]) == ARGV[1] then
+  if rcall("SET", KEYS[1], ARGV[1], "PX", ARGV[2]) then
+    rcall("SREM", KEYS[2], ARGV[3])
     return 1
   end
 end

--- a/lib/commands/moveToDelayed-3.lua
+++ b/lib/commands/moveToDelayed-3.lua
@@ -18,21 +18,23 @@
   Events:
     - delayed key.
 ]]
-if redis.call("EXISTS", KEYS[3]) == 1 then
+local rcall = redis.call
+
+if rcall("EXISTS", KEYS[3]) == 1 then
 
   -- Check for job lock
   if ARGV[3] ~= "0" then
     local lockKey = KEYS[3] .. ':lock'
-    local lock = redis.call("GET", lockKey)
-    if redis.call("GET", lockKey) ~= ARGV[3] then
+    local lock = rcall("GET", lockKey)
+    if rcall("GET", lockKey) ~= ARGV[3] then
       return -2
     end
   end
   
   local score = tonumber(ARGV[1])
-  redis.call("ZADD", KEYS[2], score, ARGV[2])
-  redis.call("PUBLISH", KEYS[2], (score / 0x1000))
-  redis.call("LREM", KEYS[1], 0, ARGV[2])
+  rcall("ZADD", KEYS[2], score, ARGV[2])
+  rcall("PUBLISH", KEYS[2], (score / 0x1000))
+  rcall("LREM", KEYS[1], 0, ARGV[2])
 
   return 0
 else

--- a/lib/commands/moveToFinished-3.lua
+++ b/lib/commands/moveToFinished-3.lua
@@ -25,30 +25,31 @@
      Events:
       'completed/failed'
 ]]
+local rcall = redis.call
 
-if redis.call("EXISTS", KEYS[3]) == 1 then -- // Make sure job exists
+if rcall("EXISTS", KEYS[3]) == 1 then -- // Make sure job exists
   if ARGV[5] ~= "0" then
     local lockKey = KEYS[3] .. ':lock'
-    if redis.call("GET", lockKey) == ARGV[5] then
-      redis.call("DEL", lockKey)
+    if rcall("GET", lockKey) == ARGV[5] then
+      rcall("DEL", lockKey)
     else
       return -2
     end
   end
 
   -- Remove from active list
-  redis.call("LREM", KEYS[1], -1, ARGV[1])
+  rcall("LREM", KEYS[1], -1, ARGV[1])
 
   -- Remove job?
   if ARGV[6] == "1" then
-    redis.call("DEL", KEYS[3])
+    rcall("DEL", KEYS[3])
   else
     -- Add to complete/failed set
-    redis.call("ZADD", KEYS[2], ARGV[2], ARGV[1])
-    redis.call("HMSET", KEYS[3], ARGV[3], ARGV[4], "finishedOn", ARGV[2]) -- "returnvalue" / "failedReason" and "finishedOn"
+    rcall("ZADD", KEYS[2], ARGV[2], ARGV[1])
+    rcall("HMSET", KEYS[3], ARGV[3], ARGV[4], "finishedOn", ARGV[2]) -- "returnvalue" / "failedReason" and "finishedOn"
   end
 
-  redis.call("PUBLISH", KEYS[2], ARGV[7])
+  rcall("PUBLISH", KEYS[2], ARGV[7])
   return 0
 else
   return -1

--- a/lib/commands/pause-4.lua
+++ b/lib/commands/pause-4.lua
@@ -12,14 +12,16 @@
     Event:
       publish paused or resumed event.
 ]]
-if redis.call("EXISTS", KEYS[1]) == 1 then
-  redis.call("RENAME", KEYS[1], KEYS[2])
+local rcall = redis.call
+
+if rcall("EXISTS", KEYS[1]) == 1 then
+  rcall("RENAME", KEYS[1], KEYS[2])
 end
 
 if ARGV[1] == "paused" then
-  redis.call("SET", KEYS[3], 1)
+  rcall("SET", KEYS[3], 1)
 else
-  redis.call("DEL", KEYS[3])
+  rcall("DEL", KEYS[3])
 end
 
-redis.call("PUBLISH", KEYS[4], ARGV[1])
+rcall("PUBLISH", KEYS[4], ARGV[1])

--- a/lib/commands/releaseLock-1.lua
+++ b/lib/commands/releaseLock-1.lua
@@ -10,8 +10,10 @@
       Output:
         "OK" if lock extented succesfully.
 ]]
-if redis.call("GET", KEYS[1]) == ARGV[1] then
-  return redis.call("DEL", KEYS[1])
+local rcall = redis.call
+
+if rcall("GET", KEYS[1]) == ARGV[1] then
+  return rcall("DEL", KEYS[1])
 else
   return 0
 end


### PR DESCRIPTION
this PR introduces an even counter. This is useful for UIs where realtime events from the queue are displayed. The counter is required so that the UI code can now if the current data it has from the queue is actually up-to-date.
(Note the PR is not ready yet)