### PR TITLE
Allow cleaning paused jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1111,9 +1111,8 @@ Queue.prototype.toKey = function(queueType) {
  * grace period.
  *
  * @param {int} grace - The grace period
- * @param {string} [type=completed] - The type of job to clean. Possible values
+ * @param {string} [type=completed] - The type of job to clean. Possible values are completed, wait, active, paused, delayed, failed. Defaults to completed.
  * @param {int} The max number of jobs to clean
- * are completed, waiting, active, delayed, failed. Defaults to completed.
  */
 Queue.prototype.clean = function(grace, type, limit) {
   var _this = this;
@@ -1127,7 +1126,10 @@ Queue.prototype.clean = function(grace, type, limit) {
   }
 
   if (
-    _.indexOf(['completed', 'wait', 'active', 'delayed', 'failed'], type) === -1
+    _.indexOf(
+      ['completed', 'wait', 'active', 'paused', 'delayed', 'failed'],
+      type
+    ) === -1
   ) {
     return Promise.reject(new Error('Cannot clean unkown queue type'));
   }


### PR DESCRIPTION
The underlying cleanInJobsSet supports it. Or is that a legacy thing?