### PR TITLE
Implement prettier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,9 @@ node_js:
 services:
   - redis-server
 
+script:
+  - npm run prettier -- --list-different
+  - npm run test
+
 after_script:
   - npm run coveralls

--- a/examples/cluster-queue.js
+++ b/examples/cluster-queue.js
@@ -1,31 +1,29 @@
 'use strict';
 
-var
-  Queue = require('..'),
+var Queue = require('..'),
   cluster = require('cluster');
 
 var numWorkers = 8;
 var queue = Queue('test concurrent queue', 6379, '127.0.0.1');
 
-if(cluster.isMaster){
+if (cluster.isMaster) {
   for (var i = 0; i < numWorkers; i++) {
     cluster.fork();
   }
 
   cluster.on('online', function(worker) {
     // Lets create a few jobs for every created worker
-    for(var i=0; i<500; i++){
-      queue.add({foo: 'bar'});
-    };
+    for (var i = 0; i < 500; i++) {
+      queue.add({ foo: 'bar' });
+    }
   });
 
   cluster.on('exit', function(worker, code, signal) {
     console.log('worker ' + worker.process.pid + ' died');
   });
-}else{
-  queue.process(function(job, jobDone){
+} else {
+  queue.process(function(job, jobDone) {
     console.log('Job done by worker', cluster.worker.id, job.jobId);
     jobDone();
   });
 }
-

--- a/examples/state.js
+++ b/examples/state.js
@@ -6,14 +6,14 @@
 
 var machine = Machine('signup', opts); // opts -> redis connection mostly, name of the machine.
 
-machine.state('send mail', function(data, next){
+machine.state('send mail', function(data, next) {
   // In this state we send an email with a confirmation link and exit the state
   next('wait confirmation', data);
 });
 
 machine.state('wait confirmation'); // // In this state we do nothing we just wait for an external input
 
-machine.state('confirm user', function(task){
+machine.state('confirm user', function(task) {
   return data;
 });
 
@@ -22,27 +22,25 @@ machine.next('wait confirmation', data);
 /**
   queue('wait confirmation').add(data);
   */
-machine.state('transcode video', function(data){
-  // transcode...
-  this.next('append moov');
-}).catch(function(err){
-  this.next('delete tmp');
-});
+machine
+  .state('transcode video', function(data) {
+    // transcode...
+    this.next('append moov');
+  })
+  .catch(function(err) {
+    this.next('delete tmp');
+  });
 
-machine.state('append moov', input, function(data, next){
+machine.state('append moov', input, function(data, next) {
   // Append MOOV etc.
   this.next('delete tmp');
 });
 
-machine.next('delete temp', input, function(data, next){
+machine.next('delete temp', input, function(data, next) {
   // delete temp file
   this.next('update user account');
 });
 
-machine.state('update user account', function(data, next){
+machine.state('update user account', function(data, next) {
   // update database
 });
-
-
-
-

--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-
 module.exports = require('./lib/queue');
 module.exports.Job = require('./lib/job');

--- a/lib/backoffs.js
+++ b/lib/backoffs.js
@@ -1,14 +1,14 @@
 var _ = require('lodash');
 
 var builtinStrategies = {
-  fixed: function (delay) {
-    return function () {
+  fixed: function(delay) {
+    return function() {
       return delay;
     };
   },
 
-  exponential: function (delay) {
-    return function (attemptsMade) {
+  exponential: function(delay) {
+    return function(attemptsMade) {
       return Math.round((Math.pow(2, attemptsMade) - 1) * delay);
     };
   }
@@ -20,12 +20,16 @@ function lookupStrategy(backoff, customStrategies) {
   } else if (backoff.type in builtinStrategies) {
     return builtinStrategies[backoff.type](backoff.delay);
   } else {
-    throw new Error('Unknown backoff strategy ' + backoff.type + '. If a custom backoff strategy is used, specify it when the queue is created.');
+    throw new Error(
+      'Unknown backoff strategy ' +
+        backoff.type +
+        '. If a custom backoff strategy is used, specify it when the queue is created.'
+    );
   }
 }
 
 module.exports = {
-  normalize: function (backoff) {
+  normalize: function(backoff) {
     if (_.isFinite(backoff)) {
       return {
         type: 'fixed',
@@ -36,7 +40,7 @@ module.exports = {
     }
   },
 
-  calculate: function (backoff, attemptsMade, customStrategies) {
+  calculate: function(backoff, attemptsMade, customStrategies) {
     if (backoff) {
       var strategy = lookupStrategy(backoff, customStrategies);
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -24,14 +24,14 @@ fs = Promise.promisifyAll(fs);
 // for some very strange reason, defining scripts with this code results in this error
 // when executing the scripts: ERR value is not an integer or out of range
 //
-module.exports = (function (){
+module.exports = (function() {
   var scripts;
 
-  return function(client){
-    return utils.isRedisReady(client).then(function(){
+  return function(client) {
+    return utils.isRedisReady(client).then(function() {
       scripts = scripts || loadScripts(__dirname);
 
-      return scripts.each(function (command){
+      return scripts.each(function(command) {
         return client.defineCommand(command.name, command.options);
       });
     });
@@ -39,18 +39,21 @@ module.exports = (function (){
 })();
 
 function loadScripts(dir) {
-  return fs.readdirAsync(dir).filter(function (file){
-    return path.extname(file) === '.lua';
-  }).map(function (file) {
-    var longName = path.basename(file, '.lua');
-    var name = longName.split('-')[0];
-    var numberOfKeys = parseInt(longName.split('-')[1]);
+  return fs
+    .readdirAsync(dir)
+    .filter(function(file) {
+      return path.extname(file) === '.lua';
+    })
+    .map(function(file) {
+      var longName = path.basename(file, '.lua');
+      var name = longName.split('-')[0];
+      var numberOfKeys = parseInt(longName.split('-')[1]);
 
-    return fs.readFileAsync(path.join(dir, file)).then(function(lua){
-      return {
-        name: name,
-        options: { numberOfKeys: numberOfKeys, lua: lua.toString() }
-      };
+      return fs.readFileAsync(path.join(dir, file)).then(function(lua) {
+        return {
+          name: name,
+          options: { numberOfKeys: numberOfKeys, lua: lua.toString() }
+        };
+      });
     });
-  });
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,7 +1,8 @@
 'use strict';
 
 module.exports.Messages = {
-  RETRY_JOB_NOT_EXIST: 'Couldn\'t retry job: The job doesn\'t exist',
-  RETRY_JOB_IS_LOCKED: 'Couldn\'t retry job: The job is locked',
-  RETRY_JOB_NOT_FAILED: 'Couldn\'t retry job: The job has been already retried or has not failed'
+  RETRY_JOB_NOT_EXIST: "Couldn't retry job: The job doesn't exist",
+  RETRY_JOB_IS_LOCKED: "Couldn't retry job: The job is locked",
+  RETRY_JOB_NOT_FAILED:
+    "Couldn't retry job: The job has been already retried or has not failed"
 };

--- a/lib/getters.js
+++ b/lib/getters.js
@@ -4,9 +4,8 @@
 var _ = require('lodash');
 var Job = require('./job');
 
-module.exports = function(Queue){
-  
-  Queue.prototype.getJob = function(jobId){
+module.exports = function(Queue) {
+  Queue.prototype.getJob = function(jobId) {
     return Job.fromId(this, jobId);
   };
 
@@ -18,7 +17,7 @@ module.exports = function(Queue){
 
       var key = _this.toKey(type);
 
-      switch(type) {
+      switch (type) {
         case 'completed':
         case 'failed':
         case 'delayed':
@@ -35,7 +34,7 @@ module.exports = function(Queue){
   /**
     Returns the number of jobs waiting to be processed.
   */
-  Queue.prototype.count = function(){
+  Queue.prototype.count = function() {
     return this.getJobCountByTypes('wait', 'paused', 'delayed');
   };
 
@@ -45,8 +44,11 @@ module.exports = function(Queue){
   // Queue#getJobCountByTypes('completed', 'failed') => completed + failed count
   // Queue#getJobCountByTypes('completed,waiting', 'failed') => completed + waiting + failed count
   Queue.prototype.getJobCountByTypes = function() {
-    return this.getJobCounts.apply(this, arguments).then(function(result){
-      return _.chain(result).values().sum().value();
+    return this.getJobCounts.apply(this, arguments).then(function(result) {
+      return _.chain(result)
+        .values()
+        .sum()
+        .value();
     });
   };
 
@@ -54,17 +56,17 @@ module.exports = function(Queue){
    * Returns the job counts for each type specified or every list/set in the queue by default.
    *
    */
-  Queue.prototype.getJobCounts = function(){
+  Queue.prototype.getJobCounts = function() {
     var types = parseTypeArg(arguments);
     var multi = this.multi();
 
-    this._commandByType(types, true, function(key, command){
+    this._commandByType(types, true, function(key, command) {
       multi[command](key);
     });
 
-    return multi.exec().then(function(res){
+    return multi.exec().then(function(res) {
       var counts = {};
-      res.forEach(function(res, index){
+      res.forEach(function(res, index) {
         counts[types[index]] = res[1] || 0;
       });
       return counts;
@@ -95,65 +97,77 @@ module.exports = function(Queue){
     return this.getJobCountByTypes('paused');
   };
 
-  Queue.prototype.getWaiting = function(start, end){
-    return this.getJobs([ 'wait', 'paused' ], start, end, true);
+  Queue.prototype.getWaiting = function(start, end) {
+    return this.getJobs(['wait', 'paused'], start, end, true);
   };
 
-  Queue.prototype.getActive = function(start, end){
+  Queue.prototype.getActive = function(start, end) {
     return this.getJobs('active', start, end, true);
   };
 
-  Queue.prototype.getDelayed = function(start, end){
+  Queue.prototype.getDelayed = function(start, end) {
     return this.getJobs('delayed', start, end, true);
   };
 
-  Queue.prototype.getCompleted = function(start, end){
+  Queue.prototype.getCompleted = function(start, end) {
     return this.getJobs('completed', start, end, false);
   };
 
-  Queue.prototype.getFailed = function(start, end){
+  Queue.prototype.getFailed = function(start, end) {
     return this.getJobs('failed', start, end, false);
   };
 
-  Queue.prototype.getRanges = function(types, start, end, asc){
+  Queue.prototype.getRanges = function(types, start, end, asc) {
     var _this = this;
 
     start = _.isUndefined(start) ? 0 : start;
     end = _.isUndefined(end) ? -1 : end;
 
-    var resultByType = _this._commandByType(parseTypeArg(types), false, function(key, command){
-      switch(command){
-        case 'lrange':
-          if(asc){
-            return _this.client.lrange(key, -(end + 1), -(start + 1)).then(function(result){
-              return result.reverse();
-            });
-          }else{
-            return _this.client.lrange(key, start, end);
-          }
-        case 'zrange':
-          return asc ? _this.client.zrange(key, start, end) : _this.client.zrevrange(key, start, end);
+    var resultByType = _this._commandByType(
+      parseTypeArg(types),
+      false,
+      function(key, command) {
+        switch (command) {
+          case 'lrange':
+            if (asc) {
+              return _this.client
+                .lrange(key, -(end + 1), -(start + 1))
+                .then(function(result) {
+                  return result.reverse();
+                });
+            } else {
+              return _this.client.lrange(key, start, end);
+            }
+          case 'zrange':
+            return asc
+              ? _this.client.zrange(key, start, end)
+              : _this.client.zrevrange(key, start, end);
+        }
       }
-    });
+    );
 
-    return Promise.all(resultByType).then(function(results){
+    return Promise.all(resultByType).then(function(results) {
       return _.flatten(results);
     });
   };
 
-  Queue.prototype.getJobs = function(types, start, end, asc){
+  Queue.prototype.getJobs = function(types, start, end, asc) {
     var _this = this;
-    return this.getRanges(types, start, end, asc).then(function(jobIds){
+    return this.getRanges(types, start, end, asc).then(function(jobIds) {
       return Promise.all(jobIds.map(_this.getJobFromId));
     });
   };
 };
 
 function parseTypeArg(args) {
-  var types = _.chain([]).concat(args).join(',').split(/\s*,\s*/g).compact().value();
+  var types = _.chain([])
+    .concat(args)
+    .join(',')
+    .split(/\s*,\s*/g)
+    .compact()
+    .value();
 
   return types.length
     ? types
     : ['waiting', 'active', 'completed', 'failed', 'delayed'];
 }
-

--- a/lib/job.js
+++ b/lib/job.js
@@ -21,8 +21,8 @@ interface JobOptions
 */
 
 // queue: Queue, data: {}, opts: JobOptions
-var Job = function(queue, name, data, opts){
-  if(typeof name !== 'string'){
+var Job = function(queue, name, data, opts) {
+  if (typeof name !== 'string') {
     opts = data;
     data = name;
     name = '__default__';
@@ -44,12 +44,13 @@ var Job = function(queue, name, data, opts){
   this.toKey = _.bind(queue.toKey, queue);
 };
 
-function setDefaultOpts(opts){
+function setDefaultOpts(opts) {
   var _opts = Object.assign({}, opts);
 
   _opts.attempts = typeof _opts.attempts == 'undefined' ? 1 : _opts.attempts;
   _opts.delay = typeof _opts.delay == 'undefined' ? 0 : _opts.delay;
-  _opts.timestamp = typeof _opts.timestamp == 'undefined' ? Date.now() : _opts.timestamp;
+  _opts.timestamp =
+    typeof _opts.timestamp == 'undefined' ? Date.now() : _opts.timestamp;
 
   _opts.attempts = parseInt(_opts.attempts);
   _opts.backoff = backoffs.normalize(_opts.backoff);
@@ -59,53 +60,66 @@ function setDefaultOpts(opts){
 
 Job.DEFAULT_JOB_NAME = '__default__';
 
-function addJob(queue, job){
+function addJob(queue, job) {
   var opts = job.opts;
 
   var jobData = job.toData();
-  return scripts.addJob(queue.client, queue, jobData, {
-    lifo: opts.lifo,
-    customJobId: opts.jobId,
-    priority: opts.priority
-  }, queue.token);
+  return scripts.addJob(
+    queue.client,
+    queue,
+    jobData,
+    {
+      lifo: opts.lifo,
+      customJobId: opts.jobId,
+      priority: opts.priority
+    },
+    queue.token
+  );
 }
 
-Job.create = function(queue, name, data, opts){
+Job.create = function(queue, name, data, opts) {
   var job = new Job(queue, name, data, opts);
 
-  return queue.isReady().then(function(){
-    return addJob(queue, job);
-  }).then(function(jobId){
-    job.id = jobId;
-    job.lockKey = job.toKey(jobId) + ':lock';
-    debuglog('Job added', jobId);
-    return job;
-  });
+  return queue
+    .isReady()
+    .then(function() {
+      return addJob(queue, job);
+    })
+    .then(function(jobId) {
+      job.id = jobId;
+      job.lockKey = job.toKey(jobId) + ':lock';
+      debuglog('Job added', jobId);
+      return job;
+    });
 };
 
-Job.fromId = function(queue, jobId){
+Job.fromId = function(queue, jobId) {
   // jobId can be undefined if moveJob returns undefined
-  if(!jobId) {
+  if (!jobId) {
     return Promise.resolve();
   }
-  return queue.client.hgetall(queue.toKey(jobId)).then(function(jobData){
+  return queue.client.hgetall(queue.toKey(jobId)).then(function(jobData) {
     return utils.isEmpty(jobData) ? null : Job.fromJSON(queue, jobData, jobId);
   });
 };
 
-Job.prototype.progress = function(progress){
-  if(_.isUndefined(progress)){
+Job.prototype.progress = function(progress) {
+  if (_.isUndefined(progress)) {
     return this._progress;
   }
   this._progress = progress;
   return scripts.updateProgress(this, progress);
 };
 
-Job.prototype.update = function(data){
-  return this.queue.client.hset(this.queue.toKey(this.id), 'data', JSON.stringify(data));
+Job.prototype.update = function(data) {
+  return this.queue.client.hset(
+    this.queue.toKey(this.id),
+    'data',
+    JSON.stringify(data)
+  );
 };
 
-Job.prototype.toJSON = function(){
+Job.prototype.toJSON = function() {
   var opts = Object.assign({}, this.opts);
   return {
     id: this.id,
@@ -124,7 +138,7 @@ Job.prototype.toJSON = function(){
   };
 };
 
-Job.prototype.toData = function(){
+Job.prototype.toData = function() {
   var json = this.toJSON();
 
   json.data = JSON.stringify(json.data);
@@ -139,7 +153,7 @@ Job.prototype.toData = function(){
 /**
   Return a unique key representing a lock for this Job
 */
-Job.prototype.lockKey = function(){
+Job.prototype.lockKey = function() {
   return this.toKey(this.id) + ':lock';
 };
 
@@ -147,7 +161,7 @@ Job.prototype.lockKey = function(){
   Takes a lock for this job so that no other queue worker can process it at the
   same time.
 */
-Job.prototype.takeLock = function(){
+Job.prototype.takeLock = function() {
   return scripts.takeLock(this.queue, this).then(function(lock) {
     return lock || false;
   });
@@ -156,63 +170,82 @@ Job.prototype.takeLock = function(){
 /**
   Releases the lock. Only locks owned by the queue instance can be released.
 */
-Job.prototype.releaseLock = function(){
+Job.prototype.releaseLock = function() {
   var _this = this;
   return scripts.releaseLock(this.queue, this.id).then(function(unlocked) {
-    if(unlocked != 1){
+    if (unlocked != 1) {
       throw new Error('Could not release lock for job ' + _this.id);
     }
   });
 };
 
-Job.prototype.moveToCompleted = function(returnValue, ignoreLock){
+Job.prototype.moveToCompleted = function(returnValue, ignoreLock) {
   this.returnvalue = returnValue || 0;
 
   returnValue = utils.tryCatch(JSON.stringify, JSON, [returnValue]);
-  if(returnValue === utils.errorObject) {
+  if (returnValue === utils.errorObject) {
     var err = utils.errorObject.value;
     return Promise.reject(err);
   }
 
-  return scripts.moveToCompleted(this, returnValue, this.opts.removeOnComplete, ignoreLock);
+  return scripts.moveToCompleted(
+    this,
+    returnValue,
+    this.opts.removeOnComplete,
+    ignoreLock
+  );
 };
 
-Job.prototype.discard = function(){
+Job.prototype.discard = function() {
   this._discarded = true;
 };
 
-Job.prototype.moveToFailed = function(err, ignoreLock){
+Job.prototype.moveToFailed = function(err, ignoreLock) {
   var _this = this;
   this.failedReason = err.message;
-  return new Promise(function(resolve, reject){
+  return new Promise(function(resolve, reject) {
     var command;
     var multi = _this.queue.client.multi();
     _this._saveAttempt(multi, err);
 
     // Check if an automatic retry should be performed
-    if(_this.attemptsMade < _this.opts.attempts && !_this._discarded){
+    if (_this.attemptsMade < _this.opts.attempts && !_this._discarded) {
       // Check if backoff is needed
-      var delay = backoffs.calculate(_this.opts.backoff, _this.attemptsMade, _this.queue.settings.backoffStrategies);
+      var delay = backoffs.calculate(
+        _this.opts.backoff,
+        _this.attemptsMade,
+        _this.queue.settings.backoffStrategies
+      );
 
-      if(delay){
+      if (delay) {
         // If so, move to delayed (need to unlock job in this case!)
-        var args = scripts.moveToDelayedArgs(_this.queue, _this.id, Date.now() + delay, ignoreLock);
+        var args = scripts.moveToDelayedArgs(
+          _this.queue,
+          _this.id,
+          Date.now() + delay,
+          ignoreLock
+        );
         multi.moveToDelayed(args);
         command = 'delayed';
-      }else{
+      } else {
         // If not, retry immediately
         multi.retryJob(scripts.retryJobArgs(_this, ignoreLock));
         command = 'retry';
       }
     } else {
       // If not, move to failed
-      var args = scripts.moveToFailedArgs(_this, err.message, _this.opts.removeOnFail, ignoreLock);
+      var args = scripts.moveToFailedArgs(
+        _this,
+        err.message,
+        _this.opts.removeOnFail,
+        ignoreLock
+      );
       multi.moveToFinished(args);
       command = 'failed';
     }
-    return multi.exec().then(function(results){
+    return multi.exec().then(function(results) {
       var code = _.last(results)[1];
-      if (code < 0){
+      if (code < 0) {
         return reject(scripts.finishedErrors(code, _this.id, command));
       }
       resolve();
@@ -220,11 +253,11 @@ Job.prototype.moveToFailed = function(err, ignoreLock){
   });
 };
 
-Job.prototype.moveToDelayed = function(timestamp, ignoreLock){
+Job.prototype.moveToDelayed = function(timestamp, ignoreLock) {
   return scripts.moveToDelayed(this.queue, this.id, timestamp, ignoreLock);
 };
 
-Job.prototype.promote = function(){
+Job.prototype.promote = function() {
   var queue = this.queue;
   var jobId = this.id;
 
@@ -237,21 +270,17 @@ Job.prototype.promote = function(){
     'end'
   ].join('\n');
 
-  var keys = _.map(['delayed', 'wait'], function(name){
+  var keys = _.map(['delayed', 'wait'], function(name) {
     return queue.toKey(name);
   });
 
-  return queue.client.eval(
-    script,
-    keys.length,
-    keys[0],
-    keys[1],
-    jobId
-  ).then(function(result){
-    if(result === -1){
-      throw new Error('Job ' + jobId + ' is not in a delayed state');
-    }
-  });
+  return queue.client
+    .eval(script, keys.length, keys[0], keys[1], jobId)
+    .then(function(result) {
+      if (result === -1) {
+        throw new Error('Job ' + jobId + ' is not in a delayed state');
+      }
+    });
 };
 
 /**
@@ -261,7 +290,7 @@ Job.prototype.promote = function(){
  * otherwise the operation was not a success and throw the corresponding error. If the promise
  * rejects, it indicates that the script failed to execute
  */
-Job.prototype.retry = function(){
+Job.prototype.retry = function() {
   return scripts.reprocessJob(this, { state: 'failed' }).then(function(result) {
     if (result === 1) {
       return;
@@ -275,11 +304,11 @@ Job.prototype.retry = function(){
   });
 };
 
-Job.prototype.isCompleted = function(){
+Job.prototype.isCompleted = function() {
   return this._isDone('completed');
 };
 
-Job.prototype.isFailed = function(){
+Job.prototype.isFailed = function() {
   return this._isDone('failed');
 };
 
@@ -316,26 +345,30 @@ Job.prototype.getState = function() {
     { fn: 'isPaused', state: 'paused' }
   ];
 
-  return Promise.reduce(fns, function(state, fn) {
-    if(state){
-      return state;
-    }
-    return _this[fn.fn]().then(function(result) {
-      return result ? fn.state : null;
-    });
-  }, null).then(function(result) {
+  return Promise.reduce(
+    fns,
+    function(state, fn) {
+      if (state) {
+        return state;
+      }
+      return _this[fn.fn]().then(function(result) {
+        return result ? fn.state : null;
+      });
+    },
+    null
+  ).then(function(result) {
     return result ? result : 'stuck';
   });
 };
 
-Job.prototype.remove = function(){
+Job.prototype.remove = function() {
   var queue = this.queue;
   var job = this;
 
   return scripts.remove(queue, job.id).then(function(removed) {
-    if(removed){
+    if (removed) {
       queue.emit('removed', job);
-    }else{
+    } else {
       throw new Error('Could not remove job ' + job.id);
     }
   });
@@ -344,30 +377,30 @@ Job.prototype.remove = function(){
 /**
  * Returns a promise the resolves when the job has finished. (completed or failed).
  */
-Job.prototype.finished = function(){
+Job.prototype.finished = function() {
   var _this = this;
 
-  return scripts.isFinished(_this).then(function(status){
+  return scripts.isFinished(_this).then(function(status) {
     var finished = status > 0;
-    if(finished){
-      return Job.fromId(_this.queue, _this.id).then(function(job){
-        if(status == 2){
+    if (finished) {
+      return Job.fromId(_this.queue, _this.id).then(function(job) {
+        if (status == 2) {
           throw new Error(job.failedReason);
         } else {
           return job.returnvalue;
         }
       });
-    }else{
-      return new Promise(function(resolve, reject){
+    } else {
+      return new Promise(function(resolve, reject) {
         var interval;
-        function onCompleted(jobId, resultValue){
-          if(String(jobId) === String(_this.id)){
+        function onCompleted(jobId, resultValue) {
+          if (String(jobId) === String(_this.id)) {
             var result = void 0;
-            try{
-              if(typeof resultValue === 'string'){
+            try {
+              if (typeof resultValue === 'string') {
                 result = JSON.parse(resultValue);
               }
-            }catch (err){
+            } catch (err) {
               //swallow exception because the resultValue got corrupted somehow.
               debuglog('corrupted resultValue: ' + resultValue, err);
             }
@@ -376,8 +409,8 @@ Job.prototype.finished = function(){
           }
         }
 
-        function onFailed(jobId, failedReason){
-          if(String(jobId) === String(_this.id)){
+        function onFailed(jobId, failedReason) {
+          if (String(jobId) === String(_this.id)) {
             reject(new Error(failedReason));
             removeListeners();
           }
@@ -386,7 +419,7 @@ Job.prototype.finished = function(){
         _this.queue.on('global:completed', onCompleted);
         _this.queue.on('global:failed', onFailed);
 
-        function removeListeners(){
+        function removeListeners() {
           clearInterval(interval);
           _this.queue.removeListener('global:completed', onCompleted);
           _this.queue.removeListener('global:failed', onFailed);
@@ -395,13 +428,13 @@ Job.prototype.finished = function(){
         //
         // Watchdog
         //
-        interval = setInterval(function(){
-          scripts.isFinished(_this).then(function(status){
+        interval = setInterval(function() {
+          scripts.isFinished(_this).then(function(status) {
             var finished = status > 0;
-            if(finished){
-              Job.fromId(_this.queue, _this.id).then(function(job){
+            if (finished) {
+              Job.fromId(_this.queue, _this.id).then(function(job) {
                 removeListeners();
-                if(status == 2){
+                if (status == 2) {
                   reject(new Error(job.failedReason));
                 } else {
                   resolve(job.returnvalue);
@@ -418,25 +451,30 @@ Job.prototype.finished = function(){
 // -----------------------------------------------------------------------------
 // Private methods
 // -----------------------------------------------------------------------------
-Job.prototype._isDone = function(list){
+Job.prototype._isDone = function(list) {
   return this.queue.client
-    .zscore(this.queue.toKey(list), this.id).then(function(score){
+    .zscore(this.queue.toKey(list), this.id)
+    .then(function(score) {
       return score !== null;
     });
 };
 
 Job.prototype._isInList = function(list) {
-  return scripts.isJobInList(this.queue.client, this.queue.toKey(list), this.id);
+  return scripts.isJobInList(
+    this.queue.client,
+    this.queue.toKey(list),
+    this.id
+  );
 };
 
-Job.prototype._saveAttempt = function(multi, err){
+Job.prototype._saveAttempt = function(multi, err) {
   this.attemptsMade++;
 
   var params = {
     attemptsMade: this.attemptsMade
   };
 
-  if(this.opts.stackTraceLimit) {
+  if (this.opts.stackTraceLimit) {
     this.stacktrace = this.stacktrace.slice(0, this.opts.stackTraceLimit - 1);
   }
 
@@ -447,9 +485,9 @@ Job.prototype._saveAttempt = function(multi, err){
   multi.hmset(this.queue.toKey(this.id), params);
 };
 
-Job.fromJSON = function(queue, json, jobId){
+Job.fromJSON = function(queue, json, jobId) {
   var data = JSON.parse(json.data || '{}');
-  var opts = JSON.parse(json.opts || '{}');
+  var opts = JSON.parse(json.opts || '{}');
 
   var job = new Job(queue, json.name || Job.DEFAULT_JOB_NAME, data, opts);
 
@@ -457,11 +495,11 @@ Job.fromJSON = function(queue, json, jobId){
   job._progress = parseInt(json.progress || 0);
   job.delay = parseInt(json.delay);
   job.timestamp = parseInt(json.timestamp);
-  if(json.finishedOn){
+  if (json.finishedOn) {
     job.finishedOn = parseInt(json.finishedOn);
   }
 
-  if(json.processedOn){
+  if (json.processedOn) {
     job.processedOn = parseInt(json.processedOn);
   }
 
@@ -470,30 +508,30 @@ Job.fromJSON = function(queue, json, jobId){
 
   job.stacktrace = getTraces(json.stacktrace);
 
-  if(typeof json.returnvalue === 'string'){
+  if (typeof json.returnvalue === 'string') {
     job.returnvalue = getReturnValue(json.returnvalue);
   }
 
   return job;
 };
 
-function getTraces(stacktrace){
+function getTraces(stacktrace) {
   var _traces;
 
   _traces = utils.tryCatch(JSON.parse, JSON, [stacktrace]);
 
-  if(_traces === utils.errorObject || !(_traces instanceof Array)) {
+  if (_traces === utils.errorObject || !(_traces instanceof Array)) {
     return [];
   } else {
     return _traces;
   }
 }
 
-function getReturnValue(_value){
+function getReturnValue(_value) {
   var value = utils.tryCatch(JSON.parse, JSON, [_value]);
-  if(value !== utils.errorObject){
+  if (value !== utils.errorObject) {
     return value;
-  }else{
+  } else {
     debuglog('corrupted returnvalue: ' + _value, value);
   }
 }

--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -6,14 +6,14 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 
 module.exports = function ChildPool() {
-  if(!(this instanceof ChildPool)){
+  if (!(this instanceof ChildPool)) {
     return new ChildPool();
   }
 
   this.retained = {};
   this.free = {};
 
-  this.retain = Promise.method(function(processFile){
+  this.retain = Promise.method(function(processFile) {
     var child = this.getFree(processFile).pop();
 
     if (child) {
@@ -22,13 +22,13 @@ module.exports = function ChildPool() {
 
     child = fork(path.join(__dirname, './master.js'));
     child.processFile = processFile;
-  
+
     this.retained[child.pid] = child;
 
     child.on('exit', this.remove.bind(this, child));
 
     var send = function(msg) {
-      return new Promise(function(resolve){
+      return new Promise(function(resolve) {
         child.send(msg, resolve);
       });
     };
@@ -36,31 +36,31 @@ module.exports = function ChildPool() {
     return send({ cmd: 'init', value: processFile }).return(child);
   });
 
-  this.release = function(child){
+  this.release = function(child) {
     delete this.retained[child.pid];
     this.getFree(child.processFile).push(child);
   };
 
-  this.remove = function(child){
+  this.remove = function(child) {
     delete this.retained[child.pid];
 
     var free = this.getFree(child.processFile);
-    
+
     var childIndex = free.indexOf(child);
     if (childIndex > -1) {
       free.splice(childIndex, 1);
     }
   };
 
-  this.kill = function(child, signal){
+  this.kill = function(child, signal) {
     child.kill(signal);
     this.remove(child);
   };
 
-  this.clean = function(){
+  this.clean = function() {
     var children = _.values(this.retained).concat(this.getAllFree());
     var _this = this;
-    children.forEach(function(child){
+    children.forEach(function(child) {
       // TODO: We may want to use SIGKILL if the process does not die after some time.
       _this.kill(child, 'SIGTERM');
     });
@@ -70,10 +70,10 @@ module.exports = function ChildPool() {
   };
 
   this.getFree = function(id) {
-    return this.free[id] = this.free[id] || [];
+    return (this.free[id] = this.free[id] || []);
   };
 
-  this.getAllFree = function(){
+  this.getAllFree = function() {
     return _.flatten(_.values(this.free));
   };
 };

--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -8,12 +8,12 @@ var processor;
 var Promise = require('bluebird');
 
 // https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
-if (!('toJSON' in Error.prototype)){
+if (!('toJSON' in Error.prototype)) {
   Object.defineProperty(Error.prototype, 'toJSON', {
-    value: function () {
+    value: function() {
       var alt = {};
 
-      Object.getOwnPropertyNames(this).forEach(function (key) {
+      Object.getOwnPropertyNames(this).forEach(function(key) {
         alt[key] = this[key];
       }, this);
 
@@ -25,50 +25,55 @@ if (!('toJSON' in Error.prototype)){
 }
 
 process.on('message', function(msg) {
-
-  switch(msg.cmd){
+  switch (msg.cmd) {
     case 'init':
       processor = require(msg.value);
-      if (processor.default) { // support es2015 module.
+      if (processor.default) {
+        // support es2015 module.
         processor = processor.default;
       }
-      if(processor.length > 1){
+      if (processor.length > 1) {
         processor = Promise.promisify(processor);
-      }else{
+      } else {
         processor = Promise.method(processor);
       }
       status = 'IDLE';
       break;
 
     case 'start':
-      if(status !== 'IDLE'){
+      if (status !== 'IDLE') {
         return process.send({
           cmd: 'error',
           err: new Error('cannot start a not idling child process')
         });
       }
       status = 'STARTED';
-      Promise.resolve(processor(wrapJob(msg.job)) || {}).then( function(result) {
-        process.send({
-          cmd: 'completed',
-          value: result
+      Promise.resolve(processor(wrapJob(msg.job)) || {})
+        .then(
+          function(result) {
+            process.send({
+              cmd: 'completed',
+              value: result
+            });
+          },
+          function(err) {
+            process.send({
+              cmd: 'failed',
+              value: err
+            });
+          }
+        )
+        .finally(function() {
+          status = 'IDLE';
         });
-      }, function(err) {
-        process.send({
-          cmd: 'failed',
-          value: err
-        });
-      }).finally(function(){
-        status = 'IDLE';
-      });
       break;
     case 'stop':
       break;
   }
 });
 
-function wrapJob(job){
-  job.progress = function(progress){
+function wrapJob(job) {
+  job.progress = function(progress) {
     process.send({
       cmd: 'progress',
       value: progress

--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -2,18 +2,17 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(processFile, childPool){
-  return function process(job){
-    return childPool.retain(processFile).then(function(child){
-
+module.exports = function(processFile, childPool) {
+  return function process(job) {
+    return childPool.retain(processFile).then(function(child) {
       child.send({
         cmd: 'start',
         job: job
       });
 
       var done = new Promise(function(resolve, reject) {
-        function handler(msg){
-          switch(msg.cmd){
+        function handler(msg) {
+          switch (msg.cmd) {
             case 'completed':
               child.removeListener('message', handler);
               resolve(msg.value);
@@ -32,7 +31,7 @@ module.exports = function(processFile, childPool){
         child.on('message', handler);
       });
 
-      return done.finally( function(){
+      return done.finally(function() {
         childPool.release(child);
       });
     });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -79,27 +79,31 @@ var MAX_TIMEOUT_MS = Math.pow(2, 31) - 1; // 32 bit signed
 */
 
 // Queue(name: string, url?, opts?)
-var Queue = function Queue(name, url, opts){
+var Queue = function Queue(name, url, opts) {
   var _this = this;
-  if(!(this instanceof Queue)){
+  if (!(this instanceof Queue)) {
     return new Queue(name, url, opts);
   }
 
-  if(_.isString(url)){
-    opts = _.extend({}, {
-      redis: redisOptsFromUrl(url)
-    }, opts);
-  }else{
+  if (_.isString(url)) {
+    opts = _.extend(
+      {},
+      {
+        redis: redisOptsFromUrl(url)
+      },
+      opts
+    );
+  } else {
     opts = url;
   }
 
   opts = _.cloneDeep(opts || {});
 
-  if(opts && !_.isObject(opts)){
+  if (opts && !_.isObject(opts)) {
     throw Error('Options must be a valid object');
   }
 
-  if(opts.limiter){
+  if (opts.limiter) {
     this.limiter = opts.limiter;
   }
 
@@ -110,13 +114,13 @@ var Queue = function Queue(name, url, opts){
   this.name = name;
   this.token = uuid();
 
-  opts.redis = opts.redis || {};
+  opts.redis = opts.redis || {};
 
   _.defaults(opts.redis, {
     port: 6379,
     host: '127.0.0.1',
     db: opts.redis.db || opts.redis.DB,
-    retryStrategy: function (times) {
+    retryStrategy: function(times) {
       return Math.min(Math.exp(times), 20000);
     }
   });
@@ -130,17 +134,20 @@ var Queue = function Queue(name, url, opts){
   delete opts.redis.keyPrefix;
 
   this.clients = [];
-  var lazyClient = redisClientGetter(this, opts, function (type, client) {
+  var lazyClient = redisClientGetter(this, opts, function(type, client) {
     // bubble up Redis error events
     client.on('error', _this.emit.bind(_this, 'error'));
 
     if (type === 'client') {
-      _this._initializing = commands(client).then(function(){
-        debuglog(name + ' queue ready');
-      }, function(err){
-        _this.emit('error', new Error('Error initializing Lua scripts'));
-        throw err;
-      });
+      _this._initializing = commands(client).then(
+        function() {
+          debuglog(name + ' queue ready');
+        },
+        function(err) {
+          _this.emit('error', new Error('Error initializing Lua scripts'));
+          throw err;
+        }
+      );
     }
   });
 
@@ -163,13 +170,23 @@ var Queue = function Queue(name, url, opts){
   });
 
   if (opts.skipVersionCheck !== true) {
-    getRedisVersion(this.client).then(function(version){
-      if (semver.lt(version, MINIMUM_REDIS_VERSION)){
-        _this.emit('error', new Error('Redis version needs to be greater than ' + MINIMUM_REDIS_VERSION + '. Current: ' + version));
-      }
-    }).catch(function(/*err*/){
-      // Ignore this error.
-    });
+    getRedisVersion(this.client)
+      .then(function(version) {
+        if (semver.lt(version, MINIMUM_REDIS_VERSION)) {
+          _this.emit(
+            'error',
+            new Error(
+              'Redis version needs to be greater than ' +
+                MINIMUM_REDIS_VERSION +
+                '. Current: ' +
+                version
+            )
+          );
+        }
+      })
+      .catch(function(/*err*/) {
+        // Ignore this error.
+      });
   }
 
   this.handlers = {};
@@ -187,9 +204,10 @@ var Queue = function Queue(name, url, opts){
     backoffStrategies: {}
   });
 
-  this.settings.lockRenewTime = this.settings.lockRenewTime || this.settings.lockDuration / 2;
+  this.settings.lockRenewTime =
+    this.settings.lockRenewTime || this.settings.lockDuration / 2;
 
-  this.on('error', function(){
+  this.on('error', function() {
     // Dummy handler to avoid process to exit with an unhandled exception.
   });
 
@@ -205,43 +223,50 @@ var Queue = function Queue(name, url, opts){
   this.getJobFromId = Job.fromId.bind(null, this);
 
   var keys = {};
-  _.each([
-    '',
-    'active',
-    'wait',
-    'waiting',
-    'paused',
-    'resumed',
-    'meta-paused',
-    'active',
-    'id',
-    'delayed',
-    'priority',
-    'stalled-check',
-    'completed',
-    'failed',
-    'stalled',
-    'repeat',
-    'limiter',
-    'drained',
-    'progress'], function(key){
-    keys[key] = _this.toKey(key);
-  });
+  _.each(
+    [
+      '',
+      'active',
+      'wait',
+      'waiting',
+      'paused',
+      'resumed',
+      'meta-paused',
+      'active',
+      'id',
+      'delayed',
+      'priority',
+      'stalled-check',
+      'completed',
+      'failed',
+      'stalled',
+      'repeat',
+      'limiter',
+      'drained',
+      'progress'
+    ],
+    function(key) {
+      keys[key] = _this.toKey(key);
+    }
+  );
   this.keys = keys;
 };
 
 function redisClientGetter(queue, options, initCallback) {
   var createClient = _.isFunction(options.createClient)
     ? options.createClient
-    : function(type, config) { return new redis(config); };
+    : function(type, config) {
+        return new redis(config);
+      };
 
   var connections = {};
 
-  return function (type) {
-    return function() { // getter function
+  return function(type) {
+    return function() {
+      // getter function
       if (connections[type] != null) return connections[type];
-      var client = connections[type] = createClient(type, options.redis);
-      if(!options.createClient){
+      var client = (connections[type] = createClient(type, options.redis));
+      if (!options.createClient) {
         queue.clients.push(client);
       }
       return initCallback(type, client), client;
@@ -249,7 +274,7 @@ function redisClientGetter(queue, options, initCallback) {
   };
 }
 
-function redisOptsFromUrl(urlString){
+function redisOptsFromUrl(urlString) {
   var redisOpts = {};
   try {
     var redisUrl = url.parse(urlString);
@@ -265,18 +290,25 @@ function redisOptsFromUrl(urlString){
   return redisOpts;
 }
 
-function setGuardianTimer(queue){
+function setGuardianTimer(queue) {
   return setInterval(function() {
     var now = Date.now();
-    if(queue.delayedTimestamp < now || queue.delayedTimestamp - now > queue.settings.guardInterval){
-      scripts.updateDelaySet(queue, now).then(function(timestamp){
-        if(timestamp){
-          queue.updateDelayTimer(timestamp);
-        }
-        return null;
-      }).catch(function(err){
-        queue.emit('error', err);
-      }).return(null);
+    if (
+      queue.delayedTimestamp < now ||
+      queue.delayedTimestamp - now > queue.settings.guardInterval
+    ) {
+      scripts
+        .updateDelaySet(queue, now)
+        .then(function(timestamp) {
+          if (timestamp) {
+            queue.updateDelayTimer(timestamp);
+          }
+          return null;
+        })
+        .catch(function(err) {
+          queue.emit('error', err);
+        })
+        .return(null);
     }
   }, queue.settings.guardInterval);
 }
@@ -295,44 +327,50 @@ Queue.prototype.off = Queue.prototype.removeListener;
 
 var _on = Queue.prototype.on;
 
-Queue.prototype.on = function(eventName){
+Queue.prototype.on = function(eventName) {
   this._registerEvent(eventName);
   return _on.apply(this, arguments);
 };
 
 var _once = Queue.prototype.once;
 
-Queue.prototype.once = function(eventName){
+Queue.prototype.once = function(eventName) {
   this._registerEvent(eventName);
   return _once.apply(this, arguments);
 };
 
-Queue.prototype._initProcess = function(){
+Queue.prototype._initProcess = function() {
   var _this = this;
-  if(!this._initializingProcess){
+  if (!this._initializingProcess) {
     //
     // Only setup listeners if .on/.addEventListener called, or process function defined.
     //
     this.delayedTimestamp = Number.MAX_VALUE;
-    this._initializingProcess = this.isReady().then(function(){
-      return _this._registerEvent('delayed');
-    }).then(function(){
-      //
-      // Init delay timestamp.
-      //
-      return scripts.updateDelaySet(_this, Date.now()).then(function(timestamp){
-        if(timestamp){
-          _this.updateDelayTimer(timestamp);
-        }
-        return null;
-      }).return(null);
-    }).then(function(){
-      //
-      // Create a guardian timer to revive delayTimer if necessary
-      // This is necessary when redis connection is unstable, which can cause the pub/sub to fail
-      //
-      _this.guardianTimer = setGuardianTimer(_this);
-    });
+    this._initializingProcess = this.isReady()
+      .then(function() {
+        return _this._registerEvent('delayed');
+      })
+      .then(function() {
+        //
+        // Init delay timestamp.
+        //
+        return scripts
+          .updateDelaySet(_this, Date.now())
+          .then(function(timestamp) {
+            if (timestamp) {
+              _this.updateDelayTimer(timestamp);
+            }
+            return null;
+          })
+          .return(null);
+      })
+      .then(function() {
+        //
+        // Create a guardian timer to revive delayTimer if necessary
+        // This is necessary when redis connection is unstable, which can cause the pub/sub to fail
+        //
+        _this.guardianTimer = setGuardianTimer(_this);
+      });
 
     this.errorRetryTimer = {};
   }
@@ -340,7 +378,7 @@ Queue.prototype._initProcess = function(){
   return this._initializingProcess;
 };
 
-Queue.prototype._setupQueueEventListeners = function(){
+Queue.prototype._setupQueueEventListeners = function() {
   /*
     if(eventName !== 'cleaned' && eventName !== 'error'){
       args[0] = Job.fromJSON(_this, args[0]);
@@ -358,22 +396,22 @@ Queue.prototype._setupQueueEventListeners = function(){
   var failedKey = _this.keys.failed;
   var drainedKey = _this.keys.drained;
 
-  this.eclient.on('pmessage', function(pattern, channel, message){
+  this.eclient.on('pmessage', function(pattern, channel, message) {
     var keyAndToken = channel.split('@');
     var key = keyAndToken[0];
     var token = keyAndToken[1];
-    switch(key){
+    switch (key) {
       case activeKey:
         _this.emit('global:active', message, 'waiting');
         break;
       case waitingKey:
-        if(_this.token === token){
+        if (_this.token === token) {
           _this.emit('waiting', message, null);
         }
         token && _this.emit('global:waiting', message, null);
         break;
       case stalledKey:
-        if(_this.token === token){
+        if (_this.token === token) {
           _this.emit('stalled', message);
         }
         _this.emit('global:stalled', message);
@@ -381,9 +419,9 @@ Queue.prototype._setupQueueEventListeners = function(){
     }
   });
 
-  this.eclient.on('message', function(channel, message){
+  this.eclient.on('message', function(channel, message) {
     var key = channel.split('@')[0];
-    switch(key){
+    switch (key) {
       case progressKey:
         var jobAndProgress = message.split(',');
         _this.emit('global:progress', jobAndProgress[0], jobAndProgress[1]);
@@ -405,36 +443,46 @@ Queue.prototype._setupQueueEventListeners = function(){
         break;
       case drainedKey:
         _this.emit('global:drained');
-        break;;
+        break;
     }
   });
 };
 
-Queue.prototype._registerEvent = function(eventName){
+Queue.prototype._registerEvent = function(eventName) {
   var internalEvents = ['waiting', 'delayed'];
 
-  if(eventName.startsWith('global:') || internalEvents.indexOf(eventName) !== -1){
-    if(!this.registeredEvents){
+  if (
+    eventName.startsWith('global:') ||
+    internalEvents.indexOf(eventName) !== -1
+  ) {
+    if (!this.registeredEvents) {
       this._setupQueueEventListeners();
       this.registeredEvents = this.registeredEvents || {};
     }
 
     var _eventName = eventName.replace('global:', '');
 
-    if(!this.registeredEvents[_eventName]){
+    if (!this.registeredEvents[_eventName]) {
       var _this = this;
-      
-      return utils.isRedisReady(this.eclient).then(function(){
-        var channel = _this.toKey(_eventName);
-        if(['active', 'waiting', 'stalled'].indexOf(_eventName) !== -1) {
-          return _this.registeredEvents[_eventName] = _this.eclient.psubscribe(channel + '*');
-        } else {
-          return _this.registeredEvents[_eventName] = _this.eclient.subscribe(channel);
-        }
-      }).then(function(){
-        _this.emit('registered:' + eventName);
-      });
-    }else{
+
+      return utils
+        .isRedisReady(this.eclient)
+        .then(function() {
+          var channel = _this.toKey(_eventName);
+          if (['active', 'waiting', 'stalled'].indexOf(_eventName) !== -1) {
+            return (_this.registeredEvents[
+              _eventName
+            ] = _this.eclient.psubscribe(channel + '*'));
+          } else {
+            return (_this.registeredEvents[
+              _eventName
+            ] = _this.eclient.subscribe(channel));
+          }
+        })
+        .then(function() {
+          _this.emit('registered:' + eventName);
+        });
+    } else {
       return this.registeredEvents[_eventName];
     }
   }
@@ -443,80 +491,97 @@ Queue.prototype._registerEvent = function(eventName){
 
 Queue.ErrorMessages = errors.Messages;
 
-Queue.prototype.isReady = function(){
+Queue.prototype.isReady = function() {
   var _this = this;
-  return this._initializing.then(function(){
+  return this._initializing.then(function() {
     return _this;
   });
 };
 
-function redisClientDisconnect(client){
-  if(client.status === 'end'){
+function redisClientDisconnect(client) {
+  if (client.status === 'end') {
     return Promise.resolve();
   }
   var _resolve, _reject;
-  return new Promise(function(resolve, reject){
+  return new Promise(function(resolve, reject) {
     _resolve = resolve;
     _reject = reject;
     client.once('end', resolve);
     client.once('error', reject);
 
-    client.quit().catch(function(err){
-      if(err.message !== 'Connection is closed.'){
-        throw err;
-      }
-    }).timeout(500).catch(function(){
-      client.disconnect();
-    });
-  }).finally(function(){
+    client
+      .quit()
+      .catch(function(err) {
+        if (err.message !== 'Connection is closed.') {
+          throw err;
+        }
+      })
+      .timeout(500)
+      .catch(function() {
+        client.disconnect();
+      });
+  }).finally(function() {
     client.removeListener('end', _resolve);
     client.removeListener('error', _reject);
   });
 }
 
-Queue.prototype.disconnect = function(){
+Queue.prototype.disconnect = function() {
   //
   // TODO: Only quit clients that we "own".
   //
-  var clients = this.clients.filter(function(client){
+  var clients = this.clients.filter(function(client) {
     return client.status !== 'end';
   });
 
-  return Promise.all(clients.map(redisClientDisconnect)).catch(function(err){
-    return console.error(err);
-  }).then(function(){
-    return null;
-  });
+  return Promise.all(clients.map(redisClientDisconnect))
+    .catch(function(err) {
+      return console.error(err);
+    })
+    .then(function() {
+      return null;
+    });
 };
 
-Queue.prototype.close = function( doNotWaitJobs ){
+Queue.prototype.close = function(doNotWaitJobs) {
   var _this = this;
 
-  if(this.closing){
+  if (this.closing) {
     return this.closing;
   }
 
-  return this.closing = this.isReady().then(function(){
-    return _this._initializingProcess;
-  }, function(/*err*/){
-    // Ignore this error and try to close anyway.
-  }).finally(function(){
-    return _this._clearTimers();
-  }).then(function(){
-    return _this.pause(true, doNotWaitJobs);
-  }).then(function(){
-    return _this.disconnect();
-  }, function(/*err*/){
-    // Ignore this error and try to close anyway.
-  }).finally(function(){
-    _this.childPool && _this.childPool.clean();
-    _this.closed = true;
-  });
+  return (this.closing = this.isReady()
+    .then(
+      function() {
+        return _this._initializingProcess;
+      },
+      function(/*err*/) {
+        // Ignore this error and try to close anyway.
+      }
+    )
+    .finally(function() {
+      return _this._clearTimers();
+    })
+    .then(function() {
+      return _this.pause(true, doNotWaitJobs);
+    })
+    .then(
+      function() {
+        return _this.disconnect();
+      },
+      function(/*err*/) {
+        // Ignore this error and try to close anyway.
+      }
+    )
+    .finally(function() {
+      _this.childPool && _this.childPool.clean();
+      _this.closed = true;
+    }));
 };
 
-Queue.prototype._clearTimers = function(){
+Queue.prototype._clearTimers = function() {
   var _this = this;
-  _.each(_this.errorRetryTimer, function(timer){
+  _.each(_this.errorRetryTimer, function(timer) {
     clearTimeout(timer);
   });
   clearTimeout(this.delayTimer);
@@ -540,18 +605,18 @@ Queue.prototype._clearTimers = function(){
 
   @method process
 */
-Queue.prototype.process = function(name, concurrency, handler){
-  switch(arguments.length){
+Queue.prototype.process = function(name, concurrency, handler) {
+  switch (arguments.length) {
     case 1:
       handler = name;
       concurrency = 1;
-      name = Job.DEFAULT_JOB_NAME;      
+      name = Job.DEFAULT_JOB_NAME;
       break;
     case 2: // (string, function) or (string, string) or (number, function) or (number, string)
       handler = concurrency;
-      if(typeof name === 'string'){
+      if (typeof name === 'string') {
         concurrency = 1;
-      }else{
+      } else {
         concurrency = name;
         name = Job.DEFAULT_JOB_NAME;
       }
@@ -561,42 +626,40 @@ Queue.prototype.process = function(name, concurrency, handler){
   this.setHandler(name, handler);
 
   var _this = this;
-  return this._initProcess().then(function(){
+  return this._initProcess().then(function() {
     return _this.start(concurrency);
   });
 };
 
-
-Queue.prototype.start = function(concurrency){
+Queue.prototype.start = function(concurrency) {
   var _this = this;
 
-  return this.run(concurrency).catch(function(err){
+  return this.run(concurrency).catch(function(err) {
     _this.emit('error', err, 'error running queue');
     throw err;
   });
 };
 
-
-Queue.prototype.setHandler = function(name, handler){
-  if(!handler){
+Queue.prototype.setHandler = function(name, handler) {
+  if (!handler) {
     throw new Error('Cannot set an undefined handler');
   }
-  if(this.handlers[name]) {
+  if (this.handlers[name]) {
     throw new Error('Cannot define the same handler twice ' + name);
   }
 
   this.setWorkerName();
 
-  if(typeof handler === 'string'){
+  if (typeof handler === 'string') {
     this.childPool = this.childPool || require('./process/child-pool')();
     var sandbox = require('./process/sandbox');
     this.handlers[name] = sandbox(handler, this.childPool).bind(this);
   } else {
     handler = handler.bind(this);
 
-    if(handler.length > 1){
+    if (handler.length > 1) {
       this.handlers[name] = Promise.promisify(handler);
-    }else{
+    } else {
       this.handlers[name] = Promise.method(handler);
     }
   }
@@ -620,8 +683,8 @@ interface JobOptions
   @param data: {} Custom data to store for this job. Should be JSON serializable.
   @param opts: JobOptions Options for this job.
 */
-Queue.prototype.add = function(name, data, opts){
-  if(typeof name !== 'string'){
+Queue.prototype.add = function(name, data, opts) {
+  if (typeof name !== 'string') {
     opts = data;
     data = name;
     name = Job.DEFAULT_JOB_NAME;
@@ -629,12 +692,12 @@ Queue.prototype.add = function(name, data, opts){
   opts = _.cloneDeep(opts || {});
   _.defaults(opts, this.defaultJobOptions);
 
-  if(opts.repeat){
+  if (opts.repeat) {
     var _this = this;
-    return this.isReady().then(function(){
+    return this.isReady().then(function() {
       return _this.nextRepeatableJob(name, data, opts);
     });
-  }else{
+  } else {
     return Job.create(this, name, data, opts);
   }
 };
@@ -650,7 +713,7 @@ Queue.prototype.add = function(name, data, opts){
 
   TODO: Use EVAL to make this operation fully atomic.
 */
-Queue.prototype.empty = function(){
+Queue.prototype.empty = function() {
   var _this = this;
 
   // Get all jobids and empty all lists atomically.
@@ -663,12 +726,12 @@ Queue.prototype.empty = function(){
   multi.del(this.toKey('meta-paused'));
   multi.del(this.toKey('delayed'));
 
-  return multi.exec().spread(function(waiting, paused){
+  return multi.exec().spread(function(waiting, paused) {
     waiting = waiting[1];
     paused = paused[1];
-    var jobKeys = (paused.concat(waiting)).map(_this.toKey, _this);
+    var jobKeys = paused.concat(waiting).map(_this.toKey, _this);
 
-    if(jobKeys.length){
+    if (jobKeys.length) {
       multi = _this.multi();
 
       multi.del.apply(multi, jobKeys);
@@ -688,61 +751,71 @@ Queue.prototype.empty = function(){
   Adding jobs requires a LUA script to check first if the paused list exist
   and in that case it will add it there instead of the wait list.
 */
-Queue.prototype.pause = function(isLocal, doNotWaitActive){
+Queue.prototype.pause = function(isLocal, doNotWaitActive) {
   var _this = this;
-  return _this.isReady().then(function(){
-    if(isLocal){
-      if(!_this.paused){
-        _this.paused = new Promise(function(resolve) {
-          _this.resumeLocal = function() {
-            resolve();
-            _this.paused = null; // Allow pause to be checked externally for paused state.
-          };
-        });
+  return _this
+    .isReady()
+    .then(function() {
+      if (isLocal) {
+        if (!_this.paused) {
+          _this.paused = new Promise(function(resolve) {
+            _this.resumeLocal = function() {
+              resolve();
+              _this.paused = null; // Allow pause to be checked externally for paused state.
+            };
+          });
+        }
+        return !doNotWaitActive && _this.whenCurrentJobsFinished();
+      } else {
+        return scripts.pause(_this, true);
       }
-      return !doNotWaitActive && _this.whenCurrentJobsFinished();
-    }else{
-      return scripts.pause(_this, true);
-    }
-  }).then(function(){
-    return _this.emit('paused');
-  });
+    })
+    .then(function() {
+      return _this.emit('paused');
+    });
 };
 
-Queue.prototype.resume = function(isLocal /* Optional */){
+Queue.prototype.resume = function(isLocal /* Optional */) {
   var _this = this;
-  return this.isReady().then(function(){
-    if(isLocal){
-      if(_this.resumeLocal){
-        _this.resumeLocal();
+  return this.isReady()
+    .then(function() {
+      if (isLocal) {
+        if (_this.resumeLocal) {
+          _this.resumeLocal();
+        }
+      } else {
+        return scripts.pause(_this, false);
       }
-    }else{
-      return scripts.pause(_this, false);
-    }
-  }).then(function(){
-    _this.emit('resumed');
-  });
+    })
+    .then(function() {
+      _this.emit('resumed');
+    });
 };
 
-Queue.prototype.run = function(concurrency){
+Queue.prototype.run = function(concurrency) {
   var promises = [];
   var _this = this;
 
-  return this.isReady().then(function(){
-    return _this.moveUnlockedJobsToWait();
-  }).then(function(){
-    return utils.isRedisReady(_this.bclient);
-  }).then(function(){
-    while(concurrency--){
-      promises.push(new Promise(function(resolve){
-        _this.processJobs(concurrency, resolve);
-      }));
-    }
+  return this.isReady()
+    .then(function() {
+      return _this.moveUnlockedJobsToWait();
+    })
+    .then(function() {
+      return utils.isRedisReady(_this.bclient);
+    })
+    .then(function() {
+      while (concurrency--) {
+        promises.push(
+          new Promise(function(resolve) {
+            _this.processJobs(concurrency, resolve);
+          })
+        );
+      }
 
-    _this.startMoveUnlockedJobsToWait();
+      _this.startMoveUnlockedJobsToWait();
 
-    return Promise.all(promises);
-  });
+      return Promise.all(promises);
+    });
 };
 
 // ---------------------------------------------------------------------
@@ -753,32 +826,39 @@ Queue.prototype.run = function(concurrency){
   This function updates the delay timer, which is a timer that timeouts
   at the next known delayed job.
 */
-Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
+Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
   var _this = this;
   var now = Date.now();
   newDelayedTimestamp = Math.round(newDelayedTimestamp);
-  if(newDelayedTimestamp < _this.delayedTimestamp && newDelayedTimestamp < (MAX_TIMEOUT_MS + now)){
+  if (
+    newDelayedTimestamp < _this.delayedTimestamp &&
+    newDelayedTimestamp < MAX_TIMEOUT_MS + now
+  ) {
     clearTimeout(this.delayTimer);
     this.delayedTimestamp = newDelayedTimestamp;
 
     var nextDelayedJob = newDelayedTimestamp - now;
     var delay = nextDelayedJob <= 0 ? 0 : nextDelayedJob;
 
-    var delayUpdate = function(){
-      scripts.updateDelaySet(_this, _this.delayedTimestamp).then(function(nextTimestamp){
-        if(nextTimestamp){
-          nextTimestamp = nextTimestamp < now ? now : nextTimestamp;
-        }else{
-          nextTimestamp = Number.MAX_VALUE;
-        }
-        return _this.updateDelayTimer(nextTimestamp);
-      }).catch(function(err){
-        _this.emit('error', err, 'Error updating the delay timer');
-      }).return(null);
-      _this.delayedTimestamp = Number.MAX_VALUE;      
+    var delayUpdate = function() {
+      scripts
+        .updateDelaySet(_this, _this.delayedTimestamp)
+        .then(function(nextTimestamp) {
+          if (nextTimestamp) {
+            nextTimestamp = nextTimestamp < now ? now : nextTimestamp;
+          } else {
+            nextTimestamp = Number.MAX_VALUE;
+          }
+          return _this.updateDelayTimer(nextTimestamp);
+        })
+        .catch(function(err) {
+          _this.emit('error', err, 'Error updating the delay timer');
+        })
+        .return(null);
+      _this.delayedTimestamp = Number.MAX_VALUE;
     };
 
-    if(delay){
+    if (delay) {
       this.delayTimer = setTimeout(delayUpdate, delay);
     } else {
       delayUpdate();
@@ -791,78 +871,90 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp){
  * Process jobs that have been added to the active list but are not being
  * processed properly. This can happen due to a process crash in the middle
  * of processing a job, leaving it in 'active' but without a job lock.
-*/
-Queue.prototype.moveUnlockedJobsToWait = function(){
+ */
+Queue.prototype.moveUnlockedJobsToWait = function() {
   var _this = this;
 
-  if(this.closed){
+  if (this.closed) {
     return Promise.resolve();
   }
 
-  return scripts.moveUnlockedJobsToWait(this).spread(function(failed, stalled){
-    var handleFailedJobs = failed.map(function(jobId){
-      return _this.getJobFromId(jobId).then(function(job){
-        _this.emit('failed', job, new Error('job stalled more than allowable limit'), 'active' );
-        return null;
+  return scripts
+    .moveUnlockedJobsToWait(this)
+    .spread(function(failed, stalled) {
+      var handleFailedJobs = failed.map(function(jobId) {
+        return _this.getJobFromId(jobId).then(function(job) {
+          _this.emit(
+            'failed',
+            job,
+            new Error('job stalled more than allowable limit'),
+            'active'
+          );
+          return null;
+        });
       });
-    });
-    var handleStalledJobs = stalled.map(function(jobId){
-      return _this.getJobFromId(jobId).then(function(job){
-        _this.emit('stalled', job);
-        return null;
+      var handleStalledJobs = stalled.map(function(jobId) {
+        return _this.getJobFromId(jobId).then(function(job) {
+          _this.emit('stalled', job);
+          return null;
+        });
       });
+      return Promise.all(handleFailedJobs.concat(handleStalledJobs));
+    })
+    .catch(function(err) {
+      _this.emit('error', err, 'Failed to handle unlocked job in active');
     });
-    return Promise.all(handleFailedJobs.concat(handleStalledJobs));
-  }).catch(function(err){
-    _this.emit('error', err, 'Failed to handle unlocked job in active');
-  });
 };
 
 Queue.prototype.startMoveUnlockedJobsToWait = function() {
   clearInterval(this.moveUnlockedJobsToWaitInterval);
-  if (this.settings.stalledInterval > 0){
-    this.moveUnlockedJobsToWaitInterval =
-      setInterval(this.moveUnlockedJobsToWait, this.settings.stalledInterval);
+  if (this.settings.stalledInterval > 0) {
+    this.moveUnlockedJobsToWaitInterval = setInterval(
+      this.moveUnlockedJobsToWait,
+      this.settings.stalledInterval
+    );
   }
 };
 
-Queue.prototype.processJobs = function(index, resolve){
+Queue.prototype.processJobs = function(index, resolve) {
   var _this = this;
   var processJobs = this.processJobs.bind(this, index, resolve);
-  process.nextTick(function(){
-    if(!_this.closing){
-      (_this.paused || Promise.resolve()).then(function(){
-        return _this.processing[index] = _this.getNextJob()
-          .then(_this.processJob)
-          .then(processJobs, function(err){
+  process.nextTick(function() {
+    if (!_this.closing) {
+      (_this.paused || Promise.resolve())
+        .then(function() {
+          return (_this.processing[index] = _this
+            .getNextJob()
+            .then(_this.processJob)
+            .then(processJobs, function(err) {
+              _this.emit('error', err, 'Error processing job');
 
-            _this.emit('error', err, 'Error processing job');
+              //
+              // Wait before trying to process again.
+              //
+              clearTimeout(_this.errorRetryTimer[index]);
+              _this.errorRetryTimer[index] = setTimeout(function() {
+                processJobs();
+              }, _this.settings.retryProcessDelay);
 
-            //
-            // Wait before trying to process again.
-            //
-            clearTimeout(_this.errorRetryTimer[index]);
-            _this.errorRetryTimer[index] = setTimeout(function(){
-              processJobs();
-            }, _this.settings.retryProcessDelay);
-
-            return null;
-          });
-      }).catch(function(err){
-        _this.emit('error', err, 'Error processing job');
-      });
-    }else{
+              return null;
+            }));
+        })
+        .catch(function(err) {
+          _this.emit('error', err, 'Error processing job');
+        });
+    } else {
       resolve(_this.closing);
     }
   });
 };
 
-Queue.prototype.processJob = function(job){
+Queue.prototype.processJob = function(job) {
   var _this = this;
   var lockRenewId;
   var timerStopped = false;
 
-  if(!job){
+  if (!job) {
     return Promise.resolve();
   }
 
@@ -874,36 +966,43 @@ Queue.prototype.processJob = function(job){
   // jobs, so we can assume the job has been stalled and is already being processed
   // by another worker. See #308
   //
-  var lockExtender = function(){
-    lockRenewId = _this.timers.set('lockExtender', _this.settings.lockRenewTime, function(){
-      scripts.extendLock(_this, job.id).then(function(lock){
-        if(lock && !timerStopped){
-          lockExtender();
-        }
-      }).catch(function(/*err*/){
-        // Somehow tell the worker this job should stop processing...
-      });
-    });
+  var lockExtender = function() {
+    lockRenewId = _this.timers.set(
+      'lockExtender',
+      _this.settings.lockRenewTime,
+      function() {
+        scripts
+          .extendLock(_this, job.id)
+          .then(function(lock) {
+            if (lock && !timerStopped) {
+              lockExtender();
+            }
+          })
+          .catch(function(/*err*/) {
+            // Somehow tell the worker this job should stop processing...
+          });
+      }
+    );
   };
 
   var timeoutMs = job.opts.timeout;
 
-  function stopTimer(){
+  function stopTimer() {
     timerStopped = true;
     _this.timers.clear(lockRenewId);
   }
 
-  function handleCompleted(result){
-    return job.moveToCompleted(result).then(function(){
+  function handleCompleted(result) {
+    return job.moveToCompleted(result).then(function() {
       _this.emit('completed', job, result, 'active');
       return null;
     });
   }
 
-  function handleFailed(err){
+  function handleFailed(err) {
     var error = err.cause || err; //Handle explicit rejection
 
-    return job.moveToFailed(err).then(function(){
+    return job.moveToFailed(err).then(function() {
       _this.emit('failed', job, error, 'active');
       return null;
     });
@@ -912,29 +1011,32 @@ Queue.prototype.processJob = function(job){
   lockExtender();
   var handler = _this.handlers[job.name];
 
-  if(!handler){
-    return handleFailed(Error('Missing process handler for job type ' + job.name));
-  }else{
-
+  if (!handler) {
+    return handleFailed(
+      Error('Missing process handler for job type ' + job.name)
+    );
+  } else {
     var jobPromise = handler(job);
 
-    if(timeoutMs){
+    if (timeoutMs) {
       jobPromise = jobPromise.timeout(timeoutMs);
     }
 
     // Local event with jobPromise so that we can cancel job.
     _this.emit('active', job, jobPromise, 'waiting');
 
-    return jobPromise.then(handleCompleted).catch(handleFailed).finally(function(){
-      stopTimer();
-    });
+    return jobPromise
+      .then(handleCompleted)
+      .catch(handleFailed)
+      .finally(function() {
+        stopTimer();
+      });
   }
 };
 
-Queue.prototype.multi = function(){
+Queue.prototype.multi = function() {
   return this.client.multi();
 };
-
 
 /**
   Returns a promise that resolves to the next job in queue.
@@ -942,39 +1044,51 @@ Queue.prototype.multi = function(){
 Queue.prototype.getNextJob = function() {
   var _this = this;
 
-  if(this.closing){
+  if (this.closing) {
     return Promise.resolve();
   }
-  if(this.drained){
+  if (this.drained) {
     //
     // Waiting for new jobs to arrive
     //
-    return this.bclient.brpoplpush(this.keys.wait, this.keys.active, _this.settings.drainDelay).then(function(jobId){
-      if(jobId){
-        return moveToActive(jobId);
-      }
-    }, function(err){
-      // Swallow error
-      if(err.message !== 'Connection is closed.'){
-        console.error('BRPOPLPUSH', err);
-      }
-    });
-  }else{
+    return this.bclient
+      .brpoplpush(this.keys.wait, this.keys.active, _this.settings.drainDelay)
+      .then(
+        function(jobId) {
+          if (jobId) {
+            return moveToActive(jobId);
+          }
+        },
+        function(err) {
+          // Swallow error
+          if (err.message !== 'Connection is closed.') {
+            console.error('BRPOPLPUSH', err);
+          }
+        }
+      );
+  } else {
     return moveToActive();
   }
 
-  function moveToActive(jobId){
-    return scripts.moveToActive(_this, jobId).spread(function(jobData, jobId){
-      if(jobData){
+  function moveToActive(jobId) {
+    return scripts.moveToActive(_this, jobId).spread(function(jobData, jobId) {
+      if (jobData) {
         _this.drained = false;
         var job = Job.fromJSON(_this, jobData, jobId);
-        if(job.opts.repeat){
-          return _this.nextRepeatableJob(job.name, job.data, job.opts, job.opts.prevMillis).then(function(){
-            return job;
-          });
+        if (job.opts.repeat) {
+          return _this
+            .nextRepeatableJob(
+              job.name,
+              job.data,
+              job.opts,
+              job.opts.prevMillis
+            )
+            .then(function() {
+              return job;
+            });
         }
         return job;
-      }else{
+      } else {
         _this.drained = true;
         _this.emit('drained');
         return null;
@@ -987,7 +1101,7 @@ Queue.prototype.retryJob = function(job) {
   return job.retry();
 };
 
-Queue.prototype.toKey = function(queueType){
+Queue.prototype.toKey = function(queueType) {
   return [this.keyPrefix, this.name, queueType].join(':');
 };
 
@@ -1001,33 +1115,33 @@ Queue.prototype.toKey = function(queueType){
  * @param {int} The max number of jobs to clean
  * are completed, waiting, active, delayed, failed. Defaults to completed.
  */
-Queue.prototype.clean = function (grace, type, limit) {
+Queue.prototype.clean = function(grace, type, limit) {
   var _this = this;
 
-  if(grace === undefined || grace === null) {
+  if (grace === undefined || grace === null) {
     return Promise.reject(new Error('You must define a grace period.'));
   }
 
-  if(!type) {
+  if (!type) {
     type = 'completed';
   }
 
-  if(_.indexOf([
-    'completed',
-    'wait',
-    'active',
-    'delayed',
-    'failed'], type) === -1){
+  if (
+    _.indexOf(['completed', 'wait', 'active', 'delayed', 'failed'], type) === -1
+  ) {
     return Promise.reject(new Error('Cannot clean unkown queue type'));
   }
 
-  return scripts.cleanJobsInSet(_this, type, Date.now() - grace, limit).then(function (jobs) {
-    _this.emit('cleaned', jobs, type);
-    return jobs;
-  }).catch(function (err) {
-    _this.emit('error', err);
-    throw err;
-  });
+  return scripts
+    .cleanJobsInSet(_this, type, Date.now() - grace, limit)
+    .then(function(jobs) {
+      _this.emit('cleaned', jobs, type);
+      return jobs;
+    })
+    .catch(function(err) {
+      _this.emit('error', err);
+      throw err;
+    });
 };
 
 /**
@@ -1035,19 +1149,23 @@ Queue.prototype.clean = function (grace, type, limit) {
  *
  * @returns {Promise}
  */
-Queue.prototype.whenCurrentJobsFinished = function(){
+Queue.prototype.whenCurrentJobsFinished = function() {
   var _this = this;
-  return new Promise(function(resolve, reject){
+  return new Promise(function(resolve, reject) {
     //
     // Force reconnection of blocking connection to abort blocking redis call immediately.
     //
-    var forcedReconnetion = redisClientDisconnect(_this.bclient).then(function(){
-      return _this.bclient.connect();
-    });
+    var forcedReconnetion = redisClientDisconnect(_this.bclient).then(
+      function() {
+        return _this.bclient.connect();
+      }
+    );
 
-    Promise.all(_this.processing).then(function(){
-      return forcedReconnetion;
-    }).then(resolve, reject);
+    Promise.all(_this.processing)
+      .then(function() {
+        return forcedReconnetion;
+      })
+      .then(resolve, reject);
 
     /*
     _this.bclient.disconnect();
@@ -1080,19 +1198,16 @@ Queue.prototype.whenCurrentJobsFinished = function(){
 // Private local functions
 //
 
-function getRedisVersion(client){
-  return client.info().then(function(doc){
+function getRedisVersion(client) {
+  return client.info().then(function(doc) {
     var prefix = 'redis_version:';
     var lines = doc.split('\r\n');
-    for(var i = 0; i < lines.length; i++){
-      if(lines[i].indexOf(prefix) === 0){
+    for (var i = 0; i < lines.length; i++) {
+      if (lines[i].indexOf(prefix) === 0) {
         return lines[i].substr(prefix.length);
       }
     }
   });
-};
+}
 
 module.exports = Queue;
-
-
-

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -7,15 +7,14 @@ var crypto = require('crypto');
 
 var Job = require('./job');
 
-module.exports = function(Queue){
-
-  Queue.prototype.nextRepeatableJob = function (name, data, opts){
+module.exports = function(Queue) {
+  Queue.prototype.nextRepeatableJob = function(name, data, opts) {
     var _this = this;
     var client = this.client;
     var repeat = opts.repeat;
     var prevMillis = opts.prevMillis || 0;
 
-    if(!prevMillis && opts.jobId){
+    if (!prevMillis && opts.jobId) {
       repeat.jobId = opts.jobId;
     }
 
@@ -29,102 +28,131 @@ module.exports = function(Queue){
     now = prevMillis < now ? now : prevMillis;
 
     var nextMillis = getNextMillis(now, repeat.cron, repeat);
-    if(nextMillis){
+    if (nextMillis) {
       var jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       var repeatJobKey = getRepeatKey(name, repeat, jobId);
-        
+
       nextMillis = nextMillis.getTime();
-      
-      return client.zadd(_this.keys.repeat, nextMillis, repeatJobKey).then(function(){
-        //
-        // Generate unique job id for this iteration.
-        //
-        var customId = getRepeatJobId(name, jobId, nextMillis, md5(repeatJobKey));
-        now = Date.now();
-        var delay = nextMillis - now;
-        
-        return Job.create(_this, name, data, _.extend(_.clone(opts), {
-          jobId: customId,
-          delay: delay < 0 ? 0 : delay,
-          timestamp: now,
-          prevMillis: nextMillis
-        }));
-      });
+
+      return client
+        .zadd(_this.keys.repeat, nextMillis, repeatJobKey)
+        .then(function() {
+          //
+          // Generate unique job id for this iteration.
+          //
+          var customId = getRepeatJobId(
+            name,
+            jobId,
+            nextMillis,
+            md5(repeatJobKey)
+          );
+          now = Date.now();
+          var delay = nextMillis - now;
+
+          return Job.create(
+            _this,
+            name,
+            data,
+            _.extend(_.clone(opts), {
+              jobId: customId,
+              delay: delay < 0 ? 0 : delay,
+              timestamp: now,
+              prevMillis: nextMillis
+            })
+          );
+        });
     } else {
       return Promise.resolve();
     }
   };
 
-  Queue.prototype.removeRepeatable = function(name, repeat){
+  Queue.prototype.removeRepeatable = function(name, repeat) {
     var _this = this;
-    
-    if(typeof name !== 'string'){
+
+    if (typeof name !== 'string') {
       repeat = name;
       name = Job.DEFAULT_JOB_NAME;
-    } 
+    }
 
-    return this.isReady().then(function(){
+    return this.isReady().then(function() {
       var jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       var repeatJobKey = getRepeatKey(name, repeat, jobId);
       var repeatJobId = getRepeatJobId(name, jobId, '', md5(repeatJobKey));
       var queueKey = _this.keys[''];
-      return _this.client.removeRepeatable(_this.keys.repeat, _this.keys.delayed, repeatJobId, repeatJobKey, queueKey);
+      return _this.client.removeRepeatable(
+        _this.keys.repeat,
+        _this.keys.delayed,
+        repeatJobId,
+        repeatJobKey,
+        queueKey
+      );
     });
   };
 
-  Queue.prototype.getRepeatableJobs = function (start, end, asc){
+  Queue.prototype.getRepeatableJobs = function(start, end, asc) {
     var key = this.keys.repeat;
     start = start || 0;
-    end = end || -1;
-    return (asc ?
-      this.client.zrange(key, start, end, 'WITHSCORES') :
-      this.client.zrevrange(key, start, end, 'WITHSCORES')
-    ).then(function(result){
+    end = end || -1;
+    return (asc
+      ? this.client.zrange(key, start, end, 'WITHSCORES')
+      : this.client.zrevrange(key, start, end, 'WITHSCORES')
+    ).then(function(result) {
       var jobs = [];
-      for(var i=0; i<result.length; i+=2){
+      for (var i = 0; i < result.length; i += 2) {
         var data = result[i].split(':');
         jobs.push({
           key: result[i],
           name: data[0],
-          id: data[1] || null,
-          endDate: parseInt(data[2]) || null,
+          id: data[1] || null,
+          endDate: parseInt(data[2]) || null,
           tz: data[3] || null,
           cron: data[4],
-          next: parseInt(result[i+1])
+          next: parseInt(result[i + 1])
         });
       }
       return jobs;
     });
   };
 
-  Queue.prototype.getRepeatableCount = function(){
+  Queue.prototype.getRepeatableCount = function() {
     return this.client.zcard(this.toKey('repeat'));
   };
 
-  function getRepeatJobId(name, jobId, nextMillis, namespace){
+  function getRepeatJobId(name, jobId, nextMillis, namespace) {
     return 'repeat:' + md5(name + jobId + namespace) + ':' + nextMillis;
   }
 
-  function getRepeatKey(name, repeat, jobId){
-    var endDate = repeat.endDate ? (new Date(repeat.endDate)).getTime() + ':' : ':';
+  function getRepeatKey(name, repeat, jobId) {
+    var endDate = repeat.endDate
+      ? new Date(repeat.endDate).getTime() + ':'
+      : ':';
     var tz = repeat.tz ? repeat.tz + ':' : ':';
     return name + ':' + jobId + endDate + tz + repeat.cron;
   }
 
-  function getNextMillis(millis, cron, opts){
+  function getNextMillis(millis, cron, opts) {
     var currentDate = new Date(millis);
-    var interval = parser.parseExpression(cron, _.defaults({
-      currentDate: currentDate
-    }, opts));
+    var interval = parser.parseExpression(
+      cron,
+      _.defaults(
+        {
+          currentDate: currentDate
+        },
+        opts
+      )
+    );
 
-    try{
+    try {
       return interval.next();
-    } catch(e){
+    } catch (e) {
       // Ignore error
     }
   }
 
-  function md5(str){
-    return crypto.createHash('md5').update(str).digest('hex');
+  function md5(str) {
+    return crypto
+      .createHash('md5')
+      .update(str)
+      .digest('hex');
   }
 };

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -9,10 +9,10 @@ var _ = require('lodash');
 var debuglog = require('debuglog')('bull');
 
 // TO Deprecate.
-function execScript(client, hash, lua, numberOfKeys){
+function execScript(client, hash, lua, numberOfKeys) {
   var args = _.drop(arguments, 4);
 
-  if(!client[hash]){
+  if (!client[hash]) {
     debuglog(hash, lua, args);
     client.defineCommand(hash, { numberOfKeys: numberOfKeys, lua: lua });
   }
@@ -21,14 +21,13 @@ function execScript(client, hash, lua, numberOfKeys){
 }
 
 var scripts = {
-  isJobInList: function(client, listKey, jobId){
-    return client.isJobInList([listKey, jobId]).then(function(result){
+  isJobInList: function(client, listKey, jobId) {
+    return client.isJobInList([listKey, jobId]).then(function(result) {
       return result === 1;
     });
   },
 
-  addJob: function(client, queue, job, opts){
-
+  addJob: function(client, queue, job, opts) {
     var queueKeys = queue.keys;
     var keys = [
       queueKeys.wait,
@@ -57,20 +56,24 @@ var scripts = {
   },
 
   pause: function(queue, pause) {
-    var src = 'wait', dst = 'paused';
-    if(!pause){
+    var src = 'wait',
+      dst = 'paused';
+    if (!pause) {
       src = 'paused';
       dst = 'wait';
     }
 
-    var keys = _.map([src, dst, 'meta-paused', pause ? 'paused' : 'resumed'], function(name){
-      return queue.toKey(name);
-    });
+    var keys = _.map(
+      [src, dst, 'meta-paused', pause ? 'paused' : 'resumed'],
+      function(name) {
+        return queue.toKey(name);
+      }
+    );
 
     return queue.client.pause(keys.concat([pause ? 'paused' : 'resumed']));
   },
 
-  moveToActive: function(queue, jobId){
+  moveToActive: function(queue, jobId) {
     var queueKeys = queue.keys;
     var keys = [queueKeys.wait, queueKeys.active, queueKeys.priority];
 
@@ -88,13 +91,13 @@ var scripts = {
       jobId
     ];
 
-    if(queue.limiter){
+    if (queue.limiter) {
       args.push(queue.limiter.max, queue.limiter.duration);
     }
-    return queue.client.moveToActive(keys.concat(args)).then(function(result){
-      if(result){
+    return queue.client.moveToActive(keys.concat(args)).then(function(result) {
+      if (result) {
         var jobData = result[0];
-        if(jobData.length){
+        if (jobData.length) {
           var job = array2obj(jobData);
           return [job, result[1]];
         }
@@ -103,21 +106,30 @@ var scripts = {
     });
   },
 
-  updateProgress: function(job, progress){
+  updateProgress: function(job, progress) {
     var queue = job.queue;
-    var keys = [job.id, 'progress'].map(function(name){
+    var keys = [job.id, 'progress'].map(function(name) {
       return queue.toKey(name);
     });
 
-    return queue.client.updateProgress(keys, [progress, job.id + ',' + progress]).then(function(){
-      queue.emit('progress', job, progress);
-    });
+    return queue.client
+      .updateProgress(keys, [progress, job.id + ',' + progress])
+      .then(function() {
+        queue.emit('progress', job, progress);
+      });
   },
 
-  moveToFinishedArgs: function(job, val, propVal, shouldRemove, target, ignoreLock){
+  moveToFinishedArgs: function(
+    job,
+    val,
+    propVal,
+    shouldRemove,
+    target,
+    ignoreLock
+  ) {
     var queue = job.queue;
 
-    var keys = _.map(['active', target, job.id], function(name){
+    var keys = _.map(['active', target, job.id], function(name) {
       return queue.toKey(name);
     });
 
@@ -128,51 +140,88 @@ var scripts = {
       _.isUndefined(val) ? 'null' : val,
       ignoreLock ? '0' : job.queue.token,
       shouldRemove ? '1' : '0',
-      JSON.stringify({jobId: job.id, val: val}),
+      JSON.stringify({ jobId: job.id, val: val })
     ];
 
     return keys.concat(args);
   },
 
-  moveToFinished: function(job, val, propVal, shouldRemove, target, ignoreLock){
-    var args = scripts.moveToFinishedArgs(job, val, propVal, shouldRemove, target, ignoreLock);
-    return job.queue.client.moveToFinished(args).then(function(result){
-      if(result < 0){
+  moveToFinished: function(
+    job,
+    val,
+    propVal,
+    shouldRemove,
+    target,
+    ignoreLock
+  ) {
+    var args = scripts.moveToFinishedArgs(
+      job,
+      val,
+      propVal,
+      shouldRemove,
+      target,
+      ignoreLock
+    );
+    return job.queue.client.moveToFinished(args).then(function(result) {
+      if (result < 0) {
         throw scripts.finishedErrors(result, job.id, 'finished');
       }
     });
   },
 
-  finishedErrors: function(code, jobId, command){
-    switch(code){
-      case -1: return new Error('Missing key for job ' + jobId + ' ' + command);
-      case -2: return new Error('Missing lock for job ' + jobId + ' ' + command);
+  finishedErrors: function(code, jobId, command) {
+    switch (code) {
+      case -1:
+        return new Error('Missing key for job ' + jobId + ' ' + command);
+      case -2:
+        return new Error('Missing lock for job ' + jobId + ' ' + command);
     }
   },
 
   // TODO: add a retention argument for completed and finished jobs (in time).
-  moveToCompleted: function(job, returnvalue, removeOnComplete, ignoreLock){
-    return scripts.moveToFinished(job, returnvalue, 'returnvalue', removeOnComplete, 'completed', ignoreLock);
+  moveToCompleted: function(job, returnvalue, removeOnComplete, ignoreLock) {
+    return scripts.moveToFinished(
+      job,
+      returnvalue,
+      'returnvalue',
+      removeOnComplete,
+      'completed',
+      ignoreLock
+    );
   },
 
-  moveToFailedArgs: function(job, failedReason, removeOnFailed, ignoreLock){
-    return scripts.moveToFinishedArgs(job, failedReason, 'failedReason', removeOnFailed, 'failed', ignoreLock);
+  moveToFailedArgs: function(job, failedReason, removeOnFailed, ignoreLock) {
+    return scripts.moveToFinishedArgs(
+      job,
+      failedReason,
+      'failedReason',
+      removeOnFailed,
+      'failed',
+      ignoreLock
+    );
   },
 
-  moveToFailed: function(job, failedReason, removeOnFailed, ignoreLock){
-    var args = scripts.moveToFailedArgs(job, failedReason, 'failedReason', removeOnFailed, 'failed', ignoreLock);
+  moveToFailed: function(job, failedReason, removeOnFailed, ignoreLock) {
+    var args = scripts.moveToFailedArgs(
+      job,
+      failedReason,
+      'failedReason',
+      removeOnFailed,
+      'failed',
+      ignoreLock
+    );
     return scripts.moveToFinished(args);
   },
 
-  isFinished: function(job){
-    var keys = _.map(['completed', 'failed'], function(key){
+  isFinished: function(job) {
+    var keys = _.map(['completed', 'failed'], function(key) {
       return job.queue.toKey(key);
     });
 
     return job.queue.client.isFinished(keys.concat([job.id]));
   },
 
-  moveToDelayedArgs: function(queue, jobId, timestamp, ignoreLock){
+  moveToDelayedArgs: function(queue, jobId, timestamp, ignoreLock) {
     //
     // Bake in the job id first 12 bits into the timestamp
     // to guarantee correct execution order of delayed jobs
@@ -184,71 +233,82 @@ var scripts = {
 
     timestamp = +timestamp || 0;
     timestamp = timestamp < 0 ? 0 : timestamp;
-    if(timestamp > 0){
+    if (timestamp > 0) {
       timestamp = timestamp * 0x1000 + (jobId & 0xfff);
     }
 
-    var keys = _.map(['active', 'delayed', jobId], function(name){
+    var keys = _.map(['active', 'delayed', jobId], function(name) {
       return queue.toKey(name);
     });
-    return keys.concat([JSON.stringify(timestamp), jobId, ignoreLock ? '0' : queue.token]);
+    return keys.concat([
+      JSON.stringify(timestamp),
+      jobId,
+      ignoreLock ? '0' : queue.token
+    ]);
   },
 
-  moveToDelayed: function(queue, jobId, timestamp, ignoreLock){
+  moveToDelayed: function(queue, jobId, timestamp, ignoreLock) {
     var args = scripts.moveToDelayedArgs(queue, jobId, timestamp, ignoreLock);
-    return queue.client.moveToDelayed(args).then(function(result){
-      switch(result){
+    return queue.client.moveToDelayed(args).then(function(result) {
+      switch (result) {
         case -1:
-          throw new Error('Missing Job ' + jobId + ' when trying to move from active to delayed');
+          throw new Error(
+            'Missing Job ' +
+              jobId +
+              ' when trying to move from active to delayed'
+          );
         case -2:
-          throw new Error('Job ' + jobId + ' was locked when trying to move from active to delayed');
+          throw new Error(
+            'Job ' +
+              jobId +
+              ' was locked when trying to move from active to delayed'
+          );
       }
     });
   },
 
-  remove: function(queue, jobId){
-    var keys = _.map([
-      'active',
-      'wait',
-      'delayed',
-      'paused',
-      'completed',
-      'failed',
-      jobId],
-    function(name){
-      return queue.toKey(name);
-    });
+  remove: function(queue, jobId) {
+    var keys = _.map(
+      ['active', 'wait', 'delayed', 'paused', 'completed', 'failed', jobId],
+      function(name) {
+        return queue.toKey(name);
+      }
+    );
 
     return queue.client.removeJob(keys.concat([jobId, queue.token]));
   },
 
-  extendLock: function(queue, jobId){
+  extendLock: function(queue, jobId) {
     return queue.client.extendLock([
       queue.toKey(jobId) + ':lock',
       queue.keys.stalled,
       queue.token,
       queue.settings.lockDuration,
-      jobId]);
+      jobId
+    ]);
   },
 
-  releaseLock: function(queue, jobId){
-    return queue.client.releaseLock([queue.toKey(jobId) + ':lock', queue.token]);
+  releaseLock: function(queue, jobId) {
+    return queue.client.releaseLock([
+      queue.toKey(jobId) + ':lock',
+      queue.token
+    ]);
   },
 
-  takeLock: function(queue, job){
-    return queue.client.takeLock([job.lockKey, queue.token, queue.settings.lockDuration]);
+  takeLock: function(queue, job) {
+    return queue.client.takeLock([
+      job.lockKey,
+      queue.token,
+      queue.settings.lockDuration
+    ]);
   },
 
   /**
     It checks if the job in the top of the delay set should be moved back to the
     top of the  wait queue (so that it will be processed as soon as possible)
   */
-  updateDelaySet: function(queue, delayedTimestamp){
-    var keys = [
-      queue.keys.delayed,
-      queue.keys.active,
-      queue.keys.wait
-    ];
+  updateDelaySet: function(queue, delayedTimestamp) {
+    var keys = [queue.keys.delayed, queue.keys.active, queue.keys.wait];
 
     var args = [queue.toKey(''), delayedTimestamp];
     return queue.client.updateDelaySet(keys.concat(args));
@@ -262,7 +322,7 @@ var scripts = {
    *    back to wait to be re-processed. To prevent jobs from cycling endlessly between active and wait,
    *    (e.g. if the job handler keeps crashing), we limit the number stalled job recoveries to settings.maxStalledCount.
    */
-  moveUnlockedJobsToWait: function(queue){
+  moveUnlockedJobsToWait: function(queue) {
     var keys = [
       queue.keys.stalled,
       queue.keys.wait,
@@ -270,9 +330,14 @@ var scripts = {
       queue.keys.failed,
       queue.keys['stalled-check'],
       queue.keys['meta-paused'],
-      queue.keys.paused,
+      queue.keys.paused
     ];
-    var args = [queue.settings.maxStalledCount, queue.toKey(''), Date.now(), queue.settings.stalledInterval];
+    var args = [
+      queue.settings.maxStalledCount,
+      queue.toKey(''),
+      Date.now(),
+      queue.settings.stalledInterval
+    ];
     return queue.client.moveStalledJobsToWait(keys.concat(args));
   },
 
@@ -284,7 +349,7 @@ var scripts = {
     var hash;
     limit = limit || 0;
 
-    switch(set) {
+    switch (set) {
       case 'wait':
       case 'active':
       case 'paused':
@@ -301,11 +366,11 @@ var scripts = {
         break;
     }
 
-    if(limit > 0) {
+    if (limit > 0) {
       breakEarlyCommand = [
         'if deletedCount >= limit then',
         '  break',
-        'end',
+        'end'
       ].join('\n');
 
       hash = hash + 'WithLimit';
@@ -347,11 +412,11 @@ var scripts = {
     return execScript.apply(scripts, args);
   },
 
-  retryJobArgs: function(job, ignoreLock){
+  retryJobArgs: function(job, ignoreLock) {
     var queue = job.queue;
     var jobId = job.id;
 
-    var keys = _.map(['active', 'wait', jobId], function(name){
+    var keys = _.map(['active', 'wait', jobId], function(name) {
       return queue.toKey(name);
     });
 
@@ -384,11 +449,7 @@ var scripts = {
       queue.toKey('wait')
     ];
 
-    var args = [
-      job.id,
-      (job.opts.lifo ? 'R' : 'L') + 'PUSH',
-      queue.token
-    ];
+    var args = [job.id, (job.opts.lifo ? 'R' : 'L') + 'PUSH', queue.token];
 
     return queue.client.reprocessJob(keys.concat(args));
   }
@@ -396,10 +457,10 @@ var scripts = {
 
 module.exports = scripts;
 
-function array2obj(arr){
+function array2obj(arr) {
   var obj = {};
-  for(var i=0; i < arr.length; i+=2){
-    obj[arr[i]] = arr[i+1];
+  for (var i = 0; i < arr.length; i += 2) {
+    obj[arr[i]] = arr[i + 1];
   }
   return obj;
 }

--- a/lib/timer-manager.js
+++ b/lib/timer-manager.js
@@ -56,7 +56,7 @@ var uuid = require('uuid');
     })
 */
 
-function TimerManager(){
+function TimerManager() {
   this.idle = true;
   this.listeners = [];
   this.timers = {};
@@ -72,16 +72,21 @@ function TimerManager(){
   @param {Function} fn - Function to execute after delay
   @returns {Number} id - The timer id. Used to clear the timer
 */
-TimerManager.prototype.set = function(name, delay, fn){
+TimerManager.prototype.set = function(name, delay, fn) {
   var id = uuid.v4();
-  var timer = setTimeout(function (timerInstance, timeoutId) {
-    timerInstance.clear(timeoutId);
-    try{
-      fn();
-    }catch(err){
-      console.error(err);
-    }
-  }, delay, this, id);
+  var timer = setTimeout(
+    function(timerInstance, timeoutId) {
+      timerInstance.clear(timeoutId);
+      try {
+        fn();
+      } catch (err) {
+        console.error(err);
+      }
+    },
+    delay,
+    this,
+    id
+  );
 
   // XXX only the timer is used, but the
   // other fields are useful for
@@ -101,38 +106,38 @@ TimerManager.prototype.set = function(name, delay, fn){
   Queued listeners are executed if there are no
   remaining timers
 */
-TimerManager.prototype.clear = function(id){
+TimerManager.prototype.clear = function(id) {
   var timers = this.timers;
   var timer = timers[id];
-  if(!timer) {
+  if (!timer) {
     return;
   }
   clearTimeout(timer.timer);
   delete timers[id];
-  if(!this.idle && (_.size(timers) === 0)){
-    while(this.listeners.length){
+  if (!this.idle && _.size(timers) === 0) {
+    while (this.listeners.length) {
       this.listeners.pop()();
     }
     this.idle = true;
   }
 };
 
-TimerManager.prototype.clearAll = function(){
+TimerManager.prototype.clearAll = function() {
   var _this = this;
-  _.each(this.timers, function(timer, id){
+  _.each(this.timers, function(timer, id) {
     _this.clear(id);
   });
 };
 
 /**
  * Returns a promise that resolves when there are no active timers.
-*/
+ */
 TimerManager.prototype.whenIdle = function() {
   var _this = this;
-  return new Promise(function(resolve){
-    if(_this.idle) {
+  return new Promise(function(resolve) {
+    if (_this.idle) {
       resolve();
-    } else{
+    } else {
       _this.listeners.unshift(resolve);
     }
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,19 +1,18 @@
 'use strict';
 var Promise = require('bluebird');
-var errorObject = {value: null};
+var errorObject = { value: null };
 function tryCatch(fn, ctx, args) {
   try {
     return fn.apply(ctx, args);
-  }
-  catch(e) {
+  } catch (e) {
     errorObject.value = e;
     return errorObject;
   }
 }
 
-function isEmpty(obj){
-  for(var key in obj) {
-    if(obj.hasOwnProperty(key)){
+function isEmpty(obj) {
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
       return false;
     }
   }
@@ -24,17 +23,17 @@ function isEmpty(obj){
  * Waits for a redis client to be ready.
  * @param {Redis} redis client
  */
-function isRedisReady(client){
-  return new Promise(function(resolve, reject){
-    if(client.status === 'ready'){
+function isRedisReady(client) {
+  return new Promise(function(resolve, reject) {
+    if (client.status === 'ready') {
       resolve();
     } else {
-      function handleReady(){
+      function handleReady() {
         client.removeListener('error', handleError);
         resolve();
       }
 
-      function handleError(err){
+      function handleError(err) {
         client.removeListener('ready', handleError);
         reject(err);
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,53 +2,55 @@
 'use strict';
 
 var utils = require('./utils');
-module.exports = function(Queue){
-
+module.exports = function(Queue) {
   // IDEA, How to store metadata associated to a worker.
   // create a key from the worker ID associated to the given name.
   // We keep a hash table bull:myqueue:workers where every worker is a hash key workername:workerId with json holding
   // metadata of the worker. The worker key gets expired every 30 seconds or so, we renew the worker metadata.
   //
-  Queue.prototype.setWorkerName = function(){
+  Queue.prototype.setWorkerName = function() {
     var _this = this;
-    return utils.isRedisReady(this.client).then(function(){
+    return utils.isRedisReady(this.client).then(function() {
       return _this.client.client('setname', _this.clientName());
     });
   };
 
-  Queue.prototype.getWorkers = function(){
+  Queue.prototype.getWorkers = function() {
     var _this = this;
-    return utils.isRedisReady(this.client).then(function(){
-      return _this.client.client('list');
-    }).then(function(clients){
-      return _this.parseClientList(clients);
-    });
+    return utils
+      .isRedisReady(this.client)
+      .then(function() {
+        return _this.client.client('list');
+      })
+      .then(function(clients) {
+        return _this.parseClientList(clients);
+      });
   };
 
-  Queue.prototype.base64Name = function(){
-    return (new Buffer(this.name)).toString('base64');
+  Queue.prototype.base64Name = function() {
+    return new Buffer(this.name).toString('base64');
   };
 
-  Queue.prototype.clientName = function(){
+  Queue.prototype.clientName = function() {
     return this.keyPrefix + ':' + this.base64Name();
   };
 
-  Queue.prototype.parseClientList = function(list){
+  Queue.prototype.parseClientList = function(list) {
     var _this = this;
     var lines = list.split('\n');
     var clients = [];
 
-    lines.forEach(function(line){
+    lines.forEach(function(line) {
       var client = {};
       var keyValues = line.split(' ');
-      keyValues.forEach(function(keyValue){
+      keyValues.forEach(function(keyValue) {
         var index = keyValue.indexOf('=');
         var key = keyValue.substring(0, index);
-        var value = keyValue.substring(index+1);
+        var value = keyValue.substring(index + 1);
         client[key] = value;
       });
       var name = client['name'];
-      if(name && name.startsWith(_this.clientName())){
+      if (name && name.startsWith(_this.clientName())) {
         client['name'] = _this.name;
         clients.push(client);
       }
@@ -56,4 +58,3 @@ module.exports = function(Queue){
     return clients;
   };
 };
-

--- a/package.json
+++ b/package.json
@@ -51,14 +51,6 @@
   },
   "eslintConfig": {
     "rules": {
-      "indent": [
-        2,
-        2,
-        {
-          "SwitchCase": 1
-        }
-      ],
-      "semi": 2,
       "valid-jsdoc": 0,
       "func-style": 0,
       "no-use-before-define": 0,
@@ -71,7 +63,6 @@
           "allow": ["warn", "error"]
         }
       ],
-      "quotes": [2, "single"],
       "no-underscore-dangle": 0
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "coveralls":
       "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "postpublish": "git push && git push --tags",
+    "prettier": "prettier --config package.json --write '**/*.js'",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,7 @@
     "type": "git",
     "url": "git://github.com/OptimalBits/bull.git"
   },
-  "keywords": [
-    "job",
-    "queue",
-    "task",
-    "parallel"
-  ],
+  "keywords": ["job", "queue", "task", "parallel"],
   "author": "OptimalBits",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -30,18 +25,29 @@
     "coveralls": "^3.0.0",
     "eslint": "^4.4.1",
     "expect.js": "^0.3.1",
+    "husky": "^0.14.3",
     "istanbul": "^0.4.5",
+    "lint-staged": "^6.1.0",
     "mocha": "^3.4.2",
     "mocha-lcov-reporter": "^1.3.0",
     "moment": "^2.18.1",
+    "prettier": "^1.10.2",
     "sinon": "^1.17.7"
   },
   "scripts": {
     "lint": "eslint lib test",
     "pretest": "npm run lint",
     "test": "NODE_ENV=test mocha",
-    "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "postpublish": "git push && git push --tags"
+    "coveralls":
+      "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "postpublish": "git push && git push --tags",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.{js,json}": ["prettier --write", "git add"]
+  },
+  "prettier": {
+    "singleQuote": true
   },
   "eslintConfig": {
     "rules": {
@@ -62,16 +68,10 @@
       "no-console": [
         2,
         {
-          "allow": [
-            "warn",
-            "error"
-          ]
+          "allow": ["warn", "error"]
         }
       ],
-      "quotes": [
-        2,
-        "single"
-      ],
+      "quotes": [2, "single"],
       "no-underscore-dangle": 0
     }
   }

--- a/test/cluster_worker.js
+++ b/test/cluster_worker.js
@@ -20,11 +20,14 @@ queue.process(1, function(job, jobDone) {
   });
 });
 
-process.on('disconnect', function () {
-  queue.close().then(function () {
-  //  process.exit(0);
-  }).catch(function (err) {
-    console.error(err);
-  //  process.exit(-1);
-  });
+process.on('disconnect', function() {
+  queue
+    .close()
+    .then(function() {
+      //  process.exit(0);
+    })
+    .catch(function(err) {
+      console.error(err);
+      //  process.exit(-1);
+    });
 });

--- a/test/fixtures/fixture_processor.js
+++ b/test/fixtures/fixture_processor.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(/*job*/){
-  return Promise.delay(500).then(function(){
+module.exports = function(/*job*/) {
+  return Promise.delay(500).then(function() {
     return 42;
   });
 };

--- a/test/fixtures/fixture_processor_bar.js
+++ b/test/fixtures/fixture_processor_bar.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(/*job*/){
-  return Promise.delay(500).then(function(){
+module.exports = function(/*job*/) {
+  return Promise.delay(500).then(function() {
     return 'bar';
   });
 };

--- a/test/fixtures/fixture_processor_callback.js
+++ b/test/fixtures/fixture_processor_callback.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(job, done){
-  Promise.delay(500).then(function(){
+module.exports = function(job, done) {
+  Promise.delay(500).then(function() {
     done(null, 42);
   });
 };

--- a/test/fixtures/fixture_processor_callback_fail.js
+++ b/test/fixtures/fixture_processor_callback_fail.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(job, done){
-  Promise.delay(500).then(function(){
+module.exports = function(job, done) {
+  Promise.delay(500).then(function() {
     done(new Error('Manually failed processor'));
   });
 };

--- a/test/fixtures/fixture_processor_exit.js
+++ b/test/fixtures/fixture_processor_exit.js
@@ -5,9 +5,9 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(/*job*/){
-  return Promise.delay(500).then(function(){
-    Promise.delay(100).then(function(){
+module.exports = function(/*job*/) {
+  return Promise.delay(500).then(function() {
+    Promise.delay(100).then(function() {
       process.exit(0);
     });
   });

--- a/test/fixtures/fixture_processor_fail.js
+++ b/test/fixtures/fixture_processor_fail.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(/*job*/){
-  return Promise.delay(500).then(function(){
+module.exports = function(/*job*/) {
+  return Promise.delay(500).then(function() {
     throw new Error('Manually failed processor');
   });
 };

--- a/test/fixtures/fixture_processor_foo.js
+++ b/test/fixtures/fixture_processor_foo.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(/*job*/){
-  return Promise.delay(500).then(function(){
+module.exports = function(/*job*/) {
+  return Promise.delay(500).then(function() {
     return 'foo';
   });
 };

--- a/test/fixtures/fixture_processor_progress.js
+++ b/test/fixtures/fixture_processor_progress.js
@@ -5,19 +5,24 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(job){
-  return Promise.delay(50).then(function(){
-    job.progress(10);
-    return Promise.delay(100);
-  }).then(function(){
-    job.progress(27);
-    return Promise.delay(150);
-  }).then(function(){
-    job.progress(78);
-    return Promise.delay(100);
-  }).then(function(){
-    return job.progress(100);
-  }).then(function(){
-    return 37;
-  });
+module.exports = function(job) {
+  return Promise.delay(50)
+    .then(function() {
+      job.progress(10);
+      return Promise.delay(100);
+    })
+    .then(function() {
+      job.progress(27);
+      return Promise.delay(150);
+    })
+    .then(function() {
+      job.progress(78);
+      return Promise.delay(100);
+    })
+    .then(function() {
+      return job.progress(100);
+    })
+    .then(function() {
+      return 37;
+    });
 };

--- a/test/fixtures/fixture_processor_slow.js
+++ b/test/fixtures/fixture_processor_slow.js
@@ -5,8 +5,8 @@
 
 var Promise = require('bluebird');
 
-module.exports = function(/*job*/){
-  return Promise.delay(1000).then(function(){
+module.exports = function(/*job*/) {
+  return Promise.delay(1000).then(function() {
     return 42;
   });
 };

--- a/test/test_cluster.js
+++ b/test/test_cluster.js
@@ -24,12 +24,10 @@ function purgeQueue(queue) {
   var script = [
     'local KS = redis.call("KEYS", ARGV[1])',
     'local result = redis.call("DEL", unpack(KS))',
-    'return'].join('\n');
+    'return'
+  ].join('\n');
 
-  return queue.client.eval(
-    script,
-    0,
-    queue.toKey('*'));
+  return queue.client.eval(script, 0, queue.toKey('*'));
 }
 
 cluster.setupMaster({
@@ -38,19 +36,18 @@ cluster.setupMaster({
 
 var workerMessageHandler;
 function workerMessageHandlerWrapper(message) {
-  if(workerMessageHandler) {
+  if (workerMessageHandler) {
     workerMessageHandler(message);
   }
 }
 
-describe.skip('Cluster', function () {
-
+describe.skip('Cluster', function() {
   var workers = [];
 
   before(function() {
     var worker;
     var _i = 0;
-    for(_i; _i < os.cpus().length - 1; _i++) {
+    for (_i; _i < os.cpus().length - 1; _i++) {
       worker = cluster.fork();
       worker.on('message', workerMessageHandlerWrapper);
       workers.push(worker);
@@ -60,13 +57,15 @@ describe.skip('Cluster', function () {
 
   var queue;
 
-  afterEach(function(){
-    if(queue){
+  afterEach(function() {
+    if (queue) {
       return purgeQueue(queue).then(function() {
-        return queue.close.bind(queue)().then(function() {
-          queue = undefined;
-          workerMessageHandler = undefined;
-        });
+        return queue.close
+          .bind(queue)()
+          .then(function() {
+            queue = undefined;
+            workerMessageHandler = undefined;
+          });
       });
     }
   });
@@ -76,16 +75,16 @@ describe.skip('Cluster', function () {
     queue = buildQueue();
     var numJobs = 100;
 
-    queue.on('stalled', function(job){
+    queue.on('stalled', function(job) {
       jobs.splice(jobs.indexOf(job.jobId), 1);
     });
 
     workerMessageHandler = function(job) {
       jobs.push(job.id);
-      if(jobs.length === numJobs) {
+      if (jobs.length === numJobs) {
         var counts = {};
         var j = 0;
-        for(j; j < jobs.length; j++) {
+        for (j; j < jobs.length; j++) {
           expect(counts[jobs[j]]).to.be(undefined);
           counts[jobs[j]] = 1;
         }
@@ -94,7 +93,7 @@ describe.skip('Cluster', function () {
     };
 
     var i = 0;
-    for(i; i < numJobs; i++) {
+    for (i; i < numJobs; i++) {
       queue.add({});
     }
   });
@@ -107,7 +106,7 @@ describe.skip('Cluster', function () {
     workerMessageHandler = function(job) {
       expect(order).to.be.below(job.data.order);
       order = job.data.order;
-      if(order === 10) {
+      if (order === 10) {
         done();
       }
     };
@@ -143,7 +142,7 @@ describe.skip('Cluster', function () {
     workerMessageHandler = function(job) {
       expect(order).to.be.below(job.data.order);
       order = job.data.order;
-      if(order === 10) {
+      if (order === 10) {
         done();
       }
     };
@@ -162,9 +161,8 @@ describe.skip('Cluster', function () {
 
   after(function() {
     var _i = 0;
-    for(_i; _i < workers.length; _i++) {
+    for (_i; _i < workers.length; _i++) {
       workers[_i].kill();
     }
   });
-
 });

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -5,80 +5,83 @@ var expect = require('expect.js');
 var utils = require('./utils');
 var redis = require('ioredis');
 
-
-describe('connection', function () {
+describe('connection', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     var client = new redis();
-    return client.flushdb().then(function(){
+    return client.flushdb().then(function() {
       queue = utils.buildQueue();
       return queue;
     });
   });
 
-  it('should recover from a connection loss', function (done) {
-    queue.on('error', function () {
+  it('should recover from a connection loss', function(done) {
+    queue.on('error', function() {
       // error event has to be observed or the exception will bubble up
     });
 
-    queue.process(function (job, jobDone) {
-      expect(job.data.foo).to.be.equal('bar');
-      jobDone();
-      queue.close();
-    }).then(function() {
-      done();
-    }).catch(done);
+    queue
+      .process(function(job, jobDone) {
+        expect(job.data.foo).to.be.equal('bar');
+        jobDone();
+        queue.close();
+      })
+      .then(function() {
+        done();
+      })
+      .catch(done);
 
     // Simulate disconnect
-    queue.isReady().then(function(){
+    queue.isReady().then(function() {
       queue.client.stream.end();
       queue.client.emit('error', new Error('ECONNRESET'));
 
       // add something to the queue
-      queue.add({ 'foo': 'bar' });
+      queue.add({ foo: 'bar' });
     });
   });
 
-  it('should handle jobs added before and after a redis disconnect', function(done){
+  it('should handle jobs added before and after a redis disconnect', function(done) {
     var count = 0;
-    queue.process(function (job, jobDone) {
-      if(count == 0){
-        expect(job.data.foo).to.be.equal('bar');
-        jobDone();
-      } else {
-        jobDone();
-        queue.close().then(done, done);
-      }
-      count ++;
-    }).catch(done);
+    queue
+      .process(function(job, jobDone) {
+        if (count == 0) {
+          expect(job.data.foo).to.be.equal('bar');
+          jobDone();
+        } else {
+          jobDone();
+          queue.close().then(done, done);
+        }
+        count++;
+      })
+      .catch(done);
 
-    queue.on('completed', function(){
-      if(count === 1){
+    queue.on('completed', function() {
+      if (count === 1) {
         queue.client.stream.end();
         queue.client.emit('error', new Error('ECONNRESET'));
       }
     });
 
-    queue.isReady().then(function(){
-      queue.add({ 'foo': 'bar' });
+    queue.isReady().then(function() {
+      queue.add({ foo: 'bar' });
     });
 
-    queue.on('error', function (/*err*/) {
-      if(count === 1) {
-        queue.add({ 'foo': 'bar' });
+    queue.on('error', function(/*err*/) {
+      if (count === 1) {
+        queue.add({ foo: 'bar' });
       }
     });
   });
 
-  it('should not close external connections', function () {
-
+  it('should not close external connections', function() {
     var client = new redis();
     var subscriber = new redis();
-    
+
     var opts = {
-      createClient: function(type){
-        switch(type){
+      createClient: function(type) {
+        switch (type) {
           case 'client':
             return client;
           case 'subscriber':
@@ -91,20 +94,24 @@ describe('connection', function () {
 
     var testQueue = utils.buildQueue('external connections', opts);
 
-    return testQueue.isReady().then(function(){
-      return testQueue.add({'foo': 'bar'});
-    }).then(function(){
-      expect(testQueue.client).to.be.eql(client);
-      expect(testQueue.eclient).to.be.eql(subscriber);
+    return testQueue
+      .isReady()
+      .then(function() {
+        return testQueue.add({ foo: 'bar' });
+      })
+      .then(function() {
+        expect(testQueue.client).to.be.eql(client);
+        expect(testQueue.eclient).to.be.eql(subscriber);
 
-      return testQueue.close();
-    }).then(function(){
-      expect(client.status).to.be.eql('ready');
-      expect(subscriber.status).to.be.eql('ready');
-    });
+        return testQueue.close();
+      })
+      .then(function() {
+        expect(client.status).to.be.eql('ready');
+        expect(subscriber.status).to.be.eql('ready');
+      });
   });
 
-  it('should fail if redis connection fails', function(done){
+  it('should fail if redis connection fails', function(done) {
     queue = utils.buildQueue('connection fail', {
       redis: {
         host: 'localhost',
@@ -112,12 +119,14 @@ describe('connection', function () {
       }
     });
 
-    queue.isReady().then(function(){
-      done(new Error('Did not fail connecting to invalid redis instance'));
-    }, function(err){
-      expect(err.code).to.be.eql('ECONNREFUSED');
-      queue.close().then(done, done);
-    });
+    queue.isReady().then(
+      function() {
+        done(new Error('Did not fail connecting to invalid redis instance'));
+      },
+      function(err) {
+        expect(err.code).to.be.eql('ECONNREFUSED');
+        queue.close().then(done, done);
+      }
+    );
   });
-  
 });

--- a/test/test_events.js
+++ b/test/test_events.js
@@ -1,4 +1,3 @@
-
 /*eslint-env node */
 'use strict';
 
@@ -11,119 +10,125 @@ var expect = require('chai').expect;
 
 var _ = require('lodash');
 
-describe('events', function () {
+describe('events', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     var client = new redis();
-    return client.flushdb().then(function(){
-      queue = utils.buildQueue('test events', {settings: {
-        stalledInterval: 100,
-        lockDuration: 50
-      }});
+    return client.flushdb().then(function() {
+      queue = utils.buildQueue('test events', {
+        settings: {
+          stalledInterval: 100,
+          lockDuration: 50
+        }
+      });
       return queue;
     });
   });
 
-  afterEach(function(){
+  afterEach(function() {
     return queue.close();
   });
 
-  it('should emit waiting when a job has been added', function(done){
-    queue.on('waiting', function(){
+  it('should emit waiting when a job has been added', function(done) {
+    queue.on('waiting', function() {
       done();
     });
 
-    queue.on('registered:waiting', function(){
+    queue.on('registered:waiting', function() {
       queue.add({ foo: 'bar' });
     });
   });
 
-  it('should emit global:waiting when a job has been added', function(done){
-    queue.on('global:waiting', function(){
+  it('should emit global:waiting when a job has been added', function(done) {
+    queue.on('global:waiting', function() {
       done();
     });
 
-    queue.on('registered:global:waiting', function(){
+    queue.on('registered:global:waiting', function() {
       queue.add({ foo: 'bar' });
     });
   });
 
-  it('should emit stalled when a job has been stalled', function (done) {
-    queue.on('completed', function (/*job*/) {
+  it('should emit stalled when a job has been stalled', function(done) {
+    queue.on('completed', function(/*job*/) {
       done(new Error('should not have completed'));
     });
 
-    queue.process(function (/*job*/) {
+    queue.process(function(/*job*/) {
       return Promise.delay(250);
     });
 
     queue.add({ foo: 'bar' });
 
-    var queue2 = utils.buildQueue('test events', {settings: {
-      stalledInterval: 100
-    }});
+    var queue2 = utils.buildQueue('test events', {
+      settings: {
+        stalledInterval: 100
+      }
+    });
 
-    queue2.on('stalled', function (/*job*/) {
+    queue2.on('stalled', function(/*job*/) {
       queue2.close().then(done);
     });
 
-    queue.on('active', function(){
+    queue.on('active', function() {
       queue2.startMoveUnlockedJobsToWait();
       queue.close(true);
     });
   });
 
-  it('should emit global:stalled when a job has been stalled', function (done) {
-    queue.on('completed', function (/*job*/) {
+  it('should emit global:stalled when a job has been stalled', function(done) {
+    queue.on('completed', function(/*job*/) {
       done(new Error('should not have completed'));
     });
 
-    queue.process(function (/*job*/) {
+    queue.process(function(/*job*/) {
       return Promise.delay(250);
     });
 
     queue.add({ foo: 'bar' });
 
-    var queue2 = utils.buildQueue('test events', {settings: {
-      stalledInterval: 100
-    }});
+    var queue2 = utils.buildQueue('test events', {
+      settings: {
+        stalledInterval: 100
+      }
+    });
 
-    queue2.on('global:stalled', function (/*job*/) {
+    queue2.on('global:stalled', function(/*job*/) {
       queue2.close().then(done);
     });
 
-    queue.on('active', function(){
+    queue.on('active', function() {
       queue2.startMoveUnlockedJobsToWait();
       queue.close(true);
     });
   });
 
-  it('emits waiting event when a job is added', function (done) {
+  it('emits waiting event when a job is added', function(done) {
     var queue = utils.buildQueue();
 
-    queue.once('waiting', function (jobId) {
-      Job.fromId(queue, jobId).then(function(job){
+    queue.once('waiting', function(jobId) {
+      Job.fromId(queue, jobId).then(function(job) {
         expect(job.data.foo).to.be.equal('bar');
         queue.close().then(done);
       });
     });
-    queue.once('registered:waiting', function(){
+    queue.once('registered:waiting', function() {
       queue.add({ foo: 'bar' });
     });
   });
 
-  it('emits drained and global:drained event when all jobs have been processed', function (done) {
+  it('emits drained and global:drained event when all jobs have been processed', function(done) {
     var queue = utils.buildQueue('event drained', {
-      settings: {drainDelay: 1}
+      settings: { drainDelay: 1 }
     });
 
-    queue.process(function (job, done) {
+    queue.process(function(job, done) {
       done();
     });
 
-    var drainedCallback = _.after(2, function () {
-      queue.getJobCountByTypes('completed').then(function (completed) {
+    var drainedCallback = _.after(2, function() {
+      queue.getJobCountByTypes('completed').then(function(completed) {
         expect(completed).to.be.equal(2);
         return queue.close().then(done);
       });
@@ -136,62 +141,61 @@ describe('events', function () {
     queue.add({ foo: 'baz' });
   });
 
-  it('should emit an event when a new message is added to the queue', function (done) {
+  it('should emit an event when a new message is added to the queue', function(done) {
     var client = new redis(6379, '127.0.0.1', {});
     client.select(0);
     var queue = new Queue('test pub sub');
-    queue.on('waiting', function(jobId){
+    queue.on('waiting', function(jobId) {
       expect(parseInt(jobId, 10)).to.be.eql(1);
       done();
     });
-    queue.once('registered:waiting', function(){
+    queue.once('registered:waiting', function() {
       queue.add({ test: 'stuff' });
     });
   });
 
-  it('should emit an event when a job becomes active', function (done) {
+  it('should emit an event when a job becomes active', function(done) {
     var queue = utils.buildQueue();
-    queue.process(function (job, jobDone) {
+    queue.process(function(job, jobDone) {
       jobDone();
     });
     queue.add({});
-    queue.once('active', function () {
-      queue.once('completed', function () {
+    queue.once('active', function() {
+      queue.once('completed', function() {
         queue.close().then(done);
       });
     });
   });
 
-  it('should listen to global events', function(done){
+  it('should listen to global events', function(done) {
     var queue1 = utils.buildQueue();
     var queue2 = utils.buildQueue();
-    queue1.process(function (job, jobDone) {
+    queue1.process(function(job, jobDone) {
       jobDone();
     });
 
     var state;
-    queue2.on('global:waiting', function () {
+    queue2.on('global:waiting', function() {
       expect(state).to.be.undefined;
       state = 'waiting';
     });
-    queue2.once('registered:global:waiting', function(){
-      queue2.once('global:active', function () {
+    queue2.once('registered:global:waiting', function() {
+      queue2.once('global:active', function() {
         expect(state).to.be.equal('waiting');
         state = 'active';
       });
     });
-    queue2.once('registered:global:active', function(){
-      queue2.once('global:completed', function () {
+    queue2.once('registered:global:active', function() {
+      queue2.once('global:completed', function() {
         expect(state).to.be.equal('active');
-        queue1.close().then(function(){
+        queue1.close().then(function() {
           queue2.close().then(done);
         });
       });
     });
 
-    queue2.once('registered:global:completed', function(){
+    queue2.once('registered:global:completed', function() {
       queue1.add({});
     });
   });
-
 });

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -8,39 +8,42 @@ var redis = require('ioredis');
 var Promise = require('bluebird');
 var uuid = require('uuid');
 
-
-describe('Job', function(){
+describe('Job', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     var client = new redis();
     return client.flushdb();
   });
 
-  beforeEach(function(){
-    queue = new Queue('test-' + uuid(), {redis: {port: 6379, host: '127.0.0.1'}});
+  beforeEach(function() {
+    queue = new Queue('test-' + uuid(), {
+      redis: { port: 6379, host: '127.0.0.1' }
+    });
   });
 
-  afterEach(function(){
-    this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+  afterEach(function() {
+    this.timeout(
+      queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+    );
     return queue.close();
   });
 
-  describe('.create', function () {
+  describe('.create', function() {
     var job;
     var data;
     var opts;
 
-    beforeEach(function () {
-      data = {foo: 'bar'};
-      opts = {testOpt: 'enabled'};
+    beforeEach(function() {
+      data = { foo: 'bar' };
+      opts = { testOpt: 'enabled' };
 
-      return Job.create(queue, data, opts).then(function(createdJob){
+      return Job.create(queue, data, opts).then(function(createdJob) {
         job = createdJob;
       });
     });
 
-    it('returns a promise for the job', function () {
+    it('returns a promise for the job', function() {
       expect(job).to.have.property('id');
       expect(job).to.have.property('data');
     });
@@ -49,8 +52,8 @@ describe('Job', function(){
       expect(opts).not.to.have.property('jobId');
     });
 
-    it('saves the job in redis', function () {
-      return Job.fromId(queue, job.id).then(function(storedJob){
+    it('saves the job in redis', function() {
+      return Job.fromId(queue, job.id).then(function(storedJob) {
         expect(storedJob).to.have.property('id');
         expect(storedJob).to.have.property('data');
 
@@ -62,14 +65,16 @@ describe('Job', function(){
 
     it('should use the custom jobId if one is provided', function() {
       var customJobId = 'customjob';
-      return Job.create(queue, data, { jobId: customJobId }).then(function(createdJob){
+      return Job.create(queue, data, { jobId: customJobId }).then(function(
+        createdJob
+      ) {
         expect(createdJob.id).to.be.equal(customJobId);
       });
     });
 
     it('should process jobs with custom jobIds', function(done) {
       var customJobId = 'customjob';
-      queue.process(function () {
+      queue.process(function() {
         return Promise.resolve();
       });
 
@@ -83,174 +88,204 @@ describe('Job', function(){
     });
   });
 
-  describe('.update', function(){
-    it('should allow updating job data', function(){
-      return Job.create(queue, {foo: 'bar'}).then(function(job){
-        return job.update({baz: 'qux'}).then(function(){
-          return job;
+  describe('.update', function() {
+    it('should allow updating job data', function() {
+      return Job.create(queue, { foo: 'bar' })
+        .then(function(job) {
+          return job.update({ baz: 'qux' }).then(function() {
+            return job;
+          });
+        })
+        .then(function(job) {
+          return Job.fromId(queue, job.id).then(function(job) {
+            expect(job.data).to.be.eql({ baz: 'qux' });
+          });
         });
-      }).then(function(job){
-        return Job.fromId(queue, job.id).then(function(job){
-          expect(job.data).to.be.eql({baz: 'qux'});
-        });
-      });
     });
   });
 
-  describe('.remove', function () {
-    it('removes the job from redis', function(){
-      return Job.create(queue, {foo: 'bar'})
-        .tap(function(job){
+  describe('.remove', function() {
+    it('removes the job from redis', function() {
+      return Job.create(queue, { foo: 'bar' })
+        .tap(function(job) {
           return job.remove();
         })
-        .then(function(job){
+        .then(function(job) {
           return Job.fromId(queue, job.id);
         })
-        .then(function(storedJob){
+        .then(function(storedJob) {
           expect(storedJob).to.be(null);
         });
     });
 
     it('fails to remove a locked job', function() {
-      return Job.create(queue, 1, {foo: 'bar'}).then(function(job) {
-        return job.takeLock().then(function(lock) {
-          expect(lock).to.be.truthy;
-        }).then(function() {
-          return Job.fromId(queue, job.id).then(function(job){
-            return job.remove();
+      return Job.create(queue, 1, { foo: 'bar' }).then(function(job) {
+        return job
+          .takeLock()
+          .then(function(lock) {
+            expect(lock).to.be.truthy;
+          })
+          .then(function() {
+            return Job.fromId(queue, job.id).then(function(job) {
+              return job.remove();
+            });
+          })
+          .then(function() {
+            throw new Error('Should not be able to remove a locked job');
+          })
+          .catch(function(/*err*/) {
+            // Good!
           });
-        }).then(function() {
-          throw new Error('Should not be able to remove a locked job');
-        }).catch(function(/*err*/) {
-          // Good!
-        });
       });
     });
 
     it('removes any job from active set', function() {
       return queue.add({ foo: 'bar' }).then(function(job) {
         // Simulate a job in active state but not locked
-        return queue.getNextJob().then(function() {
-          return job.isActive().then(function(isActive) {
-            expect(isActive).to.be(true);
-            return job.releaseLock();
-          }).then(function(){
-            return job.remove();
+        return queue
+          .getNextJob()
+          .then(function() {
+            return job
+              .isActive()
+              .then(function(isActive) {
+                expect(isActive).to.be(true);
+                return job.releaseLock();
+              })
+              .then(function() {
+                return job.remove();
+              });
+          })
+          .then(function() {
+            return Job.fromId(queue, job.id);
+          })
+          .then(function(stored) {
+            expect(stored).to.be(null);
+            return job.getState();
+          })
+          .then(function(state) {
+            // This check is a bit of a hack. A job that is not found in any list will return the state
+            // stuck.
+            expect(state).to.equal('stuck');
           });
-        }).then(function() {
-          return Job.fromId(queue, job.id);
-        }).then(function(stored) {
-          expect(stored).to.be(null);
-          return job.getState();
-        }).then(function(state) {
-          // This check is a bit of a hack. A job that is not found in any list will return the state
-          // stuck.
-          expect(state).to.equal('stuck');
-        });
       });
     });
 
-    it('emits removed event', function (cb) {
-      queue.once('removed', function (job) {
+    it('emits removed event', function(cb) {
+      queue.once('removed', function(job) {
         expect(job.data.foo).to.be.equal('bar');
         cb();
       });
-      Job.create(queue, {foo: 'bar'}).then(function(job){
+      Job.create(queue, { foo: 'bar' }).then(function(job) {
         job.remove();
       });
     });
 
     it('a succesful job should be removable', function(done) {
-      queue.process(function () {
+      queue.process(function() {
         return Promise.resolve();
       });
 
       queue.add({ foo: 'bar' });
 
       queue.on('completed', function(job) {
-        job.remove().then(done).catch(done);
+        job
+          .remove()
+          .then(done)
+          .catch(done);
       });
     });
 
     it('a failed job should be removable', function(done) {
-      queue.process(function () {
+      queue.process(function() {
         throw new Error();
       });
 
       queue.add({ foo: 'bar' });
 
       queue.on('failed', function(job) {
-        job.remove().then(done).catch(done);
+        job
+          .remove()
+          .then(done)
+          .catch(done);
       });
     });
   });
 
-  describe('.retry', function () {
-    it('emits waiting event', function (cb) {
-      queue.add({foo: 'bar'});
-      queue.process(function (job, done) {
+  describe('.retry', function() {
+    it('emits waiting event', function(cb) {
+      queue.add({ foo: 'bar' });
+      queue.process(function(job, done) {
         done(new Error('the job failed'));
       });
 
-      queue.once('failed', function (job) {
-        queue.once('global:waiting', function (jobId2) {
-          Job.fromId(queue, jobId2).then(function(job2){
+      queue.once('failed', function(job) {
+        queue.once('global:waiting', function(jobId2) {
+          Job.fromId(queue, jobId2).then(function(job2) {
             expect(job2.data.foo).to.be.equal('bar');
             cb();
           });
         });
-        queue.once('registered:global:waiting', function(){
+        queue.once('registered:global:waiting', function() {
           job.retry();
         });
       });
     });
   });
 
-  describe('Locking', function(){
+  describe('Locking', function() {
     var job;
 
-    beforeEach(function () {
-      return Job.create(queue, {foo: 'bar'}).then(function(createdJob){
+    beforeEach(function() {
+      return Job.create(queue, { foo: 'bar' }).then(function(createdJob) {
         job = createdJob;
       });
     });
 
-    it('can take a lock', function(){
-      return job.takeLock().then(function(lockTaken){
-        expect(lockTaken).to.be.truthy;
-      }).then(function(){
-        return job.releaseLock().then(function(lockReleased){
-          expect(lockReleased).to.not.exist;
-        });
-      });
-    });
-
-    it('take an already taken lock', function(){
-      return job.takeLock().then(function(lockTaken){
-        expect(lockTaken).to.be.truthy;
-      }).then(function(){
-        return job.takeLock().then(function(lockTaken){
+    it('can take a lock', function() {
+      return job
+        .takeLock()
+        .then(function(lockTaken) {
           expect(lockTaken).to.be.truthy;
+        })
+        .then(function() {
+          return job.releaseLock().then(function(lockReleased) {
+            expect(lockReleased).to.not.exist;
+          });
         });
-      });
     });
 
-    it('can release a lock', function(){
-      return job.takeLock().then(function(lockTaken){
-        expect(lockTaken).to.be.truthy;
-      }).then(function(){
-        return job.releaseLock().then(function(lockReleased){
-          expect(lockReleased).to.not.exist;
+    it('take an already taken lock', function() {
+      return job
+        .takeLock()
+        .then(function(lockTaken) {
+          expect(lockTaken).to.be.truthy;
+        })
+        .then(function() {
+          return job.takeLock().then(function(lockTaken) {
+            expect(lockTaken).to.be.truthy;
+          });
         });
-      });
+    });
+
+    it('can release a lock', function() {
+      return job
+        .takeLock()
+        .then(function(lockTaken) {
+          expect(lockTaken).to.be.truthy;
+        })
+        .then(function() {
+          return job.releaseLock().then(function(lockReleased) {
+            expect(lockReleased).to.not.exist;
+          });
+        });
     });
   });
 
-  describe('.progress', function () {
-    it('can set and get progress', function () {
-      return Job.create(queue, {foo: 'bar'}).then(function(job){
-        return job.progress(42).then(function(){
-          return Job.fromId(queue, job.id).then(function(storedJob){
+  describe('.progress', function() {
+    it('can set and get progress', function() {
+      return Job.create(queue, { foo: 'bar' }).then(function(job) {
+        return job.progress(42).then(function() {
+          return Job.fromId(queue, job.id).then(function(storedJob) {
             expect(storedJob.progress()).to.be(42);
           });
         });
@@ -258,149 +293,195 @@ describe('Job', function(){
     });
   });
 
-  describe('.moveToCompleted', function () {
-    it('marks the job as completed', function(){
-      return Job.create(queue, {foo: 'bar'}).then(function(job){
-        return job.isCompleted().then(function(isCompleted){
-          expect(isCompleted).to.be(false);
-        }).then(function(){
-          return job.moveToCompleted('succeeded', true);
-        }).then(function(/*moved*/){
-          return job.isCompleted().then(function(isCompleted){
-            expect(isCompleted).to.be(true);
-            expect(job.returnvalue).to.be('succeeded');
+  describe('.moveToCompleted', function() {
+    it('marks the job as completed', function() {
+      return Job.create(queue, { foo: 'bar' }).then(function(job) {
+        return job
+          .isCompleted()
+          .then(function(isCompleted) {
+            expect(isCompleted).to.be(false);
+          })
+          .then(function() {
+            return job.moveToCompleted('succeeded', true);
+          })
+          .then(function(/*moved*/) {
+            return job.isCompleted().then(function(isCompleted) {
+              expect(isCompleted).to.be(true);
+              expect(job.returnvalue).to.be('succeeded');
+            });
           });
-        });
       });
     });
   });
 
-  describe('.moveToFailed', function () {
-    it('marks the job as failed', function(){
-      return Job.create(queue, {foo: 'bar'}).then(function(job){
-        return job.isFailed().then(function(isFailed){
-          expect(isFailed).to.be(false);
-        }).then(function(){
-          return job.moveToFailed(new Error('test error'), true);
-        }).then(function(){
-          return job.isFailed().then(function(isFailed){
-            expect(isFailed).to.be(true);
-            expect(job.stacktrace).not.be(null);
-            expect(job.stacktrace.length).to.be(1);
+  describe('.moveToFailed', function() {
+    it('marks the job as failed', function() {
+      return Job.create(queue, { foo: 'bar' }).then(function(job) {
+        return job
+          .isFailed()
+          .then(function(isFailed) {
+            expect(isFailed).to.be(false);
+          })
+          .then(function() {
+            return job.moveToFailed(new Error('test error'), true);
+          })
+          .then(function() {
+            return job.isFailed().then(function(isFailed) {
+              expect(isFailed).to.be(true);
+              expect(job.stacktrace).not.be(null);
+              expect(job.stacktrace.length).to.be(1);
+            });
           });
-        });
       });
     });
 
     it('moves the job to wait for retry if attempts are given', function() {
-      return Job.create(queue, {foo: 'bar'}, {attempts: 3}).then(function(job){
-        return job.isFailed().then(function(isFailed){
-          expect(isFailed).to.be(false);
-        }).then(function(){
-          return job.moveToFailed(new Error('test error'), true);
-        }).then(function(){
-          return job.isFailed().then(function(isFailed){
+      return Job.create(queue, { foo: 'bar' }, { attempts: 3 }).then(function(
+        job
+      ) {
+        return job
+          .isFailed()
+          .then(function(isFailed) {
             expect(isFailed).to.be(false);
-            expect(job.stacktrace).not.be(null);
-            expect(job.stacktrace.length).to.be(1);
-            return job.isWaiting().then(function(isWaiting){
-              expect(isWaiting).to.be(true);
+          })
+          .then(function() {
+            return job.moveToFailed(new Error('test error'), true);
+          })
+          .then(function() {
+            return job.isFailed().then(function(isFailed) {
+              expect(isFailed).to.be(false);
+              expect(job.stacktrace).not.be(null);
+              expect(job.stacktrace.length).to.be(1);
+              return job.isWaiting().then(function(isWaiting) {
+                expect(isWaiting).to.be(true);
+              });
             });
           });
-        });
       });
     });
 
     it('marks the job as failed when attempts made equal to attempts given', function() {
-      return Job.create(queue, {foo: 'bar'}, {attempts: 1}).then(function(job){
-        return job.isFailed().then(function(isFailed){
-          expect(isFailed).to.be(false);
-        }).then(function(){
-          return job.moveToFailed(new Error('test error'), true);
-        }).then(function(){
-          return job.isFailed().then(function(isFailed){
-            expect(isFailed).to.be(true);
-            expect(job.stacktrace).not.be(null);
-            expect(job.stacktrace.length).to.be(1);
+      return Job.create(queue, { foo: 'bar' }, { attempts: 1 }).then(function(
+        job
+      ) {
+        return job
+          .isFailed()
+          .then(function(isFailed) {
+            expect(isFailed).to.be(false);
+          })
+          .then(function() {
+            return job.moveToFailed(new Error('test error'), true);
+          })
+          .then(function() {
+            return job.isFailed().then(function(isFailed) {
+              expect(isFailed).to.be(true);
+              expect(job.stacktrace).not.be(null);
+              expect(job.stacktrace.length).to.be(1);
+            });
           });
-        });
       });
     });
 
     it('moves the job to delayed for retry if attempts are given and backoff is non zero', function() {
-      return Job.create(queue, {foo: 'bar'}, {attempts: 3, backoff: 300}).then(function(job){
-        return job.isFailed().then(function(isFailed){
-          expect(isFailed).to.be(false);
-        }).then(function(){
-          return job.moveToFailed(new Error('test error'), true);
-        }).then(function(){
-          return job.isFailed().then(function(isFailed){
+      return Job.create(
+        queue,
+        { foo: 'bar' },
+        { attempts: 3, backoff: 300 }
+      ).then(function(job) {
+        return job
+          .isFailed()
+          .then(function(isFailed) {
             expect(isFailed).to.be(false);
-            expect(job.stacktrace).not.be(null);
-            expect(job.stacktrace.length).to.be(1);
-            return job.isDelayed().then(function(isDelayed){
-              expect(isDelayed).to.be(true);
-            });
-          });
-        });
-      });
-    });
-
-    it('applies stacktrace limit on failure', function(){
-      var stackTraceLimit = 1;
-      return Job.create(queue, {foo: 'bar'}, {stackTraceLimit: stackTraceLimit}).then(function(job){
-        return job.isFailed().then(function(isFailed){
-          expect(isFailed).to.be(false);
-        }).then(function(){
-          return job.moveToFailed(new Error('test error'), true);
-        }).then(function(){
-          return job.moveToFailed(new Error('test error'), true).then(function(){
-            return job.isFailed().then(function(isFailed){
-              expect(isFailed).to.be(true);
+          })
+          .then(function() {
+            return job.moveToFailed(new Error('test error'), true);
+          })
+          .then(function() {
+            return job.isFailed().then(function(isFailed) {
+              expect(isFailed).to.be(false);
               expect(job.stacktrace).not.be(null);
-              expect(job.stacktrace.length).to.be(stackTraceLimit);
+              expect(job.stacktrace.length).to.be(1);
+              return job.isDelayed().then(function(isDelayed) {
+                expect(isDelayed).to.be(true);
+              });
             });
           });
-        });
       });
     });
 
+    it('applies stacktrace limit on failure', function() {
+      var stackTraceLimit = 1;
+      return Job.create(
+        queue,
+        { foo: 'bar' },
+        { stackTraceLimit: stackTraceLimit }
+      ).then(function(job) {
+        return job
+          .isFailed()
+          .then(function(isFailed) {
+            expect(isFailed).to.be(false);
+          })
+          .then(function() {
+            return job.moveToFailed(new Error('test error'), true);
+          })
+          .then(function() {
+            return job
+              .moveToFailed(new Error('test error'), true)
+              .then(function() {
+                return job.isFailed().then(function(isFailed) {
+                  expect(isFailed).to.be(true);
+                  expect(job.stacktrace).not.be(null);
+                  expect(job.stacktrace.length).to.be(stackTraceLimit);
+                });
+              });
+          });
+      });
+    });
   });
 
   describe('.promote', function() {
-
     it('can promote a delayed job to be executed immediately', function() {
-      return Job.create(queue, {foo: 'bar'}, {delay: 1500}).then(function(job){
-        return job.isDelayed().then(function(isDelayed) {
-          expect(isDelayed).to.be(true);
-        }).then(function() {
-          return job.promote();
-        }).then(function() {
-          return job.isDelayed().then(function(isDelayed) {
-            expect(isDelayed).to.be(false);
-            return job.isWaiting().then(function(isWaiting) {
-              expect(isWaiting).to.be(true);
-              return;
+      return Job.create(queue, { foo: 'bar' }, { delay: 1500 }).then(function(
+        job
+      ) {
+        return job
+          .isDelayed()
+          .then(function(isDelayed) {
+            expect(isDelayed).to.be(true);
+          })
+          .then(function() {
+            return job.promote();
+          })
+          .then(function() {
+            return job.isDelayed().then(function(isDelayed) {
+              expect(isDelayed).to.be(false);
+              return job.isWaiting().then(function(isWaiting) {
+                expect(isWaiting).to.be(true);
+                return;
+              });
             });
           });
-        });
       });
     });
 
     it('should not promote a job that is not delayed', function() {
-      return Job.create(queue, {foo: 'bar'}).then(function(job){
-        return job.isDelayed().then(function(isDelayed) {
-          expect(isDelayed).to.be(false);
-        }).then(function() {
-          return job.promote();
-        }).then(function() {
-          throw new Error('Job should not be promoted!');
-        }).catch(function(err) {
-          expect(err).to.be.ok();
-        });
+      return Job.create(queue, { foo: 'bar' }).then(function(job) {
+        return job
+          .isDelayed()
+          .then(function(isDelayed) {
+            expect(isDelayed).to.be(false);
+          })
+          .then(function() {
+            return job.promote();
+          })
+          .then(function() {
+            throw new Error('Job should not be promoted!');
+          })
+          .catch(function(err) {
+            expect(err).to.be.ok();
+          });
       });
     });
-
   });
 
   // TODO:
@@ -411,190 +492,243 @@ describe('Job', function(){
     this.timeout(12000);
 
     var client = new redis();
-    return Job.create(queue, {foo: 'baz'}).then(function(job) {
-      return job.isStuck().then(function(isStuck) {
-        expect(isStuck).to.be(false);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('waiting');
-        return scripts.moveToActive(queue).then(function(){
-          return job.moveToCompleted();
+    return Job.create(queue, { foo: 'baz' }).then(function(job) {
+      return job
+        .isStuck()
+        .then(function(isStuck) {
+          expect(isStuck).to.be(false);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('waiting');
+          return scripts.moveToActive(queue).then(function() {
+            return job.moveToCompleted();
+          });
+        })
+        .then(function() {
+          return job.isCompleted();
+        })
+        .then(function(isCompleted) {
+          expect(isCompleted).to.be(true);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('completed');
+          return client.zrem(queue.toKey('completed'), job.id);
+        })
+        .then(function() {
+          return job.moveToDelayed(Date.now() + 10000, true);
+        })
+        .then(function() {
+          return job.isDelayed();
+        })
+        .then(function(yes) {
+          expect(yes).to.be(true);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('delayed');
+          return client.zrem(queue.toKey('delayed'), job.id);
+        })
+        .then(function() {
+          return job.moveToFailed(new Error('test'), true);
+        })
+        .then(function() {
+          return job.isFailed();
+        })
+        .then(function(isFailed) {
+          expect(isFailed).to.be(true);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('failed');
+          return client.zrem(queue.toKey('failed'), job.id);
+        })
+        .then(function(res) {
+          expect(res).to.be(1);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('stuck');
+          return client.rpop(queue.toKey('wait'));
+        })
+        .then(function() {
+          return client.lpush(queue.toKey('paused'), job.id);
+        })
+        .then(function() {
+          return job.isPaused();
+        })
+        .then(function(isPaused) {
+          expect(isPaused).to.be(true);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('paused');
+          return client.rpop(queue.toKey('paused'));
+        })
+        .then(function() {
+          return client.lpush(queue.toKey('wait'), job.id);
+        })
+        .then(function() {
+          return job.isWaiting();
+        })
+        .then(function(isWaiting) {
+          expect(isWaiting).to.be(true);
+          return job.getState();
+        })
+        .then(function(state) {
+          expect(state).to.be('waiting');
         });
-      }).then(function (){
-        return job.isCompleted();
-      }).then(function (isCompleted) {
-        expect(isCompleted).to.be(true);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('completed');
-        return client.zrem(queue.toKey('completed'), job.id);
-      }).then(function(){
-        return job.moveToDelayed(Date.now() + 10000, true);
-      }).then(function (){
-        return job.isDelayed();
-      }).then(function (yes) {
-        expect(yes).to.be(true);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('delayed');
-        return client.zrem(queue.toKey('delayed'), job.id);
-      }).then(function() {
-        return job.moveToFailed(new Error('test'), true);
-      }).then(function (){
-        return job.isFailed();
-      }).then(function (isFailed) {
-        expect(isFailed).to.be(true);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('failed');
-        return client.zrem(queue.toKey('failed'), job.id);
-      }).then(function(res) {
-        expect(res).to.be(1);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('stuck');
-        return client.rpop(queue.toKey('wait'));
-      }).then(function(){
-        return client.lpush(queue.toKey('paused'), job.id);
-      }).then(function() {
-        return job.isPaused();
-      }).then(function (isPaused) {
-        expect(isPaused).to.be(true);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('paused');
-        return client.rpop(queue.toKey('paused'));
-      }).then(function() {
-        return client.lpush(queue.toKey('wait'), job.id);
-      }).then(function() {
-        return job.isWaiting();
-      }).then(function (isWaiting) {
-        expect(isWaiting).to.be(true);
-        return job.getState();
-      }).then(function(state) {
-        expect(state).to.be('waiting');
-      });
     });
   });
 
   describe('.finished', function() {
-    it('should resolve when the job has been completed', function(done){
-      queue.process(function () {
+    it('should resolve when the job has been completed', function(done) {
+      queue.process(function() {
         return Promise.delay(500);
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return job.finished();
-      }).then(done, done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return job.finished();
+        })
+        .then(done, done);
     });
 
-    it('should resolve when the job has been completed and return object', function(done){
-      queue.process(function (/*job*/) {
+    it('should resolve when the job has been completed and return object', function(done) {
+      queue.process(function(/*job*/) {
         return Promise.delay(500).then(function() {
           return { resultFoo: 'bar' };
         });
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return job.finished();
-      }).then(function(jobResult) {
-        expect(jobResult).to.be.an('object');
-        expect(jobResult.resultFoo).equal('bar');
-        done();
-      });
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return job.finished();
+        })
+        .then(function(jobResult) {
+          expect(jobResult).to.be.an('object');
+          expect(jobResult.resultFoo).equal('bar');
+          done();
+        });
     });
 
-    it('should resolve when the job has been delayed and completed and return object', function(done){
-      queue.process(function (/*job*/) {
+    it('should resolve when the job has been delayed and completed and return object', function(done) {
+      queue.process(function(/*job*/) {
         return Promise.delay(300).then(function() {
           return { resultFoo: 'bar' };
         });
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return Promise.delay(600).then(function() {
-          return job.finished();
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return Promise.delay(600).then(function() {
+            return job.finished();
+          });
+        })
+        .then(function(jobResult) {
+          expect(jobResult).to.be.an('object');
+          expect(jobResult.resultFoo).equal('bar');
+          done();
         });
-      }).then(function(jobResult) {
-        expect(jobResult).to.be.an('object');
-        expect(jobResult.resultFoo).equal('bar');
-        done();
-      });
     });
 
-    it('should resolve when the job has been completed and return string', function(done){
-      queue.process(function (/*job*/) {
+    it('should resolve when the job has been completed and return string', function(done) {
+      queue.process(function(/*job*/) {
         return Promise.delay(500).then(function() {
           return 'a string';
         });
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return Promise.delay(600).then(function() {
-          return job.finished();
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return Promise.delay(600).then(function() {
+            return job.finished();
+          });
+        })
+        .then(function(jobResult) {
+          expect(jobResult).to.be.an('string');
+          expect(jobResult).equal('a string');
+          done();
         });
-      }).then(function(jobResult) {
-        expect(jobResult).to.be.an('string');
-        expect(jobResult).equal('a string');
-        done();
-      });
     });
 
-    it('should resolve when the job has been delayed and completed and return string', function(done){
-      queue.process(function (/*job*/) {
+    it('should resolve when the job has been delayed and completed and return string', function(done) {
+      queue.process(function(/*job*/) {
         return Promise.delay(300).then(function() {
           return 'a string';
         });
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return job.finished();
-      }).then(function(jobResult) {
-        expect(jobResult).to.be.an('string');
-        expect(jobResult).equal('a string');
-        done();
-      });
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return job.finished();
+        })
+        .then(function(jobResult) {
+          expect(jobResult).to.be.an('string');
+          expect(jobResult).equal('a string');
+          done();
+        });
     });
 
-    it('should reject when the job has been failed', function(done){
-      queue.process(function () {
-        return Promise.delay(500).then(function(){
+    it('should reject when the job has been failed', function(done) {
+      queue.process(function() {
+        return Promise.delay(500).then(function() {
           return Promise.reject(Error('test error'));
         });
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return job.finished();
-      }).then(function(){
-        done(Error('should have been rejected'));
-      }, function(err){
-        expect(err.message).equal('test error');
-        done();
-      });
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return job.finished();
+        })
+        .then(
+          function() {
+            done(Error('should have been rejected'));
+          },
+          function(err) {
+            expect(err.message).equal('test error');
+            done();
+          }
+        );
     });
 
-    it('should resolve directly if already processed', function(done){
-      queue.process(function () {
+    it('should resolve directly if already processed', function(done) {
+      queue.process(function() {
         return Promise.resolve();
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return Promise.delay(500).then(function(){
-          return job.finished();
-        });
-      }).then(function(){
-        done();
-      }, done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return Promise.delay(500).then(function() {
+            return job.finished();
+          });
+        })
+        .then(function() {
+          done();
+        }, done);
     });
 
-    it('should reject directly if already processed', function(done){
-      queue.process(function () {
+    it('should reject directly if already processed', function(done) {
+      queue.process(function() {
         return Promise.reject(Error('test error'));
       });
-      queue.add({ foo: 'bar' }).then(function(job){
-        return Promise.delay(500).then(function(){
-          return job.finished();
-        });
-      }).then(function(){
-        done(Error('should have been rejected'));
-      }, function(err){
-        expect(err.message).equal('test error');
-        done();
-      });
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          return Promise.delay(500).then(function() {
+            return job.finished();
+          });
+        })
+        .then(
+          function() {
+            done(Error('should have been rejected'));
+          },
+          function(err) {
+            expect(err.message).equal('test error');
+            done();
+          }
+        );
     });
-
   });
 });

--- a/test/test_pause.js
+++ b/test/test_pause.js
@@ -8,18 +8,19 @@ var Promise = require('bluebird');
 var redis = require('ioredis');
 var utils = require('./utils');
 
-describe('.pause', function () {
-  beforeEach(function () {
+describe('.pause', function() {
+  beforeEach(function() {
     var client = new redis();
     return client.flushdb();
   });
 
-  it('should pause a queue until resumed', function () {
-    var ispaused = false, counter = 2;
+  it('should pause a queue until resumed', function() {
+    var ispaused = false,
+      counter = 2;
 
-    return utils.newQueue().then(function (queue) {
-      var resultPromise = new Promise(function (resolve) {
-        queue.process(function (job, jobDone) {
+    return utils.newQueue().then(function(queue) {
+      var resultPromise = new Promise(function(resolve) {
+        queue.process(function(job, jobDone) {
           expect(ispaused).to.be.eql(false);
           expect(job.data.foo).to.be.equal('paused');
           jobDone();
@@ -30,23 +31,32 @@ describe('.pause', function () {
         });
       });
 
-      return Promise.join(queue.pause().then(function () {
-        ispaused = true;
-        return queue.add({ foo: 'paused' });
-      }).then(function () {
-        return queue.add({ foo: 'paused' });
-      }).then(function () {
-        ispaused = false;
-        return queue.resume();
-      }), resultPromise);
+      return Promise.join(
+        queue
+          .pause()
+          .then(function() {
+            ispaused = true;
+            return queue.add({ foo: 'paused' });
+          })
+          .then(function() {
+            return queue.add({ foo: 'paused' });
+          })
+          .then(function() {
+            ispaused = false;
+            return queue.resume();
+          }),
+        resultPromise
+      );
     });
   });
 
-  it('should be able to pause a running queue and emit relevant events', function (done) {
-    var ispaused = false, isresumed = true, first = true;
+  it('should be able to pause a running queue and emit relevant events', function(done) {
+    var ispaused = false,
+      isresumed = true,
+      first = true;
 
-    utils.newQueue().then(function (queue) {
-      queue.process(function (job, jobDone) {
+    utils.newQueue().then(function(queue) {
+      queue.process(function(job, jobDone) {
         expect(ispaused).to.be.eql(false);
         expect(job.data.foo).to.be.equal('paused');
         jobDone();
@@ -64,57 +74,65 @@ describe('.pause', function () {
       queue.add({ foo: 'paused' });
       queue.add({ foo: 'paused' });
 
-      queue.on('paused', function () {
+      queue.on('paused', function() {
         ispaused = false;
-        queue.resume().catch(function (/*err*/) {
+        queue.resume().catch(function(/*err*/) {
           // Swallow error.
         });
       });
 
-      queue.on('resumed', function () {
+      queue.on('resumed', function() {
         isresumed = true;
       });
     });
   });
 
-  it('should pause the queue locally', function (done) {
+  it('should pause the queue locally', function(done) {
     var counter = 2;
 
     var queue = utils.buildQueue();
 
-    queue.pause(true /* Local */).tap(function () {
-      // Add the worker after the queue is in paused mode since the normal behavior is to pause
-      // it after the current lock expires. This way, we can ensure there isn't a lock already
-      // to test that pausing behavior works.
-      queue.process(function (job, jobDone) {
-        expect(queue.paused).not.to.be.ok;
-        jobDone();
-        counter--;
-        if (counter === 0) {
-          queue.close().then(done);
-        }
-      }).catch(done);
-    }).then(function () {
-      return queue.add({ foo: 'paused' });
-    }).then(function () {
-      return queue.add({ foo: 'paused' });
-    }).then(function () {
-      expect(counter).to.be.eql(2);
-      expect(queue.paused).to.be.ok; // Parameter should exist.
-      return queue.resume(true /* Local */);
-    }).catch(done);
+    queue
+      .pause(true /* Local */)
+      .tap(function() {
+        // Add the worker after the queue is in paused mode since the normal behavior is to pause
+        // it after the current lock expires. This way, we can ensure there isn't a lock already
+        // to test that pausing behavior works.
+        queue
+          .process(function(job, jobDone) {
+            expect(queue.paused).not.to.be.ok;
+            jobDone();
+            counter--;
+            if (counter === 0) {
+              queue.close().then(done);
+            }
+          })
+          .catch(done);
+      })
+      .then(function() {
+        return queue.add({ foo: 'paused' });
+      })
+      .then(function() {
+        return queue.add({ foo: 'paused' });
+      })
+      .then(function() {
+        expect(counter).to.be.eql(2);
+        expect(queue.paused).to.be.ok; // Parameter should exist.
+        return queue.resume(true /* Local */);
+      })
+      .catch(done);
   });
 
-  it('should wait until active jobs are finished before resolving pause', function (done) {
+  it('should wait until active jobs are finished before resolving pause', function(done) {
     var queue = utils.buildQueue();
-    var startProcessing = new Promise(function (resolve) {
-      queue.process(function (/*job*/) {
+    var startProcessing = new Promise(function(resolve) {
+      queue.process(function(/*job*/) {
         resolve();
         return Promise.delay(200);
       });
     });
 
-    queue.isReady().then(function () {
+    queue.isReady().then(function() {
       var jobs = [];
       for (var i = 0; i < 10; i++) {
         jobs.push(queue.add(i));
@@ -123,53 +141,68 @@ describe('.pause', function () {
       // Add start processing so that we can test that pause waits for this job to be completed.
       //
       jobs.push(startProcessing);
-      Promise.all(jobs).then(function () {
-        return queue.pause(true).then(function () {
-          var active = queue.getJobCountByTypes(['active']).then(function (count) {
-            expect(count).to.be.eql(0);
-            expect(queue.paused).to.be.ok;
-            return null;
-          });
+      Promise.all(jobs)
+        .then(function() {
+          return queue
+            .pause(true)
+            .then(function() {
+              var active = queue
+                .getJobCountByTypes(['active'])
+                .then(function(count) {
+                  expect(count).to.be.eql(0);
+                  expect(queue.paused).to.be.ok;
+                  return null;
+                });
 
-          // One job from the 10 posted above will be processed, so we expect 9 jobs pending
-          var paused = queue.getJobCountByTypes(['delayed', 'wait']).then(function (count) {
-            expect(count).to.be.eql(9);
-            return null;
-          });
-          return Promise.all([active, paused]);
-        }).then(function () {
-          return queue.add({});
-        }).then(function () {
-          var active = queue.getJobCountByTypes(['active']).then(function (count) {
-            expect(count).to.be.eql(0);
-            return null;
-          });
+              // One job from the 10 posted above will be processed, so we expect 9 jobs pending
+              var paused = queue
+                .getJobCountByTypes(['delayed', 'wait'])
+                .then(function(count) {
+                  expect(count).to.be.eql(9);
+                  return null;
+                });
+              return Promise.all([active, paused]);
+            })
+            .then(function() {
+              return queue.add({});
+            })
+            .then(function() {
+              var active = queue
+                .getJobCountByTypes(['active'])
+                .then(function(count) {
+                  expect(count).to.be.eql(0);
+                  return null;
+                });
 
-          var paused = queue.getJobCountByTypes(['paused', 'wait', 'delayed']).then(function (count) {
-            expect(count).to.be.eql(10);
-            return null;
-          });
+              var paused = queue
+                .getJobCountByTypes(['paused', 'wait', 'delayed'])
+                .then(function(count) {
+                  expect(count).to.be.eql(10);
+                  return null;
+                });
 
-          return Promise.all([active, paused]);
-        }).then(function () {
-          return queue.close().then(done, done);
-        });
-      }).catch(done);
+              return Promise.all([active, paused]);
+            })
+            .then(function() {
+              return queue.close().then(done, done);
+            });
+        })
+        .catch(done);
     });
   });
 
-  it('should pause the queue locally when more than one worker is active', function () {
+  it('should pause the queue locally when more than one worker is active', function() {
     var queue1 = utils.buildQueue('pause-queue');
-    var queue1IsProcessing = new Promise(function (resolve) {
-      queue1.process(function (job, jobDone) {
+    var queue1IsProcessing = new Promise(function(resolve) {
+      queue1.process(function(job, jobDone) {
         resolve();
         setTimeout(jobDone, 200);
       });
     });
 
     var queue2 = utils.buildQueue('pause-queue');
-    var queue2IsProcessing = new Promise(function (resolve) {
-      queue2.process(function (job, jobDone) {
+    var queue2IsProcessing = new Promise(function(resolve) {
+      queue2.process(function(job, jobDone) {
         resolve();
         setTimeout(jobDone, 200);
       });
@@ -180,57 +213,74 @@ describe('.pause', function () {
     queue1.add(3);
     queue1.add(4);
 
-    return Promise.all([queue1IsProcessing, queue2IsProcessing]).then(function () {
-      return Promise.all([queue1.pause(true /* local */), queue2.pause(true /* local */)]).then(function () {
+    return Promise.all([queue1IsProcessing, queue2IsProcessing]).then(
+      function() {
+        return Promise.all([
+          queue1.pause(true /* local */),
+          queue2.pause(true /* local */)
+        ]).then(function() {
+          var active = queue1
+            .getJobCountByTypes(['active'])
+            .then(function(count) {
+              expect(count).to.be.eql(0);
+            });
 
-        var active = queue1.getJobCountByTypes(['active']).then(function (count) {
-          expect(count).to.be.eql(0);
+          var pending = queue1
+            .getJobCountByTypes(['wait'])
+            .then(function(count) {
+              expect(count).to.be.eql(2);
+            });
+
+          var completed = queue1
+            .getJobCountByTypes(['completed'])
+            .then(function(count) {
+              expect(count).to.be.eql(2);
+            });
+
+          return Promise.all([active, pending, completed]);
         });
-
-        var pending = queue1.getJobCountByTypes(['wait']).then(function (count) {
-          expect(count).to.be.eql(2);
-        });
-
-        var completed = queue1.getJobCountByTypes(['completed']).then(function (count) {
-          expect(count).to.be.eql(2);
-        });
-
-        return Promise.all([active, pending, completed]);
-      });
-    });
+      }
+    );
   });
 
-  it('should wait for blocking job retrieval to complete before pausing locally', function () {
+  it('should wait for blocking job retrieval to complete before pausing locally', function() {
     var queue = utils.buildQueue();
 
-    var startsProcessing = new Promise(function (resolve) {
-      queue.process(function (/*job*/) {
+    var startsProcessing = new Promise(function(resolve) {
+      queue.process(function(/*job*/) {
         resolve();
         return Promise.delay(200);
       });
     });
 
-    return queue.add(1).then(function () {
-      return startsProcessing;
-    }).then(function () {
-      return queue.pause(true);
-    }).then(function () {
-      return queue.add(2);
-    }).then(function () {
-      var active = queue.getJobCountByTypes(['active']).then(function (count) {
-        expect(count).to.be.eql(0);
-      });
+    return queue
+      .add(1)
+      .then(function() {
+        return startsProcessing;
+      })
+      .then(function() {
+        return queue.pause(true);
+      })
+      .then(function() {
+        return queue.add(2);
+      })
+      .then(function() {
+        var active = queue.getJobCountByTypes(['active']).then(function(count) {
+          expect(count).to.be.eql(0);
+        });
 
-      var pending = queue.getJobCountByTypes(['wait']).then(function (count) {
-        expect(count).to.be.eql(1);
-      });
+        var pending = queue.getJobCountByTypes(['wait']).then(function(count) {
+          expect(count).to.be.eql(1);
+        });
 
-      var completed = queue.getJobCountByTypes(['completed']).then(function (count) {
-        expect(count).to.be.eql(1);
-      });
+        var completed = queue
+          .getJobCountByTypes(['completed'])
+          .then(function(count) {
+            expect(count).to.be.eql(1);
+          });
 
-      return Promise.all([active, pending, completed]);
-    });
+        return Promise.all([active, pending, completed]);
+      });
   });
 
   it('pauses fast when queue is drained', function(done) {
@@ -241,8 +291,8 @@ describe('.pause', function () {
       Promise.resolve();
     });
 
-    queue.on('drained', function(){
-      Promise.delay(500).then(function(){
+    queue.on('drained', function() {
+      Promise.delay(500).then(function() {
         var start = new Date().getTime();
         return queue.pause(true).finally(function() {
           var finish = new Date().getTime();
@@ -252,5 +302,4 @@ describe('.pause', function () {
       });
     });
   });
-
 });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -10,7 +10,7 @@ var _ = require('lodash');
 var uuid = require('uuid');
 var utils = require('./utils');
 
-Promise.config({'warnings': true});
+Promise.config({ warnings: true });
 
 Promise.config({
   // Enable warnings.
@@ -21,61 +21,63 @@ Promise.config({
   cancellation: true
 });
 
-describe('Queue', function () {
+describe('Queue', function() {
   var sandbox = sinon.sandbox.create();
 
-  beforeEach(function () {
+  beforeEach(function() {
     var client = new redis();
     return client.flushdb();
   });
 
-  afterEach(function () {
+  afterEach(function() {
     sandbox.restore();
   });
 
-  describe('.close', function () {
+  describe('.close', function() {
     var testQueue;
-    beforeEach(function () {
-      return utils.newQueue('test').then(function (queue) {
+    beforeEach(function() {
+      return utils.newQueue('test').then(function(queue) {
         testQueue = queue;
       });
     });
 
-    it('should call end on the client', function (done) {
-      testQueue.client.once('end', function () {
+    it('should call end on the client', function(done) {
+      testQueue.client.once('end', function() {
         done();
       });
       testQueue.close();
     });
 
-    it('should call end on the event subscriber client', function (done) {
-      testQueue.eclient.once('end', function () {
+    it('should call end on the event subscriber client', function(done) {
+      testQueue.eclient.once('end', function() {
         done();
       });
       testQueue.close();
     });
 
-    it('should resolve the promise when each client has disconnected', function () {
-      function checkStatus(status){
-        return status === 'ready' || status === 'connecting' || status === 'connect';
+    it('should resolve the promise when each client has disconnected', function() {
+      function checkStatus(status) {
+        return (
+          status === 'ready' || status === 'connecting' || status === 'connect'
+        );
       }
       expect(testQueue.client.status).to.satisfy(checkStatus);
       expect(testQueue.eclient.status).to.satisfy(checkStatus);
 
-      return testQueue.close().then(function () {
+      return testQueue.close().then(function() {
         expect(testQueue.client.status).to.be.eql('end');
         expect(testQueue.eclient.status).to.be.eql('end');
       });
     });
 
-    it('should return a promise', function () {
-      var closePromise = testQueue.close().then(function () {
+    it('should return a promise', function() {
+      var closePromise = testQueue.close().then(function() {
         expect(closePromise).to.be.instanceof(Promise);
       });
       return closePromise;
     });
 
-    it('should close if the job expires after the lockRenewTime', function (done) {
+    it('should close if the job expires after the lockRenewTime', function(done) {
       this.timeout(testQueue.settings.stalledInterval * 2, {
         settings: {
           lockDuration: 15,
@@ -83,43 +85,43 @@ describe('Queue', function () {
         }
       });
 
-      testQueue.process(function () {
+      testQueue.process(function() {
         return Promise.delay(100);
       });
 
-      testQueue.on('completed', function () {
+      testQueue.on('completed', function() {
         testQueue.close().then(done);
       });
       testQueue.add({ foo: 'bar' });
     });
 
-    describe('should be callable from within', function () {
-      it('a job handler that takes a callback', function (done) {
+    describe('should be callable from within', function() {
+      it('a job handler that takes a callback', function(done) {
         this.timeout(12000); // Close can be a slow operation
 
-        testQueue.process(function (job, jobDone) {
+        testQueue.process(function(job, jobDone) {
           expect(job.data.foo).to.be.eql('bar');
           jobDone();
           testQueue.close().then(done);
         });
 
-        testQueue.add({ foo: 'bar' }).then(function (job) {
+        testQueue.add({ foo: 'bar' }).then(function(job) {
           expect(job.id).to.be.ok;
           expect(job.data.foo).to.be.eql('bar');
         });
       });
 
-      it('a job handler that returns a promise', function (done) {
-        testQueue.process(function (job) {
+      it('a job handler that returns a promise', function(done) {
+        testQueue.process(function(job) {
           expect(job.data.foo).to.be.eql('bar');
           return Promise.resolve();
         });
 
-        testQueue.on('completed', function () {
+        testQueue.on('completed', function() {
           testQueue.close().then(done);
         });
 
-        testQueue.add({ foo: 'bar' }).then(function (job) {
+        testQueue.add({ foo: 'bar' }).then(function(job) {
           expect(job.id).to.be.ok;
           expect(job.data.foo).to.be.eql('bar');
         });
@@ -127,8 +129,8 @@ describe('Queue', function () {
     });
   });
 
-  describe('instantiation', function () {
-    it('should create a queue with standard redis opts', function (done) {
+  describe('instantiation', function() {
+    it('should create a queue with standard redis opts', function(done) {
       var queue = new Queue('standard');
 
       expect(queue.client.options.host).to.be.eql('127.0.0.1');
@@ -143,7 +145,7 @@ describe('Queue', function () {
       queue.close().then(done, done);
     });
 
-    it('should create a queue with a redis connection string', function () {
+    it('should create a queue with a redis connection string', function() {
       var queue = new Queue('connstring', 'redis://123.4.5.67:1234/2');
 
       expect(queue.client.options.host).to.be.eql('123.4.5.67');
@@ -155,12 +157,12 @@ describe('Queue', function () {
       expect(queue.client.options.db).to.be.eql(2);
       expect(queue.eclient.options.db).to.be.eql(2);
 
-      queue.close().catch(function(/*err*/){
+      queue.close().catch(function(/*err*/) {
         // Swallow error.
       });
     });
 
-    it('should create a queue with only a hostname', function () {
+    it('should create a queue with only a hostname', function() {
       var queue = new Queue('connstring', 'redis://127.2.3.4');
 
       expect(queue.client.options.host).to.be.eql('127.2.3.4');
@@ -172,12 +174,12 @@ describe('Queue', function () {
       expect(queue.client.condition.select).to.be.eql(0);
       expect(queue.eclient.condition.select).to.be.eql(0);
 
-      queue.close().catch(function(/*err*/){
+      queue.close().catch(function(/*err*/) {
         // Swallow error.
       });
     });
 
-    it('should create a queue with connection string and password', function () {
+    it('should create a queue with connection string and password', function() {
       var queue = new Queue('connstring', 'redis://:123@127.2.3.4:6379');
 
       expect(queue.client.options.host).to.be.eql('127.2.3.4');
@@ -192,12 +194,12 @@ describe('Queue', function () {
       expect(queue.client.options.password).to.be.eql('123');
       expect(queue.eclient.options.password).to.be.eql('123');
 
-      queue.close().catch(function(/*err*/){
+      queue.close().catch(function(/*err*/) {
         // Swallow error.
       });
     });
 
-    it('creates a queue using the supplied redis DB', function (done) {
+    it('creates a queue using the supplied redis DB', function(done) {
       var queue = new Queue('custom', { redis: { DB: 1 } });
 
       expect(queue.client.options.host).to.be.eql('127.0.0.1');
@@ -212,7 +214,7 @@ describe('Queue', function () {
       queue.close().then(done, done);
     });
 
-    it('creates a queue using the supplied redis host', function (done) {
+    it('creates a queue using the supplied redis host', function(done) {
       var queue = new Queue('custom', { redis: { host: 'localhost' } });
 
       expect(queue.client.options.host).to.be.eql('localhost');
@@ -224,63 +226,74 @@ describe('Queue', function () {
       queue.close().then(done, done);
     });
 
-    it('creates a queue with dots in its name', function () {
+    it('creates a queue with dots in its name', function() {
       var queue = new Queue('using. dots. in.name.');
 
-      return queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).then(function () {
-        queue.process(function (job, jobDone) {
-          expect(job.data.foo).to.be.equal('bar');
-          jobDone();
+      return queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .then(function() {
+          queue.process(function(job, jobDone) {
+            expect(job.data.foo).to.be.equal('bar');
+            jobDone();
+          });
+          return null;
+        })
+        .then(function() {
+          return queue.close();
         });
-        return null;
-      }).then(function () {
-        return queue.close();
-      });
     });
 
-    it('creates a queue accepting port as a string', function () {
+    it('creates a queue accepting port as a string', function() {
       var queue = new Queue('foobar', '6379', 'localhost');
 
-      return queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).then(function () {
-        queue.process(function (job, jobDone) {
-          expect(job.data.foo).to.be.equal('bar');
-          jobDone();
+      return queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .then(function() {
+          queue.process(function(job, jobDone) {
+            expect(job.data.foo).to.be.equal('bar');
+            jobDone();
+          });
+          return null;
+        })
+        .then(function() {
+          return queue.close();
         });
-        return null;
-      }).then(function () {
-        return queue.close();
-      });
     });
 
-    it('should create a queue with a prefix option', function () {
+    it('should create a queue with a prefix option', function() {
       var queue = new Queue('q', 'redis://127.0.0.1', { keyPrefix: 'myQ' });
 
-      return queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-        var client = new redis();
-        return client.hgetall('myQ:q:' + job.id).then(function(result){
-          expect(result).to.not.be.null;
+      return queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+          var client = new redis();
+          return client.hgetall('myQ:q:' + job.id).then(function(result) {
+            expect(result).to.not.be.null;
+          });
+        })
+        .then(function() {
+          return queue.close();
         });
-      }).then(function () {
-        return queue.close();
-      });
     });
 
-    it('should allow reuse redis connections', function(done){
+    it('should allow reuse redis connections', function(done) {
       var client, subscriber;
       client = new redis();
       subscriber = new redis();
 
       var opts = {
-        createClient: function(type, opts){
-          switch(type){
+        createClient: function(type, opts) {
+          switch (type) {
             case 'client':
               return client;
             case 'subscriber':
@@ -299,41 +312,44 @@ describe('Queue', function () {
       expect(queueQux.client).to.be.equal(client);
       expect(queueQux.eclient).to.be.equal(subscriber);
 
-      queueFoo.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).then(function(){
-        return queueQux.add({ qux: 'baz' }).then(function(job){
+      queueFoo
+        .add({ foo: 'bar' })
+        .then(function(job) {
           expect(job.id).to.be.ok;
-          expect(job.data.qux).to.be.eql('baz');
-          var completed = 0;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .then(function() {
+          return queueQux.add({ qux: 'baz' }).then(function(job) {
+            expect(job.id).to.be.ok;
+            expect(job.data.qux).to.be.eql('baz');
+            var completed = 0;
 
-          queueFoo.process(function(job, jobDone){
-            jobDone();
-          });
+            queueFoo.process(function(job, jobDone) {
+              jobDone();
+            });
 
-          queueQux.process(function(job, jobDone){
-            jobDone();
-          });
+            queueQux.process(function(job, jobDone) {
+              jobDone();
+            });
 
-          queueFoo.on('completed', function(){
-            completed++;
-            if(completed == 2){
-              done();
-            }
-          });
+            queueFoo.on('completed', function() {
+              completed++;
+              if (completed == 2) {
+                done();
+              }
+            });
 
-          queueQux.on('completed', function(){
-            completed++;
-            if(completed == 2){
-              done();
-            }
+            queueQux.on('completed', function() {
+              completed++;
+              if (completed == 2) {
+                done();
+              }
+            });
           });
-        });
-      }, done);
+        }, done);
     });
 
-    it('creates a queue with default job options', function (done) {
+    it('creates a queue with default job options', function(done) {
       var defaultJobOptions = { removeOnComplete: true };
       var queue = new Queue('custom', { defaultJobOptions: defaultJobOptions });
 
@@ -343,147 +359,193 @@ describe('Queue', function () {
     });
   });
 
-  describe(' a worker', function () {
+  describe(' a worker', function() {
     var queue;
 
-    beforeEach(function () {
+    beforeEach(function() {
       var client = new redis();
-      return client.flushdb().then(function () {
-        return utils.newQueue();
-      }).then(function (_queue) {
-        queue = _queue;
-      });
+      return client
+        .flushdb()
+        .then(function() {
+          return utils.newQueue();
+        })
+        .then(function(_queue) {
+          queue = _queue;
+        });
     });
 
-    afterEach(function () {
-      this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+    afterEach(function() {
+      this.timeout(
+        queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+      );
       return utils.cleanupQueues();
     });
 
-    it('should process a job', function (done) {
-      queue.process(function (job, jobDone) {
-        expect(job.data.foo).to.be.equal('bar');
-        jobDone();
-        done();
-      }).catch(done);
-
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }, done);
-    });
-
-    it('should remove job after completed if removeOnComplete', function (done) {
-      queue.process(function (job, jobDone) {
-        expect(job.data.foo).to.be.equal('bar');
-        jobDone();
-      }).catch(done);
-
-      queue.add({ foo: 'bar' }, {removeOnComplete: true}).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }, done);
-
-      queue.on('completed', function(job){
-        queue.getJob(job.id).then(function(job){
-          expect(job).to.be.equal(null);
-        }).then(function(){
-          queue.getJobCounts().then(function(counts){
-            expect(counts.completed).to.be.equal(0);
-            done();
-          });
-        });
-      });
-    });
-
-    it('should remove a job after completed if the default job options specify removeOnComplete', function (done) {
-      utils.newQueue('test-' + uuid(), {
-        defaultJobOptions: {
-          removeOnComplete: true,
-        }
-      }).then(function (myQueue) {
-        myQueue.process(function (job, jobDone) {
+    it('should process a job', function(done) {
+      queue
+        .process(function(job, jobDone) {
           expect(job.data.foo).to.be.equal('bar');
           jobDone();
-        }).catch(done);
+          done();
+        })
+        .catch(done);
 
-        myQueue.add({ foo: 'bar' }).then(function (job) {
-          expect(job.id).to.be.ok;
-          expect(job.data.foo).to.be.eql('bar');
-        }, done).catch(done);
-
-        myQueue.on('completed', function(job){
-          myQueue.getJob(job.id).then(function(job){
-            expect(job).to.be.equal(null);
-          }).then(function(){
-            return myQueue.getJobCounts();
-          }).then(function(counts){
-            expect(counts.completed).to.be.equal(0);
-
-            return utils.cleanupQueues();
-          }).then(done).catch(done);
-        });
-      }).catch(done);
+      queue.add({ foo: 'bar' }).then(function(job) {
+        expect(job.id).to.be.ok;
+        expect(job.data.foo).to.be.eql('bar');
+      }, done);
     });
 
-    it('should remove job after failed if removeOnFail', function (done) {
-      queue.process(function (job) {
-        expect(job.data.foo).to.be.equal('bar');
-        throw Error('error');
-      }).catch(done);
+    it('should remove job after completed if removeOnComplete', function(done) {
+      queue
+        .process(function(job, jobDone) {
+          expect(job.data.foo).to.be.equal('bar');
+          jobDone();
+        })
+        .catch(done);
 
-      queue.add({ foo: 'bar' }, {removeOnFail: true}).then(function (job) {
+      queue.add({ foo: 'bar' }, { removeOnComplete: true }).then(function(job) {
         expect(job.id).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
       }, done);
 
-      queue.on('failed', function(jobId){
-        queue.getJob(jobId).then(function(job){
-          expect(job).to.be.equal(null);
-        }).then(function(){
-          queue.getJobCounts().then(function(counts){
-            expect(counts.failed).to.be.equal(0);
-            done();
+      queue.on('completed', function(job) {
+        queue
+          .getJob(job.id)
+          .then(function(job) {
+            expect(job).to.be.equal(null);
+          })
+          .then(function() {
+            queue.getJobCounts().then(function(counts) {
+              expect(counts.completed).to.be.equal(0);
+              done();
+            });
           });
-        });
       });
     });
 
-    it('should remove a job after fail if the default job options specify removeOnFail', function (done) {
-      utils.newQueue('test-' + uuid(), {
-        defaultJobOptions: {
-          removeOnFail: true,
-        }
-      }).then(function (myQueue) {
-        myQueue.process(function (job) {
-          expect(job.data.foo).to.be.equal('bar');
-          throw Error('error');
-        }).catch(done);
+    it('should remove a job after completed if the default job options specify removeOnComplete', function(done) {
+      utils
+        .newQueue('test-' + uuid(), {
+          defaultJobOptions: {
+            removeOnComplete: true
+          }
+        })
+        .then(function(myQueue) {
+          myQueue
+            .process(function(job, jobDone) {
+              expect(job.data.foo).to.be.equal('bar');
+              jobDone();
+            })
+            .catch(done);
 
-        myQueue.add({ foo: 'bar' }).then(function (job) {
-          expect(job.id).to.be.ok;
-          expect(job.data.foo).to.be.eql('bar');
-        }, done).catch(done);
+          myQueue
+            .add({ foo: 'bar' })
+            .then(function(job) {
+              expect(job.id).to.be.ok;
+              expect(job.data.foo).to.be.eql('bar');
+            }, done)
+            .catch(done);
 
-        myQueue.on('failed', function(jobId){
-          myQueue.getJob(jobId).then(function(job){
-            expect(job).to.be.equal(null);
-          }).then(function(){
-            return myQueue.getJobCounts();
-          }).then(function(counts){
-            expect(counts.completed).to.be.equal(0);
+          myQueue.on('completed', function(job) {
+            myQueue
+              .getJob(job.id)
+              .then(function(job) {
+                expect(job).to.be.equal(null);
+              })
+              .then(function() {
+                return myQueue.getJobCounts();
+              })
+              .then(function(counts) {
+                expect(counts.completed).to.be.equal(0);
 
-            return utils.cleanupQueues();
-          }).then(done).catch(done);
-        });
-      }).catch(done);
+                return utils.cleanupQueues();
+              })
+              .then(done)
+              .catch(done);
+          });
+        })
+        .catch(done);
     });
 
-    it('process a lifo queue', function (done) {
+    it('should remove job after failed if removeOnFail', function(done) {
+      queue
+        .process(function(job) {
+          expect(job.data.foo).to.be.equal('bar');
+          throw Error('error');
+        })
+        .catch(done);
+
+      queue.add({ foo: 'bar' }, { removeOnFail: true }).then(function(job) {
+        expect(job.id).to.be.ok;
+        expect(job.data.foo).to.be.eql('bar');
+      }, done);
+
+      queue.on('failed', function(jobId) {
+        queue
+          .getJob(jobId)
+          .then(function(job) {
+            expect(job).to.be.equal(null);
+          })
+          .then(function() {
+            queue.getJobCounts().then(function(counts) {
+              expect(counts.failed).to.be.equal(0);
+              done();
+            });
+          });
+      });
+    });
+
+    it('should remove a job after fail if the default job options specify removeOnFail', function(done) {
+      utils
+        .newQueue('test-' + uuid(), {
+          defaultJobOptions: {
+            removeOnFail: true
+          }
+        })
+        .then(function(myQueue) {
+          myQueue
+            .process(function(job) {
+              expect(job.data.foo).to.be.equal('bar');
+              throw Error('error');
+            })
+            .catch(done);
+
+          myQueue
+            .add({ foo: 'bar' })
+            .then(function(job) {
+              expect(job.id).to.be.ok;
+              expect(job.data.foo).to.be.eql('bar');
+            }, done)
+            .catch(done);
+
+          myQueue.on('failed', function(jobId) {
+            myQueue
+              .getJob(jobId)
+              .then(function(job) {
+                expect(job).to.be.equal(null);
+              })
+              .then(function() {
+                return myQueue.getJobCounts();
+              })
+              .then(function(counts) {
+                expect(counts.completed).to.be.equal(0);
+
+                return utils.cleanupQueues();
+              })
+              .then(done)
+              .catch(done);
+          });
+        })
+        .catch(done);
+    });
+
+    it('process a lifo queue', function(done) {
       this.timeout(3000);
-      var currentValue = 0, first = true;
-      utils.newQueue('test lifo').then(function (queue2) {
-        queue2.process(function (job, jobDone) {
+      var currentValue = 0,
+        first = true;
+      utils.newQueue('test lifo').then(function(queue2) {
+        queue2.process(function(job, jobDone) {
           // Catching the job before the pause
           expect(job.data.count).to.be.equal(currentValue--);
           jobDone();
@@ -494,24 +556,24 @@ describe('Queue', function () {
           }
         });
 
-        queue2.pause().then(function () {
+        queue2.pause().then(function() {
           // Add a series of jobs in a predictable order
           var jobs = [
-            { 'count': ++currentValue },
-            { 'count': ++currentValue },
-            { 'count': ++currentValue },
-            { 'count': ++currentValue }
+            { count: ++currentValue },
+            { count: ++currentValue },
+            { count: ++currentValue },
+            { count: ++currentValue }
           ];
-          return Promise.each(jobs, function(jobData){
-            return queue2.add(jobData, { 'lifo': true });
-          }).then(function(){
+          return Promise.each(jobs, function(jobData) {
+            return queue2.add(jobData, { lifo: true });
+          }).then(function() {
             queue2.resume();
           });
         });
       });
     });
 
-    it('should processes jobs by priority', function(done){
+    it('should processes jobs by priority', function(done) {
       var normalPriority = [],
         mediumPriority = [],
         highPriority = [];
@@ -520,44 +582,45 @@ describe('Queue', function () {
       // this is done to maitain a deterministic output.
       var numJobsPerPriority = 6;
 
-      for(var i = 0; i < numJobsPerPriority; i++){
-        normalPriority.push(queue.add({p: 2}, {priority: 2}));
-        mediumPriority.push(queue.add({p: 3}, {priority: 3}));
-        highPriority.push(queue.add({p: 1}, {priority: 1}));
+      for (var i = 0; i < numJobsPerPriority; i++) {
+        normalPriority.push(queue.add({ p: 2 }, { priority: 2 }));
+        mediumPriority.push(queue.add({ p: 3 }, { priority: 3 }));
+        highPriority.push(queue.add({ p: 1 }, { priority: 1 }));
       }
 
       // wait for all jobs to enter the queue and then start processing
-      Promise
-        .all(normalPriority, mediumPriority, highPriority)
-        .then(function(){
+      Promise.all(normalPriority, mediumPriority, highPriority).then(
+        function() {
           var currentPriority = 1;
           var counter = 0;
           var total = 0;
 
-          queue.process(function(job, jobDone){
+          queue.process(function(job, jobDone) {
             expect(job.id).to.be.ok;
             expect(job.data.p).to.be.eql(currentPriority);
             jobDone();
 
-            total ++;
-            if(++counter === numJobsPerPriority){
+            total++;
+            if (++counter === numJobsPerPriority) {
               currentPriority++;
               counter = 0;
 
-              if(currentPriority === 4 && total === numJobsPerPriority * 3){
+              if (currentPriority === 4 && total === numJobsPerPriority * 3) {
                 done();
               }
             }
           });
-        }, done);
+        },
+        done
+      );
     });
 
-    it('process several jobs serially', function (done) {
+    it('process several jobs serially', function(done) {
       this.timeout(12000);
       var counter = 1;
       var maxJobs = 35;
 
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         expect(job.data.num).to.be.equal(counter);
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
@@ -572,40 +635,46 @@ describe('Queue', function () {
       }
     });
 
-    it('process a job that updates progress', function (done) {
-      queue.process(function (job, jobDone) {
+    it('process a job that updates progress', function(done) {
+      queue.process(function(job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         job.progress(42);
         jobDone();
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('progress', function (job, progress) {
+      queue.on('progress', function(job, progress) {
         expect(job).to.be.ok;
         expect(progress).to.be.eql(42);
         done();
       });
     });
 
-    it('process a job that returns data in the process handler', function (done) {
-      queue.process(function (job, jobDone) {
+    it('process a job that returns data in the process handler', function(done) {
+      queue.process(function(job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         jobDone(null, 37);
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('completed', function (job, data) {
+      queue.on('completed', function(job, data) {
         expect(job).to.be.ok;
         expect(data).to.be.eql(37);
-        queue.getJob(job.id).then(function(job){
+        queue.getJob(job.id).then(function(job) {
           expect(job.returnvalue).to.be.eql(37);
           done();
         });
@@ -614,271 +683,305 @@ describe('Queue', function () {
 
     it('process a job that returns a string in the process handler', function(done) {
       var testString = 'a very dignified string';
-      queue.on('completed', function(job/*, data*/) {
+      queue.on('completed', function(job /*, data*/) {
         expect(job).to.be.ok;
         expect(job.returnvalue).to.be.equal(testString);
         setTimeout(function() {
-          queue.getJob(job.id).then(function(job) {
-            expect(job).to.be.ok;
-            expect(job.returnvalue).to.be.equal(testString);
-            done();
-          }).catch(done);
+          queue
+            .getJob(job.id)
+            .then(function(job) {
+              expect(job).to.be.ok;
+              expect(job.returnvalue).to.be.equal(testString);
+              done();
+            })
+            .catch(done);
         }, 100);
       });
 
-      queue.process(function(/*job*/){
+      queue.process(function(/*job*/) {
         return Promise.resolve(testString);
       });
 
       queue.add({ testing: true });
     });
 
-    it('process a job that returns data in the process handler and the returnvalue gets stored in the database', function (done) {
-      queue.process(function (job, jobDone) {
+    it('process a job that returns data in the process handler and the returnvalue gets stored in the database', function(done) {
+      queue.process(function(job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         jobDone(null, 37);
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('completed', function (job, data) {
+      queue.on('completed', function(job, data) {
         expect(job).to.be.ok;
         expect(data).to.be.eql(37);
-        queue.getJob(job.id).then(function(job){
+        queue.getJob(job.id).then(function(job) {
           expect(job.returnvalue).to.be.eql(37);
-          queue.client.hget(queue.toKey(job.id), 'returnvalue').then(function (retval) {
-            expect(JSON.parse(retval)).to.be.eql(37);
-            done();
-          });
+          queue.client
+            .hget(queue.toKey(job.id), 'returnvalue')
+            .then(function(retval) {
+              expect(JSON.parse(retval)).to.be.eql(37);
+              done();
+            });
         });
       });
     });
 
-    it('process a job that returns a promise', function (done) {
-      queue.process(function (job) {
+    it('process a job that returns a promise', function(done) {
+      queue.process(function(job) {
         expect(job.data.foo).to.be.equal('bar');
-        return Promise.delay(250).then(function () {
+        return Promise.delay(250).then(function() {
           return 'my data';
         });
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('completed', function (job, data) {
+      queue.on('completed', function(job, data) {
         expect(job).to.be.ok;
         expect(data).to.be.eql('my data');
         done();
       });
     });
 
-    it('process a job that returns data in a promise', function (done) {
-      queue.process(function (job) {
+    it('process a job that returns data in a promise', function(done) {
+      queue.process(function(job) {
         expect(job.data.foo).to.be.equal('bar');
         return Promise.delay(250, 42);
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('completed', function (job, data) {
+      queue.on('completed', function(job, data) {
         expect(job).to.be.ok;
         expect(data).to.be.eql(42);
         done();
       });
     });
 
-    it('process a synchronous job', function (done) {
-      queue.process(function (job) {
+    it('process a synchronous job', function(done) {
+      queue.process(function(job) {
         expect(job.data.foo).to.be.equal('bar');
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('completed', function (job) {
+      queue.on('completed', function(job) {
         expect(job).to.be.ok;
         done();
       });
     });
 
-    it('process stalled jobs when starting a queue', function (done) {
-
+    it('process stalled jobs when starting a queue', function(done) {
       this.timeout(6000);
-      utils.newQueue('test queue stalled', {
-        settings: {
-          lockDuration: 15,
-          lockRenewTime: 5,
-          stalledInterval: 100
-        }
-      }).then(function (queueStalled) {
-        var jobs = [
-          queueStalled.add({ bar: 'baz' }),
-          queueStalled.add({ bar1: 'baz1' }),
-          queueStalled.add({ bar2: 'baz2' }),
-          queueStalled.add({ bar3: 'baz3' })
-        ];
-        Promise.all(jobs).then(function () {
-          var afterJobsRunning = function () {
-            var stalledCallback = sandbox.spy();
-            return queueStalled.close(true).then(function () {
-              return new Promise(function (resolve, reject) {
-                utils.newQueue('test queue stalled', {
-                  settings: {
-                    stalledInterval: 100
-                  }
-                }).then(function (queue2) {
-                  var doneAfterFour = _.after(4, function () {
-                    try {
-                      expect(stalledCallback.calledOnce).to.be.eql(true);
-                      queue.close().then(resolve);
-                    } catch (e) {
-                      queue.close().then(function(){
-                        reject(e);
+      utils
+        .newQueue('test queue stalled', {
+          settings: {
+            lockDuration: 15,
+            lockRenewTime: 5,
+            stalledInterval: 100
+          }
+        })
+        .then(function(queueStalled) {
+          var jobs = [
+            queueStalled.add({ bar: 'baz' }),
+            queueStalled.add({ bar1: 'baz1' }),
+            queueStalled.add({ bar2: 'baz2' }),
+            queueStalled.add({ bar3: 'baz3' })
+          ];
+          Promise.all(jobs).then(function() {
+            var afterJobsRunning = function() {
+              var stalledCallback = sandbox.spy();
+              return queueStalled
+                .close(true)
+                .then(function() {
+                  return new Promise(function(resolve, reject) {
+                    utils
+                      .newQueue('test queue stalled', {
+                        settings: {
+                          stalledInterval: 100
+                        }
+                      })
+                      .then(function(queue2) {
+                        var doneAfterFour = _.after(4, function() {
+                          try {
+                            expect(stalledCallback.calledOnce).to.be.eql(true);
+                            queue.close().then(resolve);
+                          } catch (e) {
+                            queue.close().then(function() {
+                              reject(e);
+                            });
+                          }
+                        });
+                        queue2.on('completed', doneAfterFour);
+                        queue2.on('stalled', stalledCallback);
+
+                        queue2.process(function(job, jobDone2) {
+                          jobDone2();
+                        });
                       });
-                    }
                   });
-                  queue2.on('completed', doneAfterFour);
-                  queue2.on('stalled', stalledCallback);
+                })
+                .then(done, done);
+            };
 
-                  queue2.process(function (job, jobDone2) {
-                    jobDone2();
-                  });
-                });
-              });
-            }).then(done, done);
-          };
-
-          var onceRunning = _.once(afterJobsRunning);
-          queueStalled.process(function () {
-            onceRunning();
-            return Promise.delay(150);
-          });
-        });
-      });
-    });
-
-    it('processes jobs that were added before the queue backend started', function () {
-      return utils.newQueue('test queue added before', {
-        settings: {
-          lockRenewTime: 10
-        }
-      }).then(function (queueStalled) {
-        var jobs = [
-          queueStalled.add({ bar: 'baz' }),
-          queueStalled.add({ bar1: 'baz1' }),
-          queueStalled.add({ bar2: 'baz2' }),
-          queueStalled.add({ bar3: 'baz3' })
-        ];
-
-        return Promise.all(jobs)
-          .then(queueStalled.close.bind(queueStalled))
-          .then(function () {
-            return utils.newQueue('test queue added before').then(function (queue2) {
-              queue2.process(function (job, jobDone) {
-                jobDone();
-              });
-
-              return new Promise(function (resolve) {
-                var resolveAfterAllJobs = _.after(jobs.length, resolve);
-                queue2.on('completed', resolveAfterAllJobs);
-              });
+            var onceRunning = _.once(afterJobsRunning);
+            queueStalled.process(function() {
+              onceRunning();
+              return Promise.delay(150);
             });
           });
-      });
+        });
     });
 
-    it('process a named job that returns a promise', function (done) {
-      queue.process('myname', function (job) {
+    it('processes jobs that were added before the queue backend started', function() {
+      return utils
+        .newQueue('test queue added before', {
+          settings: {
+            lockRenewTime: 10
+          }
+        })
+        .then(function(queueStalled) {
+          var jobs = [
+            queueStalled.add({ bar: 'baz' }),
+            queueStalled.add({ bar1: 'baz1' }),
+            queueStalled.add({ bar2: 'baz2' }),
+            queueStalled.add({ bar3: 'baz3' })
+          ];
+
+          return Promise.all(jobs)
+            .then(queueStalled.close.bind(queueStalled))
+            .then(function() {
+              return utils
+                .newQueue('test queue added before')
+                .then(function(queue2) {
+                  queue2.process(function(job, jobDone) {
+                    jobDone();
+                  });
+
+                  return new Promise(function(resolve) {
+                    var resolveAfterAllJobs = _.after(jobs.length, resolve);
+                    queue2.on('completed', resolveAfterAllJobs);
+                  });
+                });
+            });
+        });
+    });
+
+    it('process a named job that returns a promise', function(done) {
+      queue.process('myname', function(job) {
         expect(job.data.foo).to.be.equal('bar');
-        return Promise.delay(250).then(function () {
+        return Promise.delay(250).then(function() {
           return 'my data';
         });
       });
 
-      queue.add('myname', { foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue
+        .add('myname', { foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
 
-      queue.on('completed', function (job, data) {
+      queue.on('completed', function(job, data) {
         expect(job).to.be.ok;
         expect(data).to.be.eql('my data');
         done();
       });
     });
 
-    it('process a two named jobs that returns a promise', function (done) {
-      queue.process('myname', function (job) {
+    it('process a two named jobs that returns a promise', function(done) {
+      queue.process('myname', function(job) {
         expect(job.data.foo).to.be.equal('bar');
-        return Promise.delay(250).then(function () {
+        return Promise.delay(250).then(function() {
           return 'my data';
         });
       });
 
-      queue.process('myname2', function (job) {
+      queue.process('myname2', function(job) {
         expect(job.data.baz).to.be.equal('qux');
-        return Promise.delay(250).then(function () {
+        return Promise.delay(250).then(function() {
           return 'my data 2';
         });
       });
 
-      queue.add('myname', { foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).then(function(){
-        return queue.add('myname2', { baz: 'qux' });
-      }).catch(done);
+      queue
+        .add('myname', { foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .then(function() {
+          return queue.add('myname2', { baz: 'qux' });
+        })
+        .catch(done);
 
       var one, two;
-      queue.on('completed', function (job, data) {
+      queue.on('completed', function(job, data) {
         expect(job).to.be.ok;
-        if(job.data.foo){
+        if (job.data.foo) {
           one = true;
           expect(data).to.be.eql('my data');
         }
-        if(job.data.baz){
+        if (job.data.baz) {
           two = true;
           expect(data).to.be.eql('my data 2');
         }
-        if(one && two){
+        if (one && two) {
           done();
         }
       });
     });
 
-    it('fails job if missing named process', function (done) {
-      queue.process(function (/*job*/) {
+    it('fails job if missing named process', function(done) {
+      queue.process(function(/*job*/) {
         done(Error('should not process this job'));
       });
 
-      queue.once('failed', function(/*err*/){
+      queue.once('failed', function(/*err*/) {
         done();
       });
 
-      queue.add('myname', { foo: 'bar' }).then(function (job) {
+      queue.add('myname', { foo: 'bar' }).then(function(job) {
         expect(job.id).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
       });
     });
 
-    it('processes several stalled jobs when starting several queues', function (done) {
+    it('processes several stalled jobs when starting several queues', function(done) {
       this.timeout(50000);
 
       var NUM_QUEUES = 10;
       var NUM_JOBS_PER_QUEUE = 10;
       var stalledQueues = [];
       var jobs = [];
-      var redisOpts = {port: 6379, host: '127.0.0.1'};
+      var redisOpts = { port: 6379, host: '127.0.0.1' };
 
       for (var i = 0; i < NUM_QUEUES; i++) {
         var queueStalled2 = new Queue('test queue stalled 2', {
@@ -897,35 +1000,40 @@ describe('Queue', function () {
         stalledQueues.push(queueStalled2);
       }
 
-      var closeStalledQueues = function(){
-        return Promise.all(stalledQueues.map(function(queue){
-          return queue.close(true);
-        }));
+      var closeStalledQueues = function() {
+        return Promise.all(
+          stalledQueues.map(function(queue) {
+            return queue.close(true);
+          })
+        );
       };
 
-      Promise.all(jobs).then(function () {
+      Promise.all(jobs).then(function() {
         var processed = 0;
-        var procFn = function () {
+        var procFn = function() {
           // instead of completing we just close the queue to simulate a crash.
           utils.simulateDisconnect(this);
           processed++;
           if (processed === stalledQueues.length) {
-            setTimeout(function () {
-              var queue2 = new Queue('test queue stalled 2', {redis: redisOpts, settings: {stalledInterval: 100}});
-              queue2.on('error', function(err){
+            setTimeout(function() {
+              var queue2 = new Queue('test queue stalled 2', {
+                redis: redisOpts,
+                settings: { stalledInterval: 100 }
+              });
+              queue2.on('error', function(err) {
                 done(err);
               });
-              queue2.process(function (job2, jobDone) {
+              queue2.process(function(job2, jobDone) {
                 jobDone();
               });
 
               var counter = 0;
-              queue2.on('completed', function () {
+              queue2.on('completed', function() {
                 counter++;
                 if (counter === NUM_QUEUES * NUM_JOBS_PER_QUEUE) {
                   queue2.close().then(done);
 
-                  closeStalledQueues().then(function(){
+                  closeStalledQueues().then(function() {
                     // This can take long time since queues are disconnected.
                   });
                 }
@@ -935,8 +1043,8 @@ describe('Queue', function () {
         };
 
         var processes = [];
-        stalledQueues.forEach(function(queue){
-          queue.on('error', function(/*err*/){
+        stalledQueues.forEach(function(queue) {
+          queue.on('error', function(/*err*/) {
             //
             // Swallow errors produced by the disconnect
             //
@@ -947,30 +1055,36 @@ describe('Queue', function () {
       });
     });
 
-    it('does not process a job that is being processed when a new queue starts', function (done) {
+    it('does not process a job that is being processed when a new queue starts', function(done) {
       this.timeout(12000);
       var err = null;
       var anotherQueue;
 
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         utils.cleanupQueue(anotherQueue).then(done.bind(null, err));
       });
 
-      queue.add({ foo: 'bar' }).then(function (addedJob) {
-        queue.process(function (job, jobDone) {
-          expect(job.data.foo).to.be.equal('bar');
+      queue.add({ foo: 'bar' }).then(function(addedJob) {
+        queue
+          .process(function(job, jobDone) {
+            expect(job.data.foo).to.be.equal('bar');
 
-          if (addedJob.id !== job.id) {
-            err = new Error('Processed job id does not match that of added job');
-          }
-          setTimeout(jobDone, 500);
-        }).catch(done);
+            if (addedJob.id !== job.id) {
+              err = new Error(
+                'Processed job id does not match that of added job'
+              );
+            }
+            setTimeout(jobDone, 500);
+          })
+          .catch(done);
 
-        utils.newQueue().then(function (_anotherQueue) {
+        utils.newQueue().then(function(_anotherQueue) {
           anotherQueue = _anotherQueue;
-          setTimeout(function () {
-            anotherQueue.process(function (job, jobDone) {
-              err = new Error('The second queue should not have received a job to process');
+          setTimeout(function() {
+            anotherQueue.process(function(job, jobDone) {
+              err = new Error(
+                'The second queue should not have received a job to process'
+              );
               jobDone();
             });
           }, 50);
@@ -978,7 +1092,7 @@ describe('Queue', function () {
       });
     });
 
-    it('process stalled jobs without requiring a queue restart', function (done) {
+    it('process stalled jobs without requiring a queue restart', function(done) {
       this.timeout(12000);
 
       var queue2 = utils.buildQueue('running-stalled-job-' + uuid(), {
@@ -989,13 +1103,14 @@ describe('Queue', function () {
         }
       });
 
-      var collect = _.after(2, function () {
+      var collect = _.after(2, function() {
         queue2.close().then(done);
       });
 
-      queue2.on('completed', function () {
+      queue2.on('completed', function() {
         var client = new redis();
-        client.multi()
+        client
+          .multi()
           .zrem(queue2.toKey('completed'), 1)
           .lpush(queue2.toKey('active'), 1)
           .exec();
@@ -1003,18 +1118,21 @@ describe('Queue', function () {
         collect();
       });
 
-      queue2.process(function (job, jobDone) {
+      queue2.process(function(job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         jobDone();
       });
 
-      queue2.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue2
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
     });
 
-    it('failed stalled jobs that stall more than allowable stalled limit', function(done){
+    it('failed stalled jobs that stall more than allowable stalled limit', function(done) {
       var FAILED_MESSAGE = 'job stalled more than allowable limit';
       this.timeout(10000);
 
@@ -1028,45 +1146,51 @@ describe('Queue', function () {
       });
 
       var processedCount = 0;
-      queue2.process(function (job) {
-        processedCount ++;
+      queue2.process(function(job) {
+        processedCount++;
         expect(job.data.foo).to.be.equal('bar');
         return Promise.delay(1500);
       });
 
-      queue2.on('completed', function(){
+      queue2.on('completed', function() {
         done(new Error('should not complete'));
       });
 
-      queue2.on('failed', function(job, err){
+      queue2.on('failed', function(job, err) {
         expect(processedCount).to.be.eql(2);
         expect(job.failedReason).to.be.eql(FAILED_MESSAGE);
         expect(err.message).to.be.eql(FAILED_MESSAGE);
         done();
       });
 
-      queue2.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }).catch(done);
+      queue2
+        .add({ foo: 'bar' })
+        .then(function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        })
+        .catch(done);
     });
 
-    it('process a job that fails', function (done) {
+    it('process a job that fails', function(done) {
       var jobError = new Error('Job Failed');
 
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         expect(job.data.foo).to.be.equal('bar');
         jobDone(jobError);
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }, function (err) {
-        done(err);
-      });
+      queue.add({ foo: 'bar' }).then(
+        function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        },
+        function(err) {
+          done(err);
+        }
+      );
 
-      queue.once('failed', function (job, err) {
+      queue.once('failed', function(job, err) {
         expect(job.id).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
         expect(err).to.be.eql(jobError);
@@ -1074,22 +1198,25 @@ describe('Queue', function () {
       });
     });
 
-    it('process a job that throws an exception', function (done) {
+    it('process a job that throws an exception', function(done) {
       var jobError = new Error('Job Failed');
 
-      queue.process(function (job) {
+      queue.process(function(job) {
         expect(job.data.foo).to.be.equal('bar');
         throw jobError;
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }, function (err) {
-        done(err);
-      });
+      queue.add({ foo: 'bar' }).then(
+        function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        },
+        function(err) {
+          done(err);
+        }
+      );
 
-      queue.once('failed', function (job, err) {
+      queue.once('failed', function(job, err) {
         expect(job).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
         expect(err).to.be.eql(jobError);
@@ -1097,14 +1224,14 @@ describe('Queue', function () {
       });
     });
 
-    it('process a job that returns data with a circular dependency', function (done) {
-      queue.on('failed', function () {
+    it('process a job that returns data with a circular dependency', function(done) {
+      queue.on('failed', function() {
         done();
       });
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         done(Error('Should not complete'));
       });
-      queue.process(function () {
+      queue.process(function() {
         var circular = {};
         circular.x = circular;
         return Promise.resolve(circular);
@@ -1113,22 +1240,25 @@ describe('Queue', function () {
       queue.add({ foo: 'bar' });
     });
 
-    it('process a job that returns a rejected promise', function (done) {
+    it('process a job that returns a rejected promise', function(done) {
       var jobError = new Error('Job Failed');
 
-      queue.process(function (job) {
+      queue.process(function(job) {
         expect(job.data.foo).to.be.equal('bar');
         return Promise.reject(jobError);
       });
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }, function (err) {
-        done(err);
-      });
+      queue.add({ foo: 'bar' }).then(
+        function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        },
+        function(err) {
+          done(err);
+        }
+      );
 
-      queue.once('failed', function (job, err) {
+      queue.once('failed', function(job, err) {
         expect(job.id).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
         expect(err).to.be.eql(jobError);
@@ -1136,13 +1266,17 @@ describe('Queue', function () {
       });
     });
 
-    it('does not renew a job lock after the lock has been released [#397]', function (done) {
+    it('does not renew a job lock after the lock has been released [#397]', function(done) {
       this.timeout(queue.LOCK_RENEW_TIME * 4);
 
-      queue.process(function (job) {
-        expect(job.data.foo).to.be.equal('bar');
-        return Promise.resolve();
-      }).then(function() { done(); }, done);
+      queue
+        .process(function(job) {
+          expect(job.data.foo).to.be.equal('bar');
+          return Promise.resolve();
+        })
+        .then(function() {
+          done();
+        }, done);
 
       var emit = queue.emit.bind(queue);
       queue.emit = function() {
@@ -1152,29 +1286,32 @@ describe('Queue', function () {
         });
       };
 
-      queue.add({ foo: 'bar' }).then(function (job) {
-        expect(job.id).to.be.ok;
-        expect(job.data.foo).to.be.eql('bar');
-      }, function (err) {
-        done(err);
-      });
+      queue.add({ foo: 'bar' }).then(
+        function(job) {
+          expect(job.id).to.be.ok;
+          expect(job.data.foo).to.be.eql('bar');
+        },
+        function(err) {
+          done(err);
+        }
+      );
 
       setTimeout(queue.close.bind(queue), queue.LOCK_RENEW_TIME * 2.5);
     });
 
-    it('retry a job that fails', function (done) {
+    it('retry a job that fails', function(done) {
       var called = 0;
       var failedOnce = false;
       var notEvenErr = new Error('Not even!');
 
       var retryQueue = utils.buildQueue('retry-test-queue');
 
-      retryQueue.add({ foo: 'bar' }).then(function (job) {
+      retryQueue.add({ foo: 'bar' }).then(function(job) {
         expect(job.id).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
       });
 
-      retryQueue.process(function (job, jobDone) {
+      retryQueue.process(function(job, jobDone) {
         called++;
         if (called % 2 !== 0) {
           throw notEvenErr;
@@ -1182,7 +1319,7 @@ describe('Queue', function () {
         jobDone();
       });
 
-      retryQueue.once('failed', function (job, err) {
+      retryQueue.once('failed', function(job, err) {
         expect(job).to.be.ok;
         expect(job.data.foo).to.be.eql('bar');
         expect(err).to.be.eql(notEvenErr);
@@ -1190,15 +1327,14 @@ describe('Queue', function () {
         retryQueue.retryJob(job);
       });
 
-      retryQueue.once('completed', function () {
+      retryQueue.once('completed', function() {
         expect(failedOnce).to.be.eql(true);
         retryQueue.close().then(done);
       });
     });
-
   });
 
-  it('count added, unprocessed jobs', function () {
+  it('count added, unprocessed jobs', function() {
     var maxJobs = 100;
     var added = [];
 
@@ -1210,62 +1346,63 @@ describe('Queue', function () {
 
     return Promise.all(added)
       .then(queue.count.bind(queue))
-      .then(function (count) {
+      .then(function(count) {
         expect(count).to.be.eql(maxJobs);
       })
       .then(queue.empty.bind(queue))
       .then(queue.count.bind(queue))
-      .then(function (count) {
+      .then(function(count) {
         expect(count).to.be.eql(0);
         return queue.close();
       });
   });
 
-
-
-  describe('Delayed jobs', function () {
+  describe('Delayed jobs', function() {
     var queue;
 
-    beforeEach(function () {
+    beforeEach(function() {
       var client = new redis();
       return client.flushdb();
     });
 
-    it('should process a delayed job only after delayed time', function (done) {
+    it('should process a delayed job only after delayed time', function(done) {
       var delay = 500;
       queue = new Queue('delayed queue simple');
       var client = new redis(6379, '127.0.0.1', {});
       var timestamp = Date.now();
       var publishHappened = false;
-      client.on('ready', function () {
-        client.on('message', function (channel, message) {
+      client.on('ready', function() {
+        client.on('message', function(channel, message) {
           expect(parseInt(message, 10)).to.be.a('number');
           publishHappened = true;
         });
         client.subscribe(queue.toKey('delayed'));
       });
 
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         jobDone();
       });
 
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         expect(Date.now() > timestamp + delay);
-        queue.getWaiting().then(function (jobs) {
-          expect(jobs.length).to.be.equal(0);
-
-        }).then(function () {
-          return queue.getDelayed().then(function (jobs) {
+        queue
+          .getWaiting()
+          .then(function(jobs) {
             expect(jobs.length).to.be.equal(0);
+          })
+          .then(function() {
+            return queue.getDelayed().then(function(jobs) {
+              expect(jobs.length).to.be.equal(0);
+            });
+          })
+          .then(function() {
+            expect(publishHappened).to.be.eql(true);
+            queue.close(true).then(done, done);
           });
-        }).then(function () {
-          expect(publishHappened).to.be.eql(true);
-          queue.close(true).then(done, done);
-        });
       });
 
-      queue._initializingProcess.then(function(){
-        queue.add({ delayed: 'foobar' }, { delay: delay }).then(function (job) {
+      queue._initializingProcess.then(function() {
+        queue.add({ delayed: 'foobar' }, { delay: delay }).then(function(job) {
           expect(job.id).to.be.ok;
           expect(job.data.delayed).to.be.eql('foobar');
           expect(job.delay).to.be.eql(delay);
@@ -1273,16 +1410,16 @@ describe('Queue', function () {
       });
     });
 
-    it('should process delayed jobs in correct order', function (done) {
+    it('should process delayed jobs in correct order', function(done) {
       var order = 0;
       queue = new Queue('delayed queue multiple');
 
-      queue.on('failed', function (job, err) {
+      queue.on('failed', function(job, err) {
         err.job = job;
         done(err);
       });
 
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         order++;
         expect(order).to.be.equal(job.data.order);
         jobDone();
@@ -1303,7 +1440,7 @@ describe('Queue', function () {
       queue.add({ order: 8 }, { delay: 800 });
     });
 
-    it('should process delayed jobs in correct order even in case of restart', function (done) {
+    it('should process delayed jobs in correct order even in case of restart', function(done) {
       this.timeout(15000);
 
       var QUEUE_NAME = 'delayed queue multiple' + uuid();
@@ -1311,7 +1448,7 @@ describe('Queue', function () {
 
       queue = new Queue(QUEUE_NAME);
 
-      var fn = function (job, jobDone) {
+      var fn = function(job, jobDone) {
         expect(order).to.be.equal(job.data.order);
         jobDone();
 
@@ -1327,14 +1464,17 @@ describe('Queue', function () {
         queue.add({ order: 4 }, { delay: 500 }),
         queue.add({ order: 1 }, { delay: 200 }),
         queue.add({ order: 3 }, { delay: 400 })
-      ).then(function () {
-        //
-        // Start processing so that jobs get into the delay set.
-        //
-        queue.process(fn);
-        return null;
-      }).delay(20).then(function () {
-        /*
+      )
+        .then(function() {
+          //
+          // Start processing so that jobs get into the delay set.
+          //
+          queue.process(fn);
+          return null;
+        })
+        .delay(20)
+        .then(function() {
+          /*
         //We simulate a restart
         console.log('RESTART');
         return queue.close().then(function () {
@@ -1345,15 +1485,15 @@ describe('Queue', function () {
           });
         });
         */
-      });
+        });
     });
 
-    it('should process delayed jobs with exact same timestamps in correct order (FIFO)', function (done) {
+    it('should process delayed jobs with exact same timestamps in correct order (FIFO)', function(done) {
       var QUEUE_NAME = 'delayed queue multiple' + uuid();
       queue = new Queue(QUEUE_NAME);
       var order = 1;
 
-      var fn = function (job, jobDone) {
+      var fn = function(job, jobDone) {
         expect(order).to.be.equal(job.data.order);
         jobDone();
 
@@ -1364,17 +1504,22 @@ describe('Queue', function () {
         order++;
       };
 
-      queue.isReady().then(function () {
+      queue.isReady().then(function() {
         var now = Date.now();
         var _promises = [];
         var _i = 1;
         for (_i; _i <= 12; _i++) {
-          _promises.push(queue.add({ order: _i }, {
-            delay: 1000,
-            timestamp: now
-          }));
+          _promises.push(
+            queue.add(
+              { order: _i },
+              {
+                delay: 1000,
+                timestamp: now
+              }
+            )
+          );
         }
-        Promise.join.apply(null, _promises).then(function () {
+        Promise.join.apply(null, _promises).then(function() {
           queue.process(fn);
         });
       });
@@ -1393,7 +1538,7 @@ describe('Queue', function () {
         });
       });
 
-      queue.on('error', function(/*err*/){
+      queue.on('error', function(/*err*/) {
         job.isDelayed().then(function(isDelayed) {
           expect(isDelayed).to.be.equal(false);
           queue.close().then(done, done);
@@ -1416,7 +1561,7 @@ describe('Queue', function () {
         });
       });
 
-      queue.on('error', function(/*err*/){
+      queue.on('error', function(/*err*/) {
         job.isWaiting().then(function(isWaiting) {
           expect(isWaiting).to.be.equal(false);
           queue.close().then(done, done);
@@ -1428,27 +1573,29 @@ describe('Queue', function () {
     });
   });
 
-  describe('Concurrency process', function () {
+  describe('Concurrency process', function() {
     var queue;
 
-    beforeEach(function () {
+    beforeEach(function() {
       var client = new redis();
       queue = utils.buildQueue();
       return client.flushdb();
     });
 
-    afterEach(function () {
-      this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+    afterEach(function() {
+      this.timeout(
+        queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+      );
       return queue.close();
     });
 
-    it('should run job in sequence if I specify a concurrency of 1', function (done) {
+    it('should run job in sequence if I specify a concurrency of 1', function(done) {
       var processing = false;
 
-      queue.process(1, function (job, jobDone) {
+      queue.process(1, function(job, jobDone) {
         expect(processing).to.be.equal(false);
         processing = true;
-        Promise.delay(50).then(function () {
+        Promise.delay(50).then(function() {
           processing = false;
           jobDone();
         });
@@ -1462,25 +1609,29 @@ describe('Queue', function () {
 
     //This job use delay to check that at any time we have 4 process in parallel.
     //Due to time to get new jobs and call process, false negative can appear.
-    it('should process job respecting the concurrency set', function (done) {
+    it('should process job respecting the concurrency set', function(done) {
       var nbProcessing = 0;
       var pendingMessageToProcess = 8;
       var wait = 100;
 
-      queue.process(4, function () {
-        nbProcessing++;
-        expect(nbProcessing).to.be.lessThan(5);
+      queue
+        .process(4, function() {
+          nbProcessing++;
+          expect(nbProcessing).to.be.lessThan(5);
 
-        wait += 100;
+          wait += 100;
 
-        return Promise.delay(wait).then(function () {
-          //We should not have 4 more in parallel.
-          //At the end, due to empty list, no new job will process, so nbProcessing will decrease.
-          expect(nbProcessing).to.be.eql(Math.min(pendingMessageToProcess, 4));
-          pendingMessageToProcess--;
-          nbProcessing--;
-        });
-      }).catch(done);
+          return Promise.delay(wait).then(function() {
+            //We should not have 4 more in parallel.
+            //At the end, due to empty list, no new job will process, so nbProcessing will decrease.
+            expect(nbProcessing).to.be.eql(
+              Math.min(pendingMessageToProcess, 4)
+            );
+            pendingMessageToProcess--;
+            nbProcessing--;
+          });
+        })
+        .catch(done);
 
       queue.add();
       queue.add();
@@ -1495,34 +1646,37 @@ describe('Queue', function () {
       queue.on('failed', done);
     });
 
-    it('should wait for all concurrent processing in case of pause', function (done) {
+    it('should wait for all concurrent processing in case of pause', function(done) {
       var i = 0;
       var nbJobFinish = 0;
 
-      queue.process(3, function (job, jobDone) {
-        var error = null;
+      queue
+        .process(3, function(job, jobDone) {
+          var error = null;
 
-        if (++i === 4) {
-          queue.pause().then(function () {
-            Promise.delay(500).then(function () { // Wait for all the active jobs to finalize.
-              expect(nbJobFinish).to.be.above(3);
-              queue.resume();
+          if (++i === 4) {
+            queue.pause().then(function() {
+              Promise.delay(500).then(function() {
+                // Wait for all the active jobs to finalize.
+                expect(nbJobFinish).to.be.above(3);
+                queue.resume();
+              });
             });
+          }
+
+          // We simulate an error of one processing job.
+          // They had a bug in pause() with this special case.
+          if (i % 3 === 0) {
+            error = new Error();
+          }
+
+          //100 - i*20 is to force to finish job n°4 before lower job that will wait longer
+          Promise.delay(100 - i * 10).then(function() {
+            nbJobFinish++;
+            jobDone(error);
           });
-        }
-
-        // We simulate an error of one processing job.
-        // They had a bug in pause() with this special case.
-        if (i % 3 === 0) {
-          error = new Error();
-        }
-
-        //100 - i*20 is to force to finish job n°4 before lower job that will wait longer
-        Promise.delay(100 - i * 10).then(function () {
-          nbJobFinish++;
-          jobDone(error);
-        });
-      }).catch(done);
+        })
+        .catch(done);
 
       queue.add({});
       queue.add({});
@@ -1540,40 +1694,44 @@ describe('Queue', function () {
     });
   });
 
-  describe('Retries and backoffs', function () {
+  describe('Retries and backoffs', function() {
     var queue;
 
-    afterEach(function () {
-      this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+    afterEach(function() {
+      this.timeout(
+        queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+      );
       return queue.close();
     });
 
-    it('should not retry a job if it has been marked as unrecoverable', function (done) {
+    it('should not retry a job if it has been marked as unrecoverable', function(done) {
       var tries = 0;
       queue = utils.buildQueue('test retries and backoffs');
-      queue.isReady().then(function () {
-        queue.process(function (job, jobDone) {
+      queue.isReady().then(function() {
+        queue.process(function(job, jobDone) {
           tries++;
           expect(tries).to.equal(1);
           job.discard();
           jobDone(new Error('unrecoverable error'));
         });
 
-        queue.add({ foo: 'bar' }, {
-          attempts: 5
-        });
+        queue.add(
+          { foo: 'bar' },
+          {
+            attempts: 5
+          }
+        );
       });
-      queue.on('failed', function () {
+      queue.on('failed', function() {
         done();
       });
     });
 
-    it('should automatically retry a failed job if attempts is bigger than 1', function (done) {
+    it('should automatically retry a failed job if attempts is bigger than 1', function(done) {
       queue = utils.buildQueue('test retries and backoffs');
-      queue.isReady().then(function () {
-
+      queue.isReady().then(function() {
         var tries = 0;
-        queue.process(function (job, jobDone) {
+        queue.process(function(job, jobDone) {
           expect(job.attemptsMade).to.be.eql(tries);
           tries++;
           if (job.attemptsMade < 2) {
@@ -1583,20 +1741,23 @@ describe('Queue', function () {
           jobDone();
         });
 
-        queue.add({ foo: 'bar' }, {
-          attempts: 3
-        });
+        queue.add(
+          { foo: 'bar' },
+          {
+            attempts: 3
+          }
+        );
       });
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         done();
       });
     });
 
-    it('should not retry a failed job more than the number of given attempts times', function (done) {
+    it('should not retry a failed job more than the number of given attempts times', function(done) {
       queue = utils.buildQueue('test retries and backoffs');
       var tries = 0;
-      queue.isReady().then(function () {
-        queue.process(function (job, jobDone) {
+      queue.isReady().then(function() {
+        queue.process(function(job, jobDone) {
           tries++;
           if (job.attemptsMade < 3) {
             throw new Error('Not yet!');
@@ -1605,26 +1766,29 @@ describe('Queue', function () {
           jobDone();
         });
 
-        queue.add({ foo: 'bar' }, {
-          attempts: 3
-        });
+        queue.add(
+          { foo: 'bar' },
+          {
+            attempts: 3
+          }
+        );
       });
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         done(new Error('Failed job was retried more than it should be!'));
       });
-      queue.on('failed', function () {
+      queue.on('failed', function() {
         if (tries === 3) {
           done();
         }
       });
     });
 
-    it('should retry a job after a delay if a fixed backoff is given', function (done) {
+    it('should retry a job after a delay if a fixed backoff is given', function(done) {
       this.timeout(12000);
       queue = utils.buildQueue('test retries and backoffs');
       var start;
-      queue.isReady().then(function () {
-        queue.process(function (job, jobDone) {
+      queue.isReady().then(function() {
+        queue.process(function(job, jobDone) {
           if (job.attemptsMade < 2) {
             throw new Error('Not yet!');
           }
@@ -1632,24 +1796,27 @@ describe('Queue', function () {
         });
 
         start = Date.now();
-        queue.add({ foo: 'bar' }, {
-          attempts: 3,
-          backoff: 1000
-        });
+        queue.add(
+          { foo: 'bar' },
+          {
+            attempts: 3,
+            backoff: 1000
+          }
+        );
       });
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         var elapse = Date.now() - start;
         expect(elapse).to.be.greaterThan(2000);
         done();
       });
     });
 
-    it('should retry a job after a delay if an exponential backoff is given', function (done) {
+    it('should retry a job after a delay if an exponential backoff is given', function(done) {
       this.timeout(12000);
       queue = utils.buildQueue('test retries and backoffs');
       var start;
-      queue.isReady().then(function () {
-        queue.process(function (job, jobDone) {
+      queue.isReady().then(function() {
+        queue.process(function(job, jobDone) {
           if (job.attemptsMade < 2) {
             throw new Error('Not yet!');
           }
@@ -1657,15 +1824,18 @@ describe('Queue', function () {
         });
 
         start = Date.now();
-        queue.add({ foo: 'bar' }, {
-          attempts: 3,
-          backoff: {
-            type: 'exponential',
-            delay: 1000
+        queue.add(
+          { foo: 'bar' },
+          {
+            attempts: 3,
+            backoff: {
+              type: 'exponential',
+              delay: 1000
+            }
           }
-        });
+        );
       });
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         var elapse = Date.now() - start;
         var expected = 1000 * (Math.pow(2, 2) - 1);
         expect(elapse).to.be.greaterThan(expected);
@@ -1673,20 +1843,20 @@ describe('Queue', function () {
       });
     });
 
-    it('should retry a job after a delay if a custom backoff is given', function (done) {
+    it('should retry a job after a delay if a custom backoff is given', function(done) {
       this.timeout(12000);
       queue = utils.buildQueue('test retries and backoffs', {
         settings: {
           backoffStrategies: {
-            custom: function (attemptsMade) {
+            custom: function(attemptsMade) {
               return attemptsMade * 1000;
             }
           }
         }
       });
       var start;
-      queue.isReady().then(function () {
-        queue.process(function (job, jobDone) {
+      queue.isReady().then(function() {
+        queue.process(function(job, jobDone) {
           if (job.attemptsMade < 2) {
             throw new Error('Not yet!');
           }
@@ -1694,25 +1864,28 @@ describe('Queue', function () {
         });
 
         start = Date.now();
-        queue.add({ foo: 'bar' }, {
-          attempts: 3,
-          backoff: {
-            type: 'custom'
+        queue.add(
+          { foo: 'bar' },
+          {
+            attempts: 3,
+            backoff: {
+              type: 'custom'
+            }
           }
-        });
+        );
       });
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         var elapse = Date.now() - start;
         expect(elapse).to.be.greaterThan(3000);
         done();
       });
     });
 
-    it('should not retry a job that has been removed', function (done) {
+    it('should not retry a job that has been removed', function(done) {
       queue = utils.buildQueue('retry a removed job');
       var attempts = 0;
       var failedError = new Error('failed');
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         if (attempts === 0) {
           attempts++;
           throw failedError;
@@ -1722,35 +1895,39 @@ describe('Queue', function () {
       });
       queue.add({ foo: 'bar' });
 
-      var failedHandler = _.once(function (job, err ) {
+      var failedHandler = _.once(function(job, err) {
         expect(job.data.foo).to.equal('bar');
         expect(err).to.equal(failedError);
         expect(job.failedReason).to.equal(failedError.message);
 
-        job.retry().delay(100)
-          .then(function () {
-            return queue.getCompletedCount().then(function (count) {
+        job
+          .retry()
+          .delay(100)
+          .then(function() {
+            return queue.getCompletedCount().then(function(count) {
               return expect(count).to.equal(1);
             });
           })
-          .then(function () {
-            return queue.clean(0).then(function () {
-              return job.retry().catch(function (err) {
-                expect(err.message).to.equal(Queue.ErrorMessages.RETRY_JOB_NOT_EXIST);
+          .then(function() {
+            return queue.clean(0).then(function() {
+              return job.retry().catch(function(err) {
+                expect(err.message).to.equal(
+                  Queue.ErrorMessages.RETRY_JOB_NOT_EXIST
+                );
               });
             });
           })
-          .then(function () {
+          .then(function() {
             return Promise.all([
-              queue.getCompletedCount().then(function (count) {
+              queue.getCompletedCount().then(function(count) {
                 return expect(count).to.equal(0);
               }),
-              queue.getFailedCount().then(function (count) {
+              queue.getFailedCount().then(function(count) {
                 return expect(count).to.equal(0);
               })
             ]);
           })
-          .then(function () {
+          .then(function() {
             done();
           }, done);
       });
@@ -1758,12 +1935,12 @@ describe('Queue', function () {
       queue.on('failed', failedHandler);
     });
 
-    it('should not retry a job that has been retried already', function (done) {
+    it('should not retry a job that has been retried already', function(done) {
       queue = utils.buildQueue('retry already retried job');
       var failedError = new Error('failed');
-      queue.isReady().then(function () {
+      queue.isReady().then(function() {
         var attempts = 0;
-        queue.process(function (job, jobDone) {
+        queue.process(function(job, jobDone) {
           if (attempts === 0) {
             attempts++;
             throw failedError;
@@ -1775,32 +1952,36 @@ describe('Queue', function () {
         queue.add({ foo: 'bar' });
       });
 
-      var failedHandler = _.once(function (job, err) {
+      var failedHandler = _.once(function(job, err) {
         expect(job.data.foo).to.equal('bar');
         expect(err).to.equal(failedError);
 
-        job.retry().delay(100)
-          .then(function () {
-            return queue.getCompletedCount().then(function (count) {
+        job
+          .retry()
+          .delay(100)
+          .then(function() {
+            return queue.getCompletedCount().then(function(count) {
               return expect(count).to.equal(1);
             });
           })
-          .then(function () {
-            return job.retry().catch(function (err) {
-              expect(err.message).to.equal(Queue.ErrorMessages.RETRY_JOB_NOT_FAILED);
+          .then(function() {
+            return job.retry().catch(function(err) {
+              expect(err.message).to.equal(
+                Queue.ErrorMessages.RETRY_JOB_NOT_FAILED
+              );
             });
           })
-          .then(function () {
+          .then(function() {
             return Promise.all([
-              queue.getCompletedCount().then(function (count) {
+              queue.getCompletedCount().then(function(count) {
                 return expect(count).to.equal(1);
               }),
-              queue.getFailedCount().then(function (count) {
+              queue.getFailedCount().then(function(count) {
                 return expect(count).to.equal(0);
               })
             ]);
           })
-          .then(function () {
+          .then(function() {
             done();
           }, done);
       });
@@ -1808,20 +1989,25 @@ describe('Queue', function () {
       queue.on('failed', failedHandler);
     });
 
-    it('should not retry a job that is locked', function (done) {
+    it('should not retry a job that is locked', function(done) {
       queue = utils.buildQueue('retry a locked job');
-      var addedHandler = _.once(function (job) {
+      var addedHandler = _.once(function(job) {
         expect(job.data.foo).to.equal('bar');
 
-        Promise.delay(100).then(function(){
-          job.retry().catch(function (err) {
-            expect(err.message).to.equal(Queue.ErrorMessages.RETRY_JOB_IS_LOCKED);
-            return null;
-          }).then(done, done);
+        Promise.delay(100).then(function() {
+          job
+            .retry()
+            .catch(function(err) {
+              expect(err.message).to.equal(
+                Queue.ErrorMessages.RETRY_JOB_IS_LOCKED
+              );
+              return null;
+            })
+            .then(done, done);
         });
       });
 
-      queue.process(function (/*job*/) {
+      queue.process(function(/*job*/) {
         return Promise.delay(300);
       });
       queue.add({ foo: 'bar' }).then(addedHandler);
@@ -1844,7 +2030,7 @@ describe('Queue', function () {
         });
       });
 
-      queue.on('error', function(/*err*/){
+      queue.on('error', function(/*err*/) {
         queue.close().then(done, done);
       });
 
@@ -1853,22 +2039,27 @@ describe('Queue', function () {
     });
   });
 
-  describe('Jobs getters', function () {
+  describe('Jobs getters', function() {
     var queue;
 
-    beforeEach(function () {
+    beforeEach(function() {
       queue = utils.buildQueue();
       return queue.clean(1000);
     });
 
-    afterEach(function () {
-      this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+    afterEach(function() {
+      this.timeout(
+        queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+      );
       return queue.close();
     });
 
-    it('should get waiting jobs', function () {
-      return Promise.join(queue.add({ foo: 'bar' }), queue.add({ baz: 'qux' })).then(function () {
-        return queue.getWaiting().then(function (jobs) {
+    it('should get waiting jobs', function() {
+      return Promise.join(
+        queue.add({ foo: 'bar' }),
+        queue.add({ baz: 'qux' })
+      ).then(function() {
+        return queue.getWaiting().then(function(jobs) {
           expect(jobs).to.be.a('array');
           expect(jobs.length).to.be.equal(2);
           expect(jobs[0].data.foo).to.be.equal('bar');
@@ -1877,10 +2068,13 @@ describe('Queue', function () {
       });
     });
 
-    it('should get paused jobs', function () {
-      return queue.pause().then(function () {
-        return Promise.join(queue.add({ foo: 'bar' }), queue.add({ baz: 'qux' })).then(function () {
-          return queue.getWaiting().then(function (jobs) {
+    it('should get paused jobs', function() {
+      return queue.pause().then(function() {
+        return Promise.join(
+          queue.add({ foo: 'bar' }),
+          queue.add({ baz: 'qux' })
+        ).then(function() {
+          return queue.getWaiting().then(function(jobs) {
             expect(jobs).to.be.a('array');
             expect(jobs.length).to.be.equal(2);
             expect(jobs[0].data.foo).to.be.equal('bar');
@@ -1890,9 +2084,9 @@ describe('Queue', function () {
       });
     });
 
-    it('should get active jobs', function (done) {
-      queue.process(function (job, jobDone) {
-        queue.getActive().then(function (jobs) {
+    it('should get active jobs', function(done) {
+      queue.process(function(job, jobDone) {
+        queue.getActive().then(function(jobs) {
           expect(jobs).to.be.a('array');
           expect(jobs.length).to.be.equal(1);
           expect(jobs[0].data.foo).to.be.equal('bar');
@@ -1904,10 +2098,10 @@ describe('Queue', function () {
       queue.add({ foo: 'bar' });
     });
 
-    it('should get a specific job', function (done) {
+    it('should get a specific job', function(done) {
       var data = { foo: 'sup!' };
-      queue.add(data).then(function (job) {
-        queue.getJob(job.id).then(function (returnedJob) {
+      queue.add(data).then(function(job) {
+        queue.getJob(job.id).then(function(returnedJob) {
           expect(returnedJob.data).to.eql(data);
           expect(returnedJob.id).to.be.eql(job.id);
           done();
@@ -1915,18 +2109,18 @@ describe('Queue', function () {
       });
     });
 
-    it('should get completed jobs', function (done) {
+    it('should get completed jobs', function(done) {
       var counter = 2;
 
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         jobDone();
       });
 
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         counter--;
 
         if (counter === 0) {
-          queue.getCompleted().then(function (jobs) {
+          queue.getCompleted().then(function(jobs) {
             expect(jobs).to.be.a('array');
             // We need a "empty completed" kind of function.
             //expect(jobs.length).to.be.equal(2);
@@ -1939,18 +2133,18 @@ describe('Queue', function () {
       queue.add({ baz: 'qux' });
     });
 
-    it('should get failed jobs', function (done) {
+    it('should get failed jobs', function(done) {
       var counter = 2;
 
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         jobDone(new Error('Forced error'));
       });
 
-      queue.on('failed', function () {
+      queue.on('failed', function() {
         counter--;
 
         if (counter === 0) {
-          queue.getFailed().then(function (jobs) {
+          queue.getFailed().then(function(jobs) {
             expect(jobs).to.be.a('array');
             done();
           });
@@ -1961,335 +2155,419 @@ describe('Queue', function () {
       queue.add({ baz: 'qux' });
     });
 
-    it('fails jobs that exceed their specified timeout', function (done) {
-
-      queue.process(function (job, jobDone) {
+    it('fails jobs that exceed their specified timeout', function(done) {
+      queue.process(function(job, jobDone) {
         setTimeout(jobDone, 150);
       });
 
-      queue.on('failed', function (job, error) {
+      queue.on('failed', function(job, error) {
         expect(error.message).to.be.eql('operation timed out');
         done();
       });
 
-      queue.on('completed', function () {
+      queue.on('completed', function() {
         var error = new Error('The job should have timed out');
         done(error);
       });
 
-      queue.add({ some: 'data' }, {
-        timeout: 100
-      });
+      queue.add(
+        { some: 'data' },
+        {
+          timeout: 100
+        }
+      );
     });
   });
 
-  describe('getJobs', function () {
+  describe('getJobs', function() {
     this.timeout(12000);
     var queue;
 
-    beforeEach(function () {
+    beforeEach(function() {
       queue = utils.buildQueue();
       return queue.clean(1000);
     });
 
-    afterEach(function () {
-      this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+    afterEach(function() {
+      this.timeout(
+        queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+      );
       return queue.close();
     });
 
-    it('should return all completed jobs when not setting start/end', function (done) {
-      queue.process(function (job, completed) {
+    it('should return all completed jobs when not setting start/end', function(done) {
+      queue.process(function(job, completed) {
         completed();
       });
 
-      queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed').then(function (jobs) {
-          expect(jobs).to.be.an('array').that.have.length(3);
-          expect(jobs[0]).to.have.property('finishedOn');
-          expect(jobs[1]).to.have.property('finishedOn');
-          expect(jobs[2]).to.have.property('finishedOn');
+      queue.on(
+        'completed',
+        _.after(3, function() {
+          queue
+            .getJobs('completed')
+            .then(function(jobs) {
+              expect(jobs)
+                .to.be.an('array')
+                .that.have.length(3);
+              expect(jobs[0]).to.have.property('finishedOn');
+              expect(jobs[1]).to.have.property('finishedOn');
+              expect(jobs[2]).to.have.property('finishedOn');
 
-          expect(jobs[0]).to.have.property('processedOn');
-          expect(jobs[1]).to.have.property('processedOn');
-          expect(jobs[2]).to.have.property('processedOn');
-          done();
-        }).catch(done);
-      }));
+              expect(jobs[0]).to.have.property('processedOn');
+              expect(jobs[1]).to.have.property('processedOn');
+              expect(jobs[2]).to.have.property('processedOn');
+              done();
+            })
+            .catch(done);
+        })
+      );
 
       queue.add({ foo: 1 });
       queue.add({ foo: 2 });
       queue.add({ foo: 3 });
     });
 
-    it('should return all failed jobs when not setting start/end', function (done) {
-      queue.process(function (job, completed) {
+    it('should return all failed jobs when not setting start/end', function(done) {
+      queue.process(function(job, completed) {
         completed(new Error('error'));
       });
 
-      queue.on('failed', _.after(3, function () {
-        queue.getJobs('failed').then(function (jobs) {
-          expect(jobs).to.be.an('array').that.has.length(3);
-          expect(jobs[0]).to.have.property('finishedOn');
-          expect(jobs[1]).to.have.property('finishedOn');
-          expect(jobs[2]).to.have.property('finishedOn');
+      queue.on(
+        'failed',
+        _.after(3, function() {
+          queue
+            .getJobs('failed')
+            .then(function(jobs) {
+              expect(jobs)
+                .to.be.an('array')
+                .that.has.length(3);
+              expect(jobs[0]).to.have.property('finishedOn');
+              expect(jobs[1]).to.have.property('finishedOn');
+              expect(jobs[2]).to.have.property('finishedOn');
 
-          expect(jobs[0]).to.have.property('processedOn');
-          expect(jobs[1]).to.have.property('processedOn');
-          expect(jobs[2]).to.have.property('processedOn');
-          done();
-        }).catch(done);
-      }));
-
-      queue.add({ foo: 1 });
-      queue.add({ foo: 2 });
-      queue.add({ foo: 3 });
-    });
-
-    it('should return subset of jobs when setting positive range', function (done) {
-      queue.process(function (job, completed) {
-        completed();
-      });
-
-      queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', 1, 2, true).then(function (jobs) {
-          expect(jobs).to.be.an('array').that.has.length(2);
-          expect(jobs[0].data.foo).to.be.eql(2);
-          expect(jobs[1].data.foo).to.be.eql(3);
-          expect(jobs[0]).to.have.property('finishedOn');
-          expect(jobs[1]).to.have.property('finishedOn');
-          expect(jobs[0]).to.have.property('processedOn');
-          expect(jobs[1]).to.have.property('processedOn');
-          done();
-        }).catch(done);
-      }));
-
-      queue.add({ foo: 1 }).then(function(){
-        return queue.add({ foo: 2 });
-      }).then(function(){
-        return queue.add({ foo: 3 });
-      });
-    });
-
-    it('should return subset of jobs when setting a negative range', function (done) {
-      queue.process(function (job, completed) {
-        completed();
-      });
-
-      queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', -3, -1, true).then(function (jobs) {
-          expect(jobs).to.be.an('array').that.has.length(3);
-          expect(jobs[0].data.foo).to.be.equal(1);
-          expect(jobs[1].data.foo).to.be.eql(2);
-          expect(jobs[2].data.foo).to.be.eql(3);
-          done();
-        }).catch(done);
-      }));
+              expect(jobs[0]).to.have.property('processedOn');
+              expect(jobs[1]).to.have.property('processedOn');
+              expect(jobs[2]).to.have.property('processedOn');
+              done();
+            })
+            .catch(done);
+        })
+      );
 
       queue.add({ foo: 1 });
       queue.add({ foo: 2 });
       queue.add({ foo: 3 });
     });
 
-    it('should return subset of jobs when range overflows', function (done) {
-      queue.process(function (job, completed) {
+    it('should return subset of jobs when setting positive range', function(done) {
+      queue.process(function(job, completed) {
         completed();
       });
 
-      queue.on('completed', _.after(3, function () {
-        queue.getJobs('completed', -300, 99999, true).then(function (jobs) {
-          expect(jobs).to.be.an('array').that.has.length(3);
-          expect(jobs[0].data.foo).to.be.equal(1);
-          expect(jobs[1].data.foo).to.be.eql(2);
-          expect(jobs[2].data.foo).to.be.eql(3);
-          done();
-        }).catch(done);
-      }));
+      queue.on(
+        'completed',
+        _.after(3, function() {
+          queue
+            .getJobs('completed', 1, 2, true)
+            .then(function(jobs) {
+              expect(jobs)
+                .to.be.an('array')
+                .that.has.length(2);
+              expect(jobs[0].data.foo).to.be.eql(2);
+              expect(jobs[1].data.foo).to.be.eql(3);
+              expect(jobs[0]).to.have.property('finishedOn');
+              expect(jobs[1]).to.have.property('finishedOn');
+              expect(jobs[0]).to.have.property('processedOn');
+              expect(jobs[1]).to.have.property('processedOn');
+              done();
+            })
+            .catch(done);
+        })
+      );
+
+      queue
+        .add({ foo: 1 })
+        .then(function() {
+          return queue.add({ foo: 2 });
+        })
+        .then(function() {
+          return queue.add({ foo: 3 });
+        });
+    });
+
+    it('should return subset of jobs when setting a negative range', function(done) {
+      queue.process(function(job, completed) {
+        completed();
+      });
+
+      queue.on(
+        'completed',
+        _.after(3, function() {
+          queue
+            .getJobs('completed', -3, -1, true)
+            .then(function(jobs) {
+              expect(jobs)
+                .to.be.an('array')
+                .that.has.length(3);
+              expect(jobs[0].data.foo).to.be.equal(1);
+              expect(jobs[1].data.foo).to.be.eql(2);
+              expect(jobs[2].data.foo).to.be.eql(3);
+              done();
+            })
+            .catch(done);
+        })
+      );
 
       queue.add({ foo: 1 });
       queue.add({ foo: 2 });
       queue.add({ foo: 3 });
     });
 
-    it('should return jobs for multiple types', function (done) {
-      queue.process(function (job, completed) {
+    it('should return subset of jobs when range overflows', function(done) {
+      queue.process(function(job, completed) {
         completed();
       });
 
-      queue.on('completed', _.after(2, function () {
-        queue.pause();
-        queue.getJobs(['completed','wait']).then(function (jobs) {
-          expect(jobs).to.be.an('array');
-          expect(jobs).to.have.length(3);
-          done();
-        }).catch(done);
-      }));
+      queue.on(
+        'completed',
+        _.after(3, function() {
+          queue
+            .getJobs('completed', -300, 99999, true)
+            .then(function(jobs) {
+              expect(jobs)
+                .to.be.an('array')
+                .that.has.length(3);
+              expect(jobs[0].data.foo).to.be.equal(1);
+              expect(jobs[1].data.foo).to.be.eql(2);
+              expect(jobs[2].data.foo).to.be.eql(3);
+              done();
+            })
+            .catch(done);
+        })
+      );
 
       queue.add({ foo: 1 });
       queue.add({ foo: 2 });
       queue.add({ foo: 3 });
     });
 
+    it('should return jobs for multiple types', function(done) {
+      queue.process(function(job, completed) {
+        completed();
+      });
+
+      queue.on(
+        'completed',
+        _.after(2, function() {
+          queue.pause();
+          queue
+            .getJobs(['completed', 'wait'])
+            .then(function(jobs) {
+              expect(jobs).to.be.an('array');
+              expect(jobs).to.have.length(3);
+              done();
+            })
+            .catch(done);
+        })
+      );
+
+      queue.add({ foo: 1 });
+      queue.add({ foo: 2 });
+      queue.add({ foo: 3 });
+    });
   });
 
-  describe('Cleaner', function () {
+  describe('Cleaner', function() {
     var queue;
 
-    beforeEach(function () {
+    beforeEach(function() {
       queue = utils.buildQueue('cleaner' + uuid());
     });
 
-    afterEach(function () {
-      this.timeout(queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount));
+    afterEach(function() {
+      this.timeout(
+        queue.settings.stalledInterval * (1 + queue.settings.maxStalledCount)
+      );
       return queue.close();
     });
 
-    it('should reject the cleaner with no grace', function (done) {
-      queue.clean().then(function () {
-        done(new Error('Promise should not resolve'));
-      }, function (err) {
-        expect(err).to.be.instanceof(Error);
-        done();
-      });
+    it('should reject the cleaner with no grace', function(done) {
+      queue.clean().then(
+        function() {
+          done(new Error('Promise should not resolve'));
+        },
+        function(err) {
+          expect(err).to.be.instanceof(Error);
+          done();
+        }
+      );
     });
 
-    it('should reject the cleaner an unknown type', function (done) {
-      queue.clean(0, 'bad').then(function () {
-        done(new Error('Promise should not resolve'));
-      }, function (e) {
-        expect(e).to.be.instanceof(Error);
-        done();
-      });
+    it('should reject the cleaner an unknown type', function(done) {
+      queue.clean(0, 'bad').then(
+        function() {
+          done(new Error('Promise should not resolve'));
+        },
+        function(e) {
+          expect(e).to.be.instanceof(Error);
+          done();
+        }
+      );
     });
 
-    it('should clean an empty queue', function (done) {
+    it('should clean an empty queue', function(done) {
       queue.clean(0);
-      queue.on('error', function (err) {
+      queue.on('error', function(err) {
         done(err);
       });
-      queue.on('cleaned', function (jobs, type) {
+      queue.on('cleaned', function(jobs, type) {
         expect(type).to.be.eql('completed');
         expect(jobs.length).to.be.eql(0);
         done();
       });
     });
 
-    it('should clean two jobs from the queue', function (done) {
+    it('should clean two jobs from the queue', function(done) {
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         jobDone();
       });
 
-      queue.on('completed', _.after(2, function(){
-        queue.clean(0).then(function (jobs) {
-          expect(jobs.length).to.be.eql(2);
+      queue.on(
+        'completed',
+        _.after(2, function() {
+          queue.clean(0).then(function(jobs) {
+            expect(jobs.length).to.be.eql(2);
+            done();
+          }, done);
+        })
+      );
+    });
+
+    it('should only remove a job outside of the grace period', function(done) {
+      queue.process(function(job, jobDone) {
+        jobDone();
+      });
+      queue.add({ some: 'data' });
+      queue.add({ some: 'data' });
+      Promise.delay(200)
+        .then(function() {
+          queue.add({ some: 'data' });
+          queue.clean(100);
+          return null;
+        })
+        .delay(100)
+        .then(function() {
+          return queue.getCompleted();
+        })
+        .then(function(jobs) {
+          expect(jobs.length).to.be.eql(1);
+          return queue.empty();
+        })
+        .then(function() {
           done();
-        }, done);
-      }));
+        });
     });
 
-    it('should only remove a job outside of the grace period', function (done) {
-      queue.process(function (job, jobDone) {
-        jobDone();
-      });
+    it('should clean all failed jobs', function(done) {
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });
-      Promise.delay(200).then(function () {
-        queue.add({ some: 'data' });
-        queue.clean(100);
-        return null;
-      }).delay(100).then(function () {
-        return queue.getCompleted();
-      }).then(function (jobs) {
-        expect(jobs.length).to.be.eql(1);
-        return queue.empty();
-      }).then(function () {
-        done();
-      });
-    });
-
-    it('should clean all failed jobs', function (done) {
-      queue.add({ some: 'data' });
-      queue.add({ some: 'data' });
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         jobDone(new Error('It failed'));
       });
-      Promise.delay(100).then(function () {
-        return queue.clean(0, 'failed');
-      }).then(function (jobs) {
-        expect(jobs.length).to.be.eql(2);
-        return queue.count();
-      }).then(function (len) {
-        expect(len).to.be.eql(0);
-        done();
-      });
+      Promise.delay(100)
+        .then(function() {
+          return queue.clean(0, 'failed');
+        })
+        .then(function(jobs) {
+          expect(jobs.length).to.be.eql(2);
+          return queue.count();
+        })
+        .then(function(len) {
+          expect(len).to.be.eql(0);
+          done();
+        });
     });
 
-    it('should clean all waiting jobs', function (done) {
+    it('should clean all waiting jobs', function(done) {
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });
-      Promise.delay(100).then(function () {
-        return queue.clean(0, 'wait');
-      }).then(function (jobs) {
-        expect(jobs.length).to.be.eql(2);
-        return queue.count();
-      }).then(function (len) {
-        expect(len).to.be.eql(0);
-        done();
-      });
+      Promise.delay(100)
+        .then(function() {
+          return queue.clean(0, 'wait');
+        })
+        .then(function(jobs) {
+          expect(jobs.length).to.be.eql(2);
+          return queue.count();
+        })
+        .then(function(len) {
+          expect(len).to.be.eql(0);
+          done();
+        });
     });
 
-    it('should clean all delayed jobs', function (done) {
+    it('should clean all delayed jobs', function(done) {
       queue.add({ some: 'data' }, { delay: 5000 });
       queue.add({ some: 'data' }, { delay: 5000 });
-      Promise.delay(100).then(function () {
-        return queue.clean(0, 'delayed');
-      }).then(function (jobs) {
-        expect(jobs.length).to.be.eql(2);
-        return queue.count();
-      }).then(function (len) {
-        expect(len).to.be.eql(0);
-        done();
-      });
+      Promise.delay(100)
+        .then(function() {
+          return queue.clean(0, 'delayed');
+        })
+        .then(function(jobs) {
+          expect(jobs.length).to.be.eql(2);
+          return queue.count();
+        })
+        .then(function(len) {
+          expect(len).to.be.eql(0);
+          done();
+        });
     });
 
-    it('should clean the number of jobs requested', function (done) {
+    it('should clean the number of jobs requested', function(done) {
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });
-      Promise.delay(100).then(function () {
-        return queue.clean(0, 'wait', 1);
-      }).then(function (jobs) {
-        expect(jobs.length).to.be.eql(1);
-        return queue.count();
-      }).then(function (len) {
-        expect(len).to.be.eql(2);
-        done();
-      });
+      Promise.delay(100)
+        .then(function() {
+          return queue.clean(0, 'wait', 1);
+        })
+        .then(function(jobs) {
+          expect(jobs.length).to.be.eql(1);
+          return queue.count();
+        })
+        .then(function(len) {
+          expect(len).to.be.eql(2);
+          done();
+        });
     });
 
-    it('should clean a job without a timestamp', function (done) {
+    it('should clean a job without a timestamp', function(done) {
       var client = new redis(6379, '127.0.0.1', {});
 
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });
-      queue.process(function (job, jobDone) {
+      queue.process(function(job, jobDone) {
         jobDone(new Error('It failed'));
       });
 
-      Promise.delay(100).then(function () {
-        return new Promise(function (resolve) {
-          client.hdel('bull:' + queue.name + ':1', 'timestamp', resolve);
+      Promise.delay(100)
+        .then(function() {
+          return new Promise(function(resolve) {
+            client.hdel('bull:' + queue.name + ':1', 'timestamp', resolve);
+          });
+        })
+        .then(function() {
+          return queue.clean(0, 'failed');
+        })
+        .then(function(jobs) {
+          expect(jobs.length).to.be.eql(2);
+          return queue.getFailed();
+        })
+        .then(function(failed) {
+          expect(failed.length).to.be.eql(0);
+          done();
         });
-      }).then(function () {
-        return queue.clean(0, 'failed');
-      }).then(function (jobs) {
-        expect(jobs.length).to.be.eql(2);
-        return queue.getFailed();
-      }).then(function (failed) {
-        expect(failed.length).to.be.eql(0);
-        done();
-      });
     });
   });
 });

--- a/test/test_rate_limiter.js
+++ b/test/test_rate_limiter.js
@@ -6,12 +6,12 @@ var utils = require('./utils');
 var redis = require('ioredis');
 var _ = require('lodash');
 
-describe('Rate limiter', function () {
+describe('Rate limiter', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     var client = new redis();
-    return client.flushdb().then(function(){
+    return client.flushdb().then(function() {
       queue = utils.buildQueue('test rate limiter', {
         limiter: {
           max: 1,
@@ -22,7 +22,7 @@ describe('Rate limiter', function () {
     });
   });
 
-  afterEach(function(){
+  afterEach(function() {
     return queue.close();
   });
 
@@ -34,20 +34,24 @@ describe('Rate limiter', function () {
       return Promise.resolve();
     });
 
-    for(var i=0; i<numJobs; i++){
+    for (var i = 0; i < numJobs; i++) {
       queue.add({});
     }
 
-    queue.on('completed', _.after(numJobs, function() {
-      try {
-        expect(new Date().getTime() - startTime).to.be.above((numJobs - 1) * 1000);
-        done();
-      } catch (e) {
-        done(e);
-      }
-    }));
+    queue.on(
+      'completed',
+      _.after(numJobs, function() {
+        try {
+          expect(new Date().getTime() - startTime).to.be.above(
+            (numJobs - 1) * 1000
+          );
+          done();
+        } catch (e) {
+          done(e);
+        }
+      })
+    );
 
     queue.on('failed', done);
   });
-
 });

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -14,23 +14,25 @@ var ONE_HOUR = 60 * ONE_MINUTE;
 var ONE_DAY = 24 * ONE_HOUR;
 var MAX_INT = 2147483647;
 
-describe('repeat', function () {
+describe('repeat', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     this.clock = sinon.useFakeTimers();
     var client = new redis();
-    return client.flushdb().then(function(){
-      queue = utils.buildQueue('repeat', {settings: {
-        guardInterval: MAX_INT,
-        stalledInterval: MAX_INT,
-        drainDelay: 1 // Small delay so that .close is faster.
-      }});
+    return client.flushdb().then(function() {
+      queue = utils.buildQueue('repeat', {
+        settings: {
+          guardInterval: MAX_INT,
+          stalledInterval: MAX_INT,
+          drainDelay: 1 // Small delay so that .close is faster.
+        }
+      });
       return queue;
     });
   });
 
-  afterEach(function(){
+  afterEach(function() {
     this.clock.restore();
     return queue.close();
   });
@@ -40,101 +42,144 @@ describe('repeat', function () {
     var customJobIds = ['customjobone', 'customjobtwo'];
 
     Promise.all([
-      queue.add({}, { jobId: customJobIds[0], repeat: { cron: cron }}),
-      queue.add({}, { jobId: customJobIds[1], repeat: { cron: cron }})
-    ]).then(function() {
-      return queue.count();
-    }).then(function(count) {
-      expect(count).to.be.eql(2);
-      done();
-    }).catch(done);
+      queue.add({}, { jobId: customJobIds[0], repeat: { cron: cron } }),
+      queue.add({}, { jobId: customJobIds[1], repeat: { cron: cron } })
+    ])
+      .then(function() {
+        return queue.count();
+      })
+      .then(function(count) {
+        expect(count).to.be.eql(2);
+        done();
+      })
+      .catch(done);
   });
 
   it('should get repeatable jobs with different cron pattern', function(done) {
     var crons = ['10 * * * * *', '2 * * 1 * 2', '1 * * 5 * *', '2 * * 4 * *'];
 
     Promise.all([
-      queue.add('first', {}, { repeat: { cron: crons[0], endDate: 12345 }}),
-      queue.add('second', {}, { repeat: { cron: crons[1], endDate: 54321 }}),
-      queue.add('third', {}, { repeat: { cron: crons[2], tz: 'Africa/Abidjan' }}),
-      queue.add('fourth', {}, { repeat: { cron: crons[3], tz: 'Africa/Accra' }}),
-    ]).then(function() {
-      return queue.getRepeatableCount();
-    }).then(function(count){
-      expect(count).to.be.eql(4);
-      return queue.getRepeatableJobs(0, -1, true);
-    }).then(function(jobs){
-      expect(jobs).to.be.and.an('array').and.have.length(4);
-      expect(jobs[0]).to.include({cron: '2 * * 1 * 2', next: 2000, endDate: 54321});
-      expect(jobs[1]).to.include({cron: '10 * * * * *', next: 10000, endDate: 12345 });
-      expect(jobs[2]).to.include({cron: '2 * * 4 * *', next: 259202000, tz: 'Africa/Accra'});
-      expect(jobs[3]).to.include({cron: '1 * * 5 * *', next: 345601000, tz: 'Africa/Abidjan'});
-      done();
-    }).catch(done);
+      queue.add('first', {}, { repeat: { cron: crons[0], endDate: 12345 } }),
+      queue.add('second', {}, { repeat: { cron: crons[1], endDate: 54321 } }),
+      queue.add(
+        'third',
+        {},
+        { repeat: { cron: crons[2], tz: 'Africa/Abidjan' } }
+      ),
+      queue.add(
+        'fourth',
+        {},
+        { repeat: { cron: crons[3], tz: 'Africa/Accra' } }
+      )
+    ])
+      .then(function() {
+        return queue.getRepeatableCount();
+      })
+      .then(function(count) {
+        expect(count).to.be.eql(4);
+        return queue.getRepeatableJobs(0, -1, true);
+      })
+      .then(function(jobs) {
+        expect(jobs)
+          .to.be.and.an('array')
+          .and.have.length(4);
+        expect(jobs[0]).to.include({
+          cron: '2 * * 1 * 2',
+          next: 2000,
+          endDate: 54321
+        });
+        expect(jobs[1]).to.include({
+          cron: '10 * * * * *',
+          next: 10000,
+          endDate: 12345
+        });
+        expect(jobs[2]).to.include({
+          cron: '2 * * 4 * *',
+          next: 259202000,
+          tz: 'Africa/Accra'
+        });
+        expect(jobs[3]).to.include({
+          cron: '1 * * 5 * *',
+          next: 345601000,
+          tz: 'Africa/Abidjan'
+        });
+        done();
+      })
+      .catch(done);
   });
 
-  it('should repeat every 2 seconds', function (done) {
+  it('should repeat every 2 seconds', function(done) {
     var _this = this;
     var date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
     var nextTick = 2 * ONE_SECOND + 500;
 
-    queue.add('repeat', {foo: 'bar'}, { repeat: {cron: '*/2 * * * * *'}}).then(function(){
-      _this.clock.tick(nextTick);
-    });
+    queue
+      .add('repeat', { foo: 'bar' }, { repeat: { cron: '*/2 * * * * *' } })
+      .then(function() {
+        _this.clock.tick(nextTick);
+      });
 
-    queue.process('repeat', function(){
+    queue.process('repeat', function() {
       // dummy
     });
 
     var prev;
     var counter = 0;
-    queue.on('completed', function(job){
+    queue.on('completed', function(job) {
       _this.clock.tick(nextTick);
-      if(prev){
+      if (prev) {
         expect(prev.timestamp).to.be.lt(job.timestamp);
         expect(job.timestamp - prev.timestamp).to.be.gte(2000);
       }
       prev = job;
-      counter ++;
-      if(counter == 20){
+      counter++;
+      if (counter == 20) {
         done();
       }
     });
   });
 
-  it('should repeat once a day for 5 days', function (done) {
+  it('should repeat once a day for 5 days', function(done) {
     var _this = this;
     var date = new Date('2017-05-05 13:12:00');
     this.clock.tick(date.getTime());
     var nextTick = ONE_DAY;
 
-    queue.add('repeat', {foo: 'bar'}, {repeat: {
-      cron: '0 1 * * *',
-      endDate: new Date('2017-05-10 13:12:00')}
-    }).then(function(){
-      _this.clock.tick(nextTick);
-    });
+    queue
+      .add(
+        'repeat',
+        { foo: 'bar' },
+        {
+          repeat: {
+            cron: '0 1 * * *',
+            endDate: new Date('2017-05-10 13:12:00')
+          }
+        }
+      )
+      .then(function() {
+        _this.clock.tick(nextTick);
+      });
 
-    queue.process('repeat', function(){
+    queue.process('repeat', function() {
       // Dummy
     });
 
     var prev;
     var counter = 0;
-    queue.on('completed', function(job){
+    queue.on('completed', function(job) {
       _this.clock.tick(nextTick);
-      if(prev){
+      if (prev) {
         expect(prev.timestamp).to.be.lt(job.timestamp);
         expect(job.timestamp - prev.timestamp).to.be.gte(ONE_DAY);
       }
       prev = job;
-      
-      counter ++;
-      if(counter == 5){
-        queue.getWaiting().then(function(jobs){
+
+      counter++;
+      if (counter == 5) {
+        queue.getWaiting().then(function(jobs) {
           expect(jobs.length).to.be.eql(0);
-          queue.getDelayed().then(function(jobs){
+          queue.getDelayed().then(function(jobs) {
             expect(jobs.length).to.be.eql(0);
             done();
           });
@@ -143,52 +188,58 @@ describe('repeat', function () {
     });
   });
 
-  it('should repeat 7:th day every month at 9:25', function (done) {
+  it('should repeat 7:th day every month at 9:25', function(done) {
     var _this = this;
     var date = new Date('2017-02-02 7:21:42');
     this.clock.tick(date.getTime());
 
-    function nextTick(){
+    function nextTick() {
       var now = moment();
       var nextMonth = moment().add(1, 'months');
       _this.clock.tick(nextMonth - now);
     }
 
-    queue.add('repeat', {foo: 'bar'}, { repeat: {cron: '* 25 9 7 * *'}}).then(function(){
-      nextTick();
-    });
+    queue
+      .add('repeat', { foo: 'bar' }, { repeat: { cron: '* 25 9 7 * *' } })
+      .then(function() {
+        nextTick();
+      });
 
-    queue.process('repeat', function(/*job*/){
+    queue.process('repeat', function(/*job*/) {
       // Dummy
     });
 
     var counter = 20;
     var prev;
-    queue.on('completed', function(job){
-      if(prev){
+    queue.on('completed', function(job) {
+      if (prev) {
         expect(prev.timestamp).to.be.lt(job.timestamp);
-        var diff = moment(job.timestamp).diff(moment(prev.timestamp), 'months', true);
+        var diff = moment(job.timestamp).diff(
+          moment(prev.timestamp),
+          'months',
+          true
+        );
         expect(diff).to.be.gte(1);
       }
       prev = job;
 
-      counter --;
-      if(counter == 0){
+      counter--;
+      if (counter == 0) {
         done();
       }
       nextTick();
     });
   });
 
-  it('should create two jobs with the same ids', function(){
+  it('should create two jobs with the same ids', function() {
     var options = {
       repeat: {
-        cron: '0 1 * * *',
-      },
+        cron: '0 1 * * *'
+      }
     };
 
-    var p1 = queue.add({foo: 'bar'}, options);
-    var p2 = queue.add({foo: 'bar'}, options);
+    var p1 = queue.add({ foo: 'bar' }, options);
+    var p2 = queue.add({ foo: 'bar' }, options);
 
     return Promise.all([p1, p2]).then(function(jobs) {
       expect(jobs.length).to.be.eql(2);
@@ -196,79 +247,39 @@ describe('repeat', function () {
     });
   });
 
-  it('should allow removing a named repeatable job', function(done){
+  it('should allow removing a named repeatable job', function(done) {
     var _this = this;
     var date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
 
     var nextTick = 2 * ONE_SECOND;
-    var repeat = {cron: '*/2 * * * * *'};
+    var repeat = { cron: '*/2 * * * * *' };
 
-    queue.add('remove', {foo: 'bar'}, {repeat: repeat}).then(function(){
+    queue.add('remove', { foo: 'bar' }, { repeat: repeat }).then(function() {
       _this.clock.tick(nextTick);
     });
 
-    queue.process('remove', function(){
-      counter ++;
-      if(counter == 20){
-        return queue.removeRepeatable('remove', repeat).then(function(){
-          _this.clock.tick(nextTick);          
-          return queue.getDelayed().then(function(delayed){
-            expect(delayed).to.be.empty;
-            done();
-            return null;
-          });
-        });
-      } else if (counter > 20){
-        done(Error('should not repeat more than 20 times'));
-      }
-    });
-
-    var prev;
-    var counter = 0;
-    queue.on('completed', function(job){
-      _this.clock.tick(nextTick);
-      if(prev){
-        expect(prev.timestamp).to.be.lt(job.timestamp);
-        expect(job.timestamp - prev.timestamp).to.be.gte(2000);
-      }
-      prev = job;
-    });
-  });
-
-  it('should allow removing a customId repeatable job', function(done){
-    var _this = this;
-    var date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
-
-    var nextTick = 2 * ONE_SECOND;
-    var repeat = {cron: '*/2 * * * * *'};
-
-    queue.add({foo: 'bar'}, {repeat: repeat, jobId : 'xxxx'}).then(function(){
-      _this.clock.tick(nextTick);
-    });
-
-    queue.process(function(){
-      counter ++;
-      if(counter == 20){        
-        return queue.removeRepeatable(_.defaults({jobId:'xxxx'}, repeat)).then(function(){
+    queue.process('remove', function() {
+      counter++;
+      if (counter == 20) {
+        return queue.removeRepeatable('remove', repeat).then(function() {
           _this.clock.tick(nextTick);
-          return queue.getDelayed().then(function(delayed){
+          return queue.getDelayed().then(function(delayed) {
             expect(delayed).to.be.empty;
             done();
             return null;
           });
         });
-      } else if (counter > 20){
+      } else if (counter > 20) {
         done(Error('should not repeat more than 20 times'));
       }
     });
 
     var prev;
     var counter = 0;
-    queue.on('completed', function(job){
+    queue.on('completed', function(job) {
       _this.clock.tick(nextTick);
-      if(prev){
+      if (prev) {
         expect(prev.timestamp).to.be.lt(job.timestamp);
         expect(job.timestamp - prev.timestamp).to.be.gte(2000);
       }
@@ -276,70 +287,134 @@ describe('repeat', function () {
     });
   });
 
-  it('should allow adding a repeatable job after removing it', function(){
-    
+  it('should allow removing a customId repeatable job', function(done) {
+    var _this = this;
+    var date = new Date('2017-02-07 9:24:00');
+    this.clock.tick(date.getTime());
+
+    var nextTick = 2 * ONE_SECOND;
+    var repeat = { cron: '*/2 * * * * *' };
+
+    queue
+      .add({ foo: 'bar' }, { repeat: repeat, jobId: 'xxxx' })
+      .then(function() {
+        _this.clock.tick(nextTick);
+      });
+
+    queue.process(function() {
+      counter++;
+      if (counter == 20) {
+        return queue
+          .removeRepeatable(_.defaults({ jobId: 'xxxx' }, repeat))
+          .then(function() {
+            _this.clock.tick(nextTick);
+            return queue.getDelayed().then(function(delayed) {
+              expect(delayed).to.be.empty;
+              done();
+              return null;
+            });
+          });
+      } else if (counter > 20) {
+        done(Error('should not repeat more than 20 times'));
+      }
+    });
+
+    var prev;
+    var counter = 0;
+    queue.on('completed', function(job) {
+      _this.clock.tick(nextTick);
+      if (prev) {
+        expect(prev.timestamp).to.be.lt(job.timestamp);
+        expect(job.timestamp - prev.timestamp).to.be.gte(2000);
+      }
+      prev = job;
+    });
+  });
+
+  it('should allow adding a repeatable job after removing it', function() {
     queue.process(function(/*job*/) {
       // dummy
     });
-        
+
     var repeat = {
-      cron: '*/5 * * * *',
+      cron: '*/5 * * * *'
     };
-    
-    return queue.add('myTestJob', {
-      data: '2',
-    }, {
-      repeat: repeat,
-    }).then(function(){
-      return queue.getDelayed();
-    }).then(function(delayed){
-      expect(delayed.length).to.be.eql(1);
-    }).then(function(){
-      return queue.removeRepeatable('myTestJob', repeat);
-    }).then(function(){
-      return queue.getDelayed();
-    }).then(function(delayed){
-      expect(delayed.length).to.be.eql(0);
-    }).then(function(){
-      return queue.add('myTestJob', {
-        data: '2',
-      }, {
-        repeat: repeat,
+
+    return queue
+      .add(
+        'myTestJob',
+        {
+          data: '2'
+        },
+        {
+          repeat: repeat
+        }
+      )
+      .then(function() {
+        return queue.getDelayed();
+      })
+      .then(function(delayed) {
+        expect(delayed.length).to.be.eql(1);
+      })
+      .then(function() {
+        return queue.removeRepeatable('myTestJob', repeat);
+      })
+      .then(function() {
+        return queue.getDelayed();
+      })
+      .then(function(delayed) {
+        expect(delayed.length).to.be.eql(0);
+      })
+      .then(function() {
+        return queue.add(
+          'myTestJob',
+          {
+            data: '2'
+          },
+          {
+            repeat: repeat
+          }
+        );
+      })
+      .then(function() {
+        return queue.getDelayed();
+      })
+      .then(function(delayed) {
+        expect(delayed.length).to.be.eql(1);
       });
-    }).then(function(){
-      return queue.getDelayed();
-    }).then(function(delayed){
-      expect(delayed.length).to.be.eql(1);
-    });  
   });
 
-  it('should not repeat more than 5 times', function (done) {
+  it('should not repeat more than 5 times', function(done) {
     var _this = this;
     var date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
     var nextTick = ONE_SECOND + 500;
 
-    queue.add('repeat', {foo: 'bar'}, { repeat: {limit: 5, cron: '*/1 * * * * *'}}).then(function(){
-      _this.clock.tick(nextTick);
-    });
+    queue
+      .add(
+        'repeat',
+        { foo: 'bar' },
+        { repeat: { limit: 5, cron: '*/1 * * * * *' } }
+      )
+      .then(function() {
+        _this.clock.tick(nextTick);
+      });
 
-    queue.process('repeat', function(){
+    queue.process('repeat', function() {
       // dummy
     });
 
     var counter = 0;
-    queue.on('completed', function(){
+    queue.on('completed', function() {
       _this.clock.tick(nextTick);
       counter++;
-      if(counter == 5){
-        utils.sleep(nextTick*2).then(function() {
+      if (counter == 5) {
+        utils.sleep(nextTick * 2).then(function() {
           done();
-        }, nextTick*2);
-      }
-      else if (counter > 5) {
+        }, nextTick * 2);
+      } else if (counter > 5) {
         done(Error('should not repeat more than 5 times'));
       }
     });
   });
-
 });

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -7,34 +7,36 @@ var utils = require('./utils');
 var redis = require('ioredis');
 var _ = require('lodash');
 
-describe('sandboxed process', function () {
+describe('sandboxed process', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     var client = new redis();
-    return client.flushdb().then(function(){
-      queue = utils.buildQueue('test process', {settings: {
-        guardInterval: 300000,
-        stalledInterval: 300000,
-      }});
+    return client.flushdb().then(function() {
+      queue = utils.buildQueue('test process', {
+        settings: {
+          guardInterval: 300000,
+          stalledInterval: 300000
+        }
+      });
       return queue;
     });
   });
 
-  afterEach(function(){
-    return queue.close().then(function(){
+  afterEach(function() {
+    return queue.close().then(function() {
       var client = new redis();
       return client.flushall();
     });
   });
 
-  it('should process and complete', function (done) {
+  it('should process and complete', function(done) {
     var processFile = __dirname + '/fixtures/fixture_processor.js';
     queue.process(processFile);
 
-    queue.on('completed', function(job, value){
+    queue.on('completed', function(job, value) {
       try {
-        expect(job.data).to.be.eql({foo:'bar'});
+        expect(job.data).to.be.eql({ foo: 'bar' });
         expect(value).to.be.eql(42);
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
         expect(queue.childPool.free[processFile]).to.have.lengthOf(1);
@@ -44,16 +46,16 @@ describe('sandboxed process', function () {
       }
     });
 
-    queue.add({foo:'bar'});
+    queue.add({ foo: 'bar' });
   });
 
-  it('should process with named processor', function (done) {
+  it('should process with named processor', function(done) {
     var processFile = __dirname + '/fixtures/fixture_processor.js';
     queue.process('foobar', processFile);
 
-    queue.on('completed', function(job, value){
+    queue.on('completed', function(job, value) {
       try {
-        expect(job.data).to.be.eql({foo:'bar'});
+        expect(job.data).to.be.eql({ foo: 'bar' });
         expect(value).to.be.eql(42);
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
         expect(queue.childPool.free[processFile]).to.have.lengthOf(1);
@@ -63,27 +65,27 @@ describe('sandboxed process', function () {
       }
     });
 
-    queue.add('foobar', {foo:'bar'});
+    queue.add('foobar', { foo: 'bar' });
   });
 
-  it('should process with several named processors', function (done) {
-    var processFileFoo =  __dirname + '/fixtures/fixture_processor_foo.js';
-    var processFileBar =  __dirname + '/fixtures/fixture_processor_bar.js';
-    
+  it('should process with several named processors', function(done) {
+    var processFileFoo = __dirname + '/fixtures/fixture_processor_foo.js';
+    var processFileBar = __dirname + '/fixtures/fixture_processor_bar.js';
+
     queue.process('foo', processFileFoo);
     queue.process('bar', processFileBar);
-    
+
     var count = 0;
-    queue.on('completed', function(job, value){
+    queue.on('completed', function(job, value) {
       var data, result, processFile, retainedLength;
       count++;
-      if(count == 1){
-        data = {foo: 'bar'};
+      if (count == 1) {
+        data = { foo: 'bar' };
         result = 'foo';
         processFile = processFileFoo;
         retainedLength = 1;
-      }else {
-        data = {bar: 'qux'};
+      } else {
+        data = { bar: 'qux' };
         result = 'bar';
         processFile = processFileBar;
         retainedLength = 0;
@@ -92,9 +94,11 @@ describe('sandboxed process', function () {
       try {
         expect(job.data).to.be.eql(data);
         expect(value).to.be.eql(result);
-        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(retainedLength);
+        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(
+          retainedLength
+        );
         expect(queue.childPool.free[processFile]).to.have.lengthOf(1);
-        if(count === 2){
+        if (count === 2) {
           done();
         }
       } catch (err) {
@@ -103,26 +107,29 @@ describe('sandboxed process', function () {
       }
     });
 
-    queue.add('foo', {foo: 'bar'}).then(function(){
-      Promise.delay(500).then(function(){
-        queue.add('bar', {bar: 'qux'});
+    queue.add('foo', { foo: 'bar' }).then(function() {
+      Promise.delay(500).then(function() {
+        queue.add('bar', { bar: 'qux' });
       });
     });
 
-    queue.on('error', function(err){
+    queue.on('error', function(err) {
       console.error(err);
     });
   });
 
-  it('should process with concurrent processors', function (done) {
-    var after = _.after(4, function(){
+  it('should process with concurrent processors', function(done) {
+    var after = _.after(4, function() {
       expect(queue.childPool.getAllFree().length).to.eql(4);
       done();
     });
-    queue.on('completed', function(job, value){
+    queue.on('completed', function(job, value) {
       try {
         expect(value).to.be.eql(42);
-        expect(Object.keys(queue.childPool.retained).length + queue.childPool.getAllFree().length).to.eql(4);
+        expect(
+          Object.keys(queue.childPool.retained).length +
+            queue.childPool.getAllFree().length
+        ).to.eql(4);
         after();
       } catch (err) {
         done(err);
@@ -130,21 +137,21 @@ describe('sandboxed process', function () {
     });
 
     Promise.all([
-      queue.add({foo:'bar1'}),
-      queue.add({foo:'bar2'}),
-      queue.add({foo:'bar3'}),
-      queue.add({foo:'bar4'})
+      queue.add({ foo: 'bar1' }),
+      queue.add({ foo: 'bar2' }),
+      queue.add({ foo: 'bar3' }),
+      queue.add({ foo: 'bar4' })
     ]).then(function() {
-      queue.process(4, __dirname + '/fixtures/fixture_processor_slow.js');      
+      queue.process(4, __dirname + '/fixtures/fixture_processor_slow.js');
     });
   });
 
-  it('should process and complete using done', function (done) {
+  it('should process and complete using done', function(done) {
     queue.process(__dirname + '/fixtures/fixture_processor_callback.js');
 
-    queue.on('completed', function(job, value){
+    queue.on('completed', function(job, value) {
       try {
-        expect(job.data).to.be.eql({foo:'bar'});
+        expect(job.data).to.be.eql({ foo: 'bar' });
         expect(value).to.be.eql(42);
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
         expect(queue.childPool.getAllFree()).to.have.lengthOf(1);
@@ -154,15 +161,15 @@ describe('sandboxed process', function () {
       }
     });
 
-    queue.add({foo:'bar'});
+    queue.add({ foo: 'bar' });
   });
 
-  it('should process and update progress', function (done) {
+  it('should process and update progress', function(done) {
     queue.process(__dirname + '/fixtures/fixture_processor_progress.js');
 
-    queue.on('completed', function(job, value){
+    queue.on('completed', function(job, value) {
       try {
-        expect(job.data).to.be.eql({foo:'bar'});
+        expect(job.data).to.be.eql({ foo: 'bar' });
         expect(value).to.be.eql(37);
         expect(job.progress()).to.be.eql(100);
         expect(progresses).to.be.eql([10, 27, 78, 100]);
@@ -175,19 +182,19 @@ describe('sandboxed process', function () {
     });
 
     var progresses = [];
-    queue.on('progress', function(job, progress){
+    queue.on('progress', function(job, progress) {
       progresses.push(progress);
     });
 
-    queue.add({foo:'bar'});
+    queue.add({ foo: 'bar' });
   });
 
-  it('should process and fail', function (done) {
+  it('should process and fail', function(done) {
     queue.process(__dirname + '/fixtures/fixture_processor_fail.js');
 
-    queue.on('failed', function(job, err){
+    queue.on('failed', function(job, err) {
       try {
-        expect(job.data).eql({foo:'bar'});
+        expect(job.data).eql({ foo: 'bar' });
         expect(job.failedReason).eql('Manually failed processor');
         expect(err.message).eql('Manually failed processor');
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
@@ -198,15 +205,15 @@ describe('sandboxed process', function () {
       }
     });
 
-    queue.add({foo:'bar'});
+    queue.add({ foo: 'bar' });
   });
 
-  it('should process and fail', function (done) {
+  it('should process and fail', function(done) {
     queue.process(__dirname + '/fixtures/fixture_processor_callback_fail.js');
 
-    queue.on('failed', function(job, err){
+    queue.on('failed', function(job, err) {
       try {
-        expect(job.data).eql({foo:'bar'});
+        expect(job.data).eql({ foo: 'bar' });
         expect(job.failedReason).eql('Manually failed processor');
         expect(err.message).eql('Manually failed processor');
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
@@ -217,25 +224,27 @@ describe('sandboxed process', function () {
       }
     });
 
-    queue.add({foo:'bar'});
+    queue.add({ foo: 'bar' });
   });
 
-  it('should remove exited process', function (done) {
+  it('should remove exited process', function(done) {
     queue.process(__dirname + '/fixtures/fixture_processor_exit.js');
 
-    queue.on('completed', function(){
+    queue.on('completed', function() {
       try {
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
         expect(queue.childPool.getAllFree()).to.have.lengthOf(1);
-        Promise.delay(500).then(function(){
-          expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
-          expect(queue.childPool.getAllFree()).to.have.lengthOf(0);
-        }).asCallback(done);
+        Promise.delay(500)
+          .then(function() {
+            expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
+            expect(queue.childPool.getAllFree()).to.have.lengthOf(0);
+          })
+          .asCallback(done);
       } catch (err) {
         done(err);
       }
     });
 
-    queue.add({foo:'bar'});
+    queue.add({ foo: 'bar' });
   });
 });

--- a/test/test_worker.js
+++ b/test/test_worker.js
@@ -5,30 +5,31 @@ var expect = require('chai').expect;
 var utils = require('./utils');
 var redis = require('ioredis');
 
-describe('workers', function () {
+describe('workers', function() {
   var queue;
 
-  beforeEach(function(){
+  beforeEach(function() {
     var client = new redis();
-    return client.flushdb().then(function(){
-      queue = utils.buildQueue('test workers', {settings: {
-        guardInterval: 300000,
-        stalledInterval: 300000
-      }});
+    return client.flushdb().then(function() {
+      queue = utils.buildQueue('test workers', {
+        settings: {
+          guardInterval: 300000,
+          stalledInterval: 300000
+        }
+      });
       return queue;
     });
   });
 
-  afterEach(function(){
+  afterEach(function() {
     return queue.close();
   });
 
-  it('should get all workers for this queue', function () {
-    queue.process(function(){});
+  it('should get all workers for this queue', function() {
+    queue.process(function() {});
 
-    return queue.getWorkers().then(function(workers){
+    return queue.getWorkers().then(function(workers) {
       expect(workers).to.have.length(1);
     });
-    
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -10,19 +10,19 @@ var queues = [];
 
 var originalSetTimeout = setTimeout;
 
-function simulateDisconnect(queue){
+function simulateDisconnect(queue) {
   queue.client.disconnect();
   queue.eclient.disconnect();
 }
 
 function buildQueue(name, options) {
-  options = _.extend({redis: {port: 6379, host: '127.0.0.1'}}, options);
+  options = _.extend({ redis: { port: 6379, host: '127.0.0.1' } }, options);
   var queue = new Queue(name || STD_QUEUE_NAME, options);
   queues.push(queue);
   return queue;
 }
 
-function newQueue(name, opts){
+function newQueue(name, opts) {
   var queue = buildQueue(name, opts);
   return queue.isReady();
 }
@@ -32,16 +32,16 @@ function cleanupQueue(queue) {
 }
 
 function cleanupQueues() {
-  return Promise.map(queues, function(queue){
+  return Promise.map(queues, function(queue) {
     var errHandler = function() {};
     queue.on('error', errHandler);
     return queue.close().catch(errHandler);
-  }).then(function(){
+  }).then(function() {
     queues = [];
   });
 }
 
-function sleep(ms){
+function sleep(ms) {
   return new Promise(function(resolve) {
     originalSetTimeout(function() {
       resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-escapes@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -65,11 +69,19 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+any-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 argparse@^1.0.7:
   version "1.0.9"
@@ -200,7 +212,7 @@ chai@^4.0.2:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -218,6 +230,14 @@ chalk@^2.0.0, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.0.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.1.tgz#523fe2678aec7b04e8041909292fe8b17059b796"
+  dependencies:
+    ansi-styles "^3.2.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.2.0"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -226,15 +246,36 @@ check-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
+ci-info@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
+
 circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+
+cli-cursor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
 
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -255,6 +296,10 @@ cluster-key-slot@^1.0.6:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 color-convert@^1.9.0:
   version "1.9.1"
@@ -278,6 +323,10 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.11.0, commander@^2.9.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -293,6 +342,15 @@ concat-stream@^1.6.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+    require-from-string "^2.0.1"
 
 coveralls@^3.0.0:
   version "3.0.0"
@@ -311,7 +369,7 @@ cron-parser@^2.4.1:
     is-nan "^1.2.1"
     moment-timezone "^0.5.0"
 
-cross-spawn@^5.1.0:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -330,6 +388,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
 debug@2.6.8:
   version "2.6.8"
@@ -356,6 +418,10 @@ debuglog@^1.0.0:
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
 deep-eql@^3.0.0:
   version "3.0.1"
@@ -409,6 +475,16 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
+error-ex@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  dependencies:
+    is-arrayish "^0.2.1"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -518,6 +594,22 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+
 expect.js@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/expect.js/-/expect.js-0.3.1.tgz#b0a59a0d2eff5437544ebf0ceaa6015841d09b5b"
@@ -554,6 +646,13 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+figures@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -566,6 +665,10 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -613,6 +716,14 @@ functional-red-black-tree@^1.0.1:
 get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
+get-own-enumerable-property-symbols@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz#5c4ad87f2834c4b9b4e84549dc1e0650fb38c24b"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -714,6 +825,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 hawk@~6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
@@ -739,6 +854,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -750,6 +873,16 @@ ignore@^3.3.3:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -813,19 +946,65 @@ ioredis@^3.1.4:
     redis-commands "^1.2.0"
     redis-parser "^2.4.0"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
+is-finite@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
+  dependencies:
+    number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  dependencies:
+    number-is-nan "^1.0.0"
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-nan@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-nan/-/is-nan-1.2.1.tgz#9faf65b6fb6db24b7f5c0628475ea71f988401e2"
   dependencies:
     define-properties "^1.1.1"
+
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+
+is-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
+  dependencies:
+    symbol-observable "^0.2.2"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -847,9 +1026,17 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -886,11 +1073,24 @@ istanbul@^0.4.5:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+
+jest-validate@^21.1.0:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^21.2.0"
+    leven "^2.1.0"
+    pretty-format "^21.2.1"
+
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.x, js-yaml@^3.6.1, js-yaml@^3.9.1:
+js-yaml@3.x, js-yaml@^3.6.1, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -900,6 +1100,10 @@ js-yaml@3.x, js-yaml@^3.6.1, js-yaml@^3.9.1:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz#50183cd1b2d25275de069e9e71b467ac9eab973a"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -944,12 +1148,89 @@ lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lint-staged@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-6.1.0.tgz#28f600c10a6cbd249ceb003118a1552e53544a93"
+  dependencies:
+    app-root-path "^2.0.0"
+    chalk "^2.1.0"
+    commander "^2.11.0"
+    cosmiconfig "^4.0.0"
+    debug "^3.1.0"
+    dedent "^0.7.0"
+    execa "^0.8.0"
+    find-parent-dir "^0.3.0"
+    is-glob "^4.0.0"
+    jest-validate "^21.1.0"
+    listr "^0.13.0"
+    lodash "^4.17.4"
+    log-symbols "^2.0.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    path-is-inside "^1.0.2"
+    pify "^3.0.0"
+    staged-git-files "0.0.4"
+    stringify-object "^3.2.0"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.13.0.tgz#20bb0ba30bae660ee84cc0503df4be3d5623887d"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-observable "^0.2.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.4.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.4.2"
+    stream-to-observable "^0.2.0"
+    strip-ansi "^3.0.1"
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"
@@ -1070,6 +1351,25 @@ log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-symbols@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  dependencies:
+    chalk "^2.0.1"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
+
 lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
@@ -1099,7 +1399,7 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -1172,11 +1472,39 @@ nopt@3.x:
   dependencies:
     abbrev "1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
+npm-path@^2.0.2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.4.tgz#c641347a5ff9d6a09e4d9bce5580c4f505278e64"
+  dependencies:
+    which "^1.2.10"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
 oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1189,6 +1517,10 @@ once@1.x, once@^1.3.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -1214,9 +1546,33 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -1225,6 +1581,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 pathval@^1.0.0:
   version "1.1.0"
@@ -1237,6 +1597,10 @@ performance-now@^2.1.0:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -1255,6 +1619,17 @@ pluralize@^7.0.0:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prettier@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -1300,6 +1675,12 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
+repeating@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
+  dependencies:
+    is-finite "^1.0.0"
+
 request@^2.79.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
@@ -1327,6 +1708,10 @@ request@^2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
+
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -1341,6 +1726,13 @@ resolve-from@^1.0.0:
 resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -1377,6 +1769,12 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rxjs@^5.4.2:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -1403,7 +1801,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -1415,6 +1813,10 @@ sinon@^1.17.7:
     lolex "1.3.2"
     samsam "1.1.2"
     util ">=0.10.3 <1"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -1462,6 +1864,24 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
+stream-to-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
+  dependencies:
+    any-observable "^0.2.0"
+
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -1475,11 +1895,19 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
+stringify-object@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
+  dependencies:
+    get-own-enumerable-property-symbols "^2.0.1"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
+
 stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
-strip-ansi@^3.0.0:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
@@ -1490,6 +1918,14 @@ strip-ansi@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -1516,6 +1952,20 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
+
+supports-color@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
+symbol-observable@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
 table@^4.0.1:
   version "4.0.2"
@@ -1607,7 +2057,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-which@^1.1.1, which@^1.2.9:
+which@^1.1.1, which@^1.2.10, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
Prettier is an automatic code formatting tool (similar to `gofmt` in go) which takes care of handling code style for us. Adding it to the repository should mean new contributors can come on board more easily because they don't have to care about writing in a consistent code style, they can just focus on their code and prettier will make sure it's formatted consistently with the rest of the code. (see [the prettier website](https://prettier.io/docs/en/why-prettier.html) for more information)

This PR has four parts:

1. **Set up prettier as a pre-commit hook** (36ec5b7): With `lint-staged` and `husky` prettier now runs before contributors commit. This means everybody can write their code in whatever code style they want, but as soon as they commit it's reformatted to conform the the shared style of the codebase.
2. **Enforce prettier style in CI** (95eef4c): Altough it runs as a precommit hook and thusly all code is formatted, folks could on purpose disable the precommit hook, then commit without reformatting, and then submit a PR. By running prettier in CI with `--list-different` CI will fail if folks do this, in effect enforcing prettier's code style.
3. **Disable the stylistic eslint rules** (eb7e37e): Since prettier now enforces a consistent code style, there's no reason to enforce that again from `eslint`. I've disabled all _stylist_ eslint rules (e.g. `semi`), but left all the error catching ones in place. (e.g. `no-unused-variables`)
4. **Run prettier over the entire codebase to get a consistent style** (e3bcce6)

FWIW, we've added prettier to `styled-components` and `react-boilerplate` and have had 0 complaints overall. It's been a huge success and has made our life much easier, on top of never having to say "Hey, CI failed because you forgot a semicolon. Please add that and push again.". It's amazing and I'd love to have that in bull so folks can contribute to this amazing project more easily.