### PR TITLE
Add defaultJobOptions to Queue

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -59,6 +59,7 @@ interface QueueOptions {
   limiter?: RateLimiter;
   redis?: RedisOpts;
   prefix?: string = 'bull'; // prefix for all queue keys.
+  defaultJobOptions?: JobOpts;
   settings?: AdvancedSettings;
 }
 ```

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -59,6 +59,7 @@ var MAX_TIMEOUT_MS = Math.pow(2, 31) - 1; // 32 bit signed
     limiter?: RateLimiter,
     redis : RedisOpts, // ioredis defaults,
     createClient?: (type: enum('client', 'subscriber'), redisOpts?: RedisOpts) => redisClient,
+    defaultJobOptions?: JobOptions,
 
     // Advanced settings
     settings?: QueueSettings {
@@ -100,6 +101,10 @@ var Queue = function Queue(name, url, opts){
 
   if(opts.limiter){
     this.limiter = opts.limiter;
+  }
+
+  if (opts.defaultJobOptions) {
+    this.defaultJobOptions = opts.defaultJobOptions;
   }
 
   this.name = name;
@@ -621,6 +626,9 @@ Queue.prototype.add = function(name, data, opts){
     data = name;
     name = Job.DEFAULT_JOB_NAME;
   }
+  if (!opts) opts = {};
+  _.defaults(opts, this.defaultJobOptions);
+
   if(opts && opts.repeat){
     var _this = this;
     return this.isReady().then(function(){

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -626,10 +626,10 @@ Queue.prototype.add = function(name, data, opts){
     data = name;
     name = Job.DEFAULT_JOB_NAME;
   }
-  if (!opts) opts = {};
+  opts = _.cloneDeep(opts || {});
   _.defaults(opts, this.defaultJobOptions);
 
-  if(opts && opts.repeat){
+  if(opts.repeat){
     var _this = this;
     return this.isReady().then(function(){
       return _this.nextRepeatableJob(name, data, opts);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -332,6 +332,15 @@ describe('Queue', function () {
         });
       }, done);
     });
+
+    it('creates a queue with default job options', function (done) {
+      var defaultJobOptions = { removeOnComplete: true };
+      var queue = new Queue('custom', { defaultJobOptions: defaultJobOptions });
+
+      expect(queue.defaultJobOptions).to.be.eql(defaultJobOptions);
+
+      queue.close().then(done, done);
+    });
   });
 
   describe(' a worker', function () {
@@ -385,6 +394,36 @@ describe('Queue', function () {
           });
         });
       });
+    });
+
+    it('should remove a job after completed if the default job options specify removeOnComplete', function (done) {
+      utils.newQueue('test-' + uuid(), {
+        defaultJobOptions: {
+          removeOnComplete: true
+        }
+      }).then(function (myQueue) {
+        myQueue.process(function (job, jobDone) {
+          expect(job.data.foo).to.be.equal('bar');
+          jobDone();
+        }).catch(done);
+
+        myQueue.add({ foo: 'bar' }).then(function (job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        }, done).catch(done);
+
+        myQueue.on('completed', function(job){
+          myQueue.getJob(job.id).then(function(job){
+            expect(job).to.be.equal(null);
+          }).then(function(){
+            return myQueue.getJobCounts();
+          }).then(function(counts){
+            expect(counts.completed).to.be.equal(0);
+
+            return utils.cleanupQueues();
+          }).then(done).catch(done);
+        });
+      }).catch(done);
     });
 
     it('should remove job after failed if removeOnFail', function (done) {


### PR DESCRIPTION
I'd like to pass `removeOnComplete` and `removeOnFail` only once, instead of every time I run `.add()` on a queue. This patch adds a new option to queues called `defaultJobOptions` which, as the name suggests, sets the default job options.

Also adds two tests verifying that the option is passed through correctly and that it works with `removeOnComplete`. I wasn't sure whether to more tests were necessary, if so, please just let me know and I'll work on it.

Closes #706