### PR TITLE
Fixes #893: A promise was rejected with a non-error.

### DIFF
--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -59,7 +59,7 @@ process.on('message', function(msg) {
           function(err) {
             process.send({
               cmd: 'failed',
-              value: err
+              value: err.message || err
             });
           }
         )

--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -20,7 +20,7 @@ module.exports = function(processFile, childPool) {
             case 'failed':
             case 'error':
               child.removeListener('message', handler);
-              reject(msg.value);
+              reject(new Error(msg.value));
               break;
             case 'progress':
               job.progress(msg.value);


### PR DESCRIPTION
Instead of returning the error message in sandbox.js we return an Error object. To have a clean error message in the queue later on we must use the message property of the err object (if present) as error value in master.js.