### PR TITLE
 Added repeatable limit feature

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -255,6 +255,7 @@ interface RepeatOpts{
   cron: string; // Cron string
   tz?: string, // Timezone
   endDate?: Date | string | number; // End data when the repeat job should stop repeating.
+  limit?: number; // Number of times the job should repeat at max.
 }
 ```
 

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -19,7 +19,7 @@ module.exports = function(Queue){
       repeat.jobId = opts.jobId;
     }
 
-    repeat.count = repeat.count ? repeat.count+1 : 1;
+    repeat.count = repeat.count ? repeat.count + 1 : 1;
 
     if (!_.isUndefined(repeat.limit) && repeat.count > repeat.limit) {
       return Promise.resolve();

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -19,6 +19,12 @@ module.exports = function(Queue){
       repeat.jobId = opts.jobId;
     }
 
+    repeat.count = repeat.count ? repeat.count+1 : 1;
+
+    if (!_.isUndefined(repeat.limit) && repeat.count > repeat.limit) {
+      return Promise.resolve();
+    }
+
     var now = Date.now();
     now = prevMillis < now ? now : prevMillis;
 

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -313,4 +313,33 @@ describe('repeat', function () {
     });  
   });
 
+  it('should not repeat more than 5 times', function (done) {
+    var _this = this;
+    var date = new Date('2017-02-07 9:24:00');
+    this.clock.tick(date.getTime());
+    var nextTick = ONE_SECOND + 500;
+
+    queue.add('repeat', {foo: 'bar'}, { repeat: {limit: 5, cron: '*/1 * * * * *'}}).then(function(){
+      _this.clock.tick(nextTick);
+    });
+
+    queue.process('repeat', function(){
+      // dummy
+    });
+
+    var counter = 0;
+    queue.on('completed', function(){
+      _this.clock.tick(nextTick);
+      counter++;
+      if(counter == 5){
+        utils.sleep(nextTick*2).then(function() {
+          done();
+        }, nextTick*2);
+      }
+      else if (counter > 5) {
+        done(Error('should not repeat more than 5 times'));
+      }
+    });
+  });
+
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,6 +8,8 @@ var _ = require('lodash');
 
 var queues = [];
 
+var originalSetTimeout = setTimeout;
+
 function simulateDisconnect(queue){
   queue.client.disconnect();
   queue.eclient.disconnect();
@@ -39,10 +41,19 @@ function cleanupQueues() {
   });
 }
 
+function sleep(ms){
+  return new Promise(function(resolve) {
+    originalSetTimeout(function() {
+      resolve();
+    }, ms);
+  });
+}
+
 module.exports = {
   simulateDisconnect: simulateDisconnect,
   buildQueue: buildQueue,
   cleanupQueue: cleanupQueue,
   newQueue: newQueue,
-  cleanupQueues: cleanupQueues
+  cleanupQueues: cleanupQueues,
+  sleep: sleep
 };


### PR DESCRIPTION
The problem: 
When dealing with clustered processors, it is hard to achieve an easy implementation to limit the number of times a repeatable job should run without diving into Bull's nextRepeatableJob method.

The solution:
An extended attribute on the RepeatOpts interface to indicate how many times the job should run at max. It will increment a counter on the RepeatOpts itself ("count") to help keep track of what is the limit and how many jobs were already initiated.

I've added a test case and updated the Queue.add method documentation accordingly.

Works like a charm on my clustered app :)