### PR TITLE
Quitting own Redis clients and removing listeners on others

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -235,9 +235,26 @@ function redisClientGetter(queue, options, initCallback) {
     return function() { // getter function
       if (connections[type] != null) return connections[type];
       var client = connections[type] = createClient(type, options.redis);
-      if(!options.createClient){
-        queue.clients.push(client);
+
+      var isForeign = options.createClient === createClient;
+      var listeners = [];
+      if (isForeign && _.isFunction(client.on)) {
+        client.on = ((function (on) {
+          return function (event, listener) {
+            listeners.push({
+              event: event,
+              listener: listener
+            });
+            return on.call(this, event, listener);
+          };
+        })(client.on));
       }
+      queue.clients.push({
+        isForeign: isForeign,
+        listeners: listeners,
+        client: client
+      });
+
       return initCallback(type, client), client;
     };
   };
@@ -469,14 +486,19 @@ function redisClientDisconnect(client){
 }
 
 Queue.prototype.disconnect = function(){
-  //
-  // TODO: Only quit clients that we "own".
-  //
-  var clients = this.clients.filter(function(client){
-    return client.status !== 'end';
-  });
-
-  return Promise.all(clients.map(redisClientDisconnect))
+  return Promise.all(this.clients.map(function(c) {
+    if (!c.isForeign && c.client.status !== 'end') {
+      return redisClientDisconnect.call(this, c.client);
+    } else if (c.isForeign && _.isArray(c.listeners)) {
+      _.remove(c.listeners, function(value) {
+        if (value.event && value.listener) {
+          return c.client.removeListener(value.event, value.listener), true;
+        }
+        return false;
+      });
+    }
+    return Promise.resolve();
+  }))
     .then(function(){})
     .catch(function(err){
       return console.error(err);
@@ -535,7 +557,7 @@ Queue.prototype.process = function(name, concurrency, handler){
     case 1:
       handler = name;
       concurrency = 1;
-      name = Job.DEFAULT_JOB_NAME;      
+      name = Job.DEFAULT_JOB_NAME;
       break;
     case 2: // (string, function) or (string, string) or (number, function) or (number, string)
       handler = concurrency;
@@ -758,7 +780,7 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
       }).catch(function(err){
         _this.emit('error', err, 'Error updating the delay timer');
       }).return(null);
-      _this.delayedTimestamp = Number.MAX_VALUE;      
+      _this.delayedTimestamp = Number.MAX_VALUE;
     };
 
     if(delay){
@@ -1040,14 +1062,14 @@ Queue.prototype.whenCurrentJobsFinished = function(){
         _this.bclient.connect();
       }, 0);
     });
-    
+
     /*
     var stream = _this.bclient.connector.stream;
     if(stream){
       stream.on('finish', function(){
         console.error('FINISHED!');
         _this.bclient.connect();
-      });  
+      });
       stream.on('error', function(err){
         console.error('errir', err);
         _this.bclient.connect();

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -75,7 +75,7 @@ describe('connection', function () {
 
     var client = new redis();
     var subscriber = new redis();
-    
+
     var opts = {
       createClient: function(type){
         switch(type){
@@ -101,6 +101,9 @@ describe('connection', function () {
     }).then(function(){
       expect(client.status).to.be.eql('ready');
       expect(subscriber.status).to.be.eql('ready');
+      expect(testQueue.clients.reduce(function(sum, c) {
+        return sum + c.listeners.length;
+      }, 0)).to.be.eql(0);
     });
   });
 });


### PR DESCRIPTION
I'm pretty sure it's not an ideal approach, but it should properly work with any kind of clients. I've tested it with `npm test` and live, it looks good.