### PR TITLE
Mention global events only passing job ID in docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -700,3 +700,32 @@ queue.on('completed', listener):
 // Will listen globally, to instances of this queue...
 queue.on('global:completed', listener);
 ```
+
+When working with global events whose local counterparts pass a `Job` instance to the event listener callback, notice that global events pass the **job's ID** instead.
+
+If you need to access the `Job` instance in a global listener, use [Queue#getJob](#queuegetjob) to retrieve it. However, remember that if `removeOnComplete` is enabled when adding the job, the job will no longer be available after completion. Should you need to both access the job and remove it after completion, you can use [Job#remove](#jobremove) to remove it in the listener.
+
+```js
+
+// Local events pass the job instance...
+queue.on('progress', function(job, progress) {
+  console.log(`Job ${job.id} is ${progress * 100}% ready!`);
+});
+
+queue.on('completed', function(job, result) {
+  console.log(`Job ${job.id} completed! Result: ${result}`);
+  job.remove();
+});
+
+// ...whereas global events only pass the job ID:
+queue.on('global:progress', function(jobId, progress) {
+  console.log(`Job ${jobId} is ${progress * 100}% ready!`);
+});
+
+queue.on('global:completed', function(jobId, result) {
+  console.log(`Job ${jobId} completed! Result: ${result}`);
+  queue.getJob(jobId).then(function(job) {
+    job.remove();
+  });
+});
+```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -37,6 +37,7 @@ Reference
   - [Job#finished](#jobfinished)
 
 - [Events](#events)
+  - [Global events](#global-events)
 
 
 Queue
@@ -691,7 +692,9 @@ A queue emits also some useful events:
 });
 ```
 
-Events are local by default—in other words they only fire on the listeners that are registered on the given worker, if you need to listen to events globally, just prefix the event with `'global:'`:
+### Global events
+
+Events are local by default — in other words, they only fire on the listeners that are registered on the given worker. If you need to listen to events globally, for example from other servers across redis, just prefix the event with `'global:'`:
 
 ```js
 // Will listen locally, just to this queue...


### PR DESCRIPTION
The documentation in its current state only briefly covers global events. As seen in #693, there's no mention of global event listeners only receiving the job ID instead of the job itself. This PR attempts to fill that gap in the reference.

Additionally, this PR also highlights their existence by adding a subsection for global events in the table of contents.