### PR TITLE
docs: remove rogue 's'

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -90,7 +90,7 @@ interface AdvancedSettings {
   lockDuration: number = 30000; // Key expiration time for job locks.
   stalledInterval: number = 30000; // How often check for stalled jobs (use 0 for never checking).
   maxStalledCount: number = 1; // Max amount of times a stalled job will be re-processed.
-  guardInterval: number = 5000; // Poll interval for delayed jobs and added jobs.s
+  guardInterval: number = 5000; // Poll interval for delayed jobs and added jobs.
   retryProcessDelay: number = 5000; // delay before processing next job in case of internal error.
   backoffStrategies: {}; // A set of custom backoff strategies keyed by name.
 }


### PR DESCRIPTION
Removes random `s` character from docs.