### PR TITLE
Update Patterns Documentation to Clarify Redis Setup

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -67,7 +67,7 @@ Reusing Redis Connections
 A standard queue requires **3 connections** to the Redis server. In some situations you might want to re-use connections—for example on Heroku where the connection count is restricted. You can do this with the `createClient` option in the `Queue` constructor:
 
 ```js
-var { REDIS_URL} = process.env
+var {REDIS_URL} = process.env
 
 var Redis = require('ioredis')
 var client = new Redis(REDIS_URL);

--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -67,8 +67,11 @@ Reusing Redis Connections
 A standard queue requires **3 connections** to the Redis server. In some situations you might want to re-use connections—for example on Heroku where the connection count is restricted. You can do this with the `createClient` option in the `Queue` constructor:
 
 ```js
-var client = new redis();
-var subscriber = new redis();
+var { REDIS_URL} = process.env
+
+var Redis = require('ioredis')
+var client = new Redis(REDIS_URL);
+var subscriber = new Redis(REDIS_URL);
 
 var opts = {
     createClient: function(type){
@@ -78,7 +81,7 @@ var opts = {
         case 'subscriber':
           return subscriber;
         default:
-          return new redis();
+          return new Redis();
       }
     }
   }


### PR DESCRIPTION
:wave: awesome library!

I would just like to add a few clarifications to the documentation. This took me about 30 minutes to figure out. Not a long time, but I would hate to have somebody else stumble upon and go through what I did.

Two things:

- I tried using `redis` library, bull uses `ioredis`
- passing in a `REDIS_URL`. Doesn't have to happen here, but I would like to at least make a NOTE of it, especially since Heroku is mentioned elsewhere and I am in fact using Heroku.

Thanks 😄 