### PR TITLE
Send SIGTERM instead of 0 which does not seem to kill the child process at all

### DIFF
--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -57,7 +57,8 @@ module.exports = function ChildPool() {
     var children = _.values(this.retained).concat(this.free);
     var _this = this;
     children.forEach(function(child){
-      _this.kill(child, 0);
+      // TODO: We may want to use SIGKILL if the process does not die after some time.
+      _this.kill(child, 'SIGTERM');
     });
 
     this.retained = {};


### PR DESCRIPTION
fixes #812 