### PR TITLE
Add drainDelay to the docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -93,6 +93,7 @@ interface AdvancedSettings {
   guardInterval: number = 5000; // Poll interval for delayed jobs and added jobs.
   retryProcessDelay: number = 5000; // delay before processing next job in case of internal error.
   backoffStrategies: {}; // A set of custom backoff strategies keyed by name.
+  drainDelay: number = 5; // A timeout for when the queue is in drained state (empty waiting for jobs).
 }
 ```
 
@@ -113,6 +114,8 @@ __Warning:__ Do not override these advanced settings unless you understand the i
 `retryProcessDelay`: Time in milliseconds in which to wait before trying to process jobs, in case of a Redis error. Set to a lower value on an unstable Redis connection.
 
 `backoffStrategies`: An object containing custom backoff strategies. The key in the object is the name of the strategy and the value is a function that should return the delay in milliseconds. For a full example see [Patterns](./PATTERNS.md#custom-backoff-strategy).
+
+`drainDelay`: A timeout for when the queue is in `drained` state (empty waiting for jobs). It is used when calling `queue.getNextJob()`, which will pass itto `.brpoplpush` on the Redis client.
 
 ```js
 backoffStrategies: {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -68,7 +68,8 @@ var MAX_TIMEOUT_MS = Math.pow(2, 31) - 1; // 32 bit signed
       stalledInterval?: number = 30000,
       maxStalledCount?: number = 1, // The maximum number of times a job can be recovered from the 'stalled' state
       guardInterval?: number = 5000,
-      retryProcessDelay?: number = 5000
+      retryProcessDelay?: number = 5000,
+      drainDelay?: number = 5
     }
   }
 


### PR DESCRIPTION
Seems that the `drainDelay` setting is not present in the docs or types definitions.

Keeping it private may be intentional, or it could be a temporal API, but wasn't sure, I could also add a comment in `lib/queue.js` if that is the case.

Also, the explanation I added may not be complete.

If approved  I could update the TypeScript definitions too:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/625451856aaebad9b6446e3827650f4f2e482d4e/types/bull/index.d.ts#L59

Cheers