### PR TITLE
Adding ability to limit by stacktrace

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -234,6 +234,7 @@ interface JobOpts{
 
   removeOnFail: boolean; // If true, removes the job when it fails after all attempts.
                          // Default behavior is to keep the job in the failed set.
+  stackTraceLimit: number; // Limits the amount of failures that will be recorded in the stacktrace.
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -234,7 +234,7 @@ interface JobOpts{
 
   removeOnFail: boolean; // If true, removes the job when it fails after all attempts.
                          // Default behavior is to keep the job in the failed set.
-  stackTraceLimit: number; // Limits the amount of failures that will be recorded in the stacktrace.
+  stackTraceLimit: number; // Limits the amount of stack trace lines that will be recorded in the stacktrace.
 }
 ```
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -449,6 +449,10 @@ Job.prototype._saveAttempt = function(multi, err){
     attemptsMade: this.attemptsMade
   };
 
+  if(this.opts.stackTraceLimit) {
+    this.stacktrace = this.stacktrace.slice(0, this.opts.stackTraceLimit - 1);
+  }
+
   this.stacktrace.push(err.stack);
   params.stacktrace = JSON.stringify(this.stacktrace);
   params.failedReason = err.message;

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -346,6 +346,25 @@ describe('Job', function(){
       });
     });
 
+    it('applies stacktrace limit on failure', function(){
+      var stackTraceLimit = 1;
+      return Job.create(queue, {foo: 'bar'}, {stackTraceLimit: stackTraceLimit}).then(function(job){
+        return job.isFailed().then(function(isFailed){
+          expect(isFailed).to.be(false);
+        }).then(function(){
+          return job.moveToFailed(new Error('test error'), true);
+        }).then(function(){
+          return job.moveToFailed(new Error('test error'), true).then(function(){
+            return job.isFailed().then(function(isFailed){
+              expect(isFailed).to.be(true);
+              expect(job.stacktrace).not.be(null);
+              expect(job.stacktrace.length).to.be(stackTraceLimit);
+            });
+          });
+        });
+      });
+    });
+
   });
 
   describe('.promote', function() {


### PR DESCRIPTION
If a job fails multiple times the stacktrace can grow very large. 
This is to limit the amount of memory used by a failed job. 

This enables a job to be created with a max stacktrace. 