### PR TITLE
when --inspect is present, do not pass it on to child processes

### DIFF
--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -20,7 +20,15 @@ module.exports = function ChildPool() {
       return child;
     }
 
-    child = fork(path.join(__dirname, './master.js'));
+    // if node process is running with --inspect, don't include that option
+    // when spawning the children
+    var execArgv = _.filter(process.execArgv, function(arg) {
+        return arg.indexOf('--inspect') === -1
+    })
+
+    child = fork(path.join(__dirname, './master.js'), {
+        execArgv: execArgv
+    });
     child.processFile = processFile;
 
     this.retained[child.pid] = child;

--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -23,11 +23,11 @@ module.exports = function ChildPool() {
     // if node process is running with --inspect, don't include that option
     // when spawning the children
     var execArgv = _.filter(process.execArgv, function(arg) {
-        return arg.indexOf('--inspect') === -1
-    })
+      return arg.indexOf('--inspect') === -1;
+    });
 
     child = fork(path.join(__dirname, './master.js'), {
-        execArgv: execArgv
+      execArgv: execArgv
     });
     child.processFile = processFile;
 


### PR DESCRIPTION
Workaround for #911 

This still isn't _ideal_ because it means the debugger won't be attached to the children processes, but at least it makes it so that bull actually works when using `--inspect` in the main process.

The issue was simply that it was trying to bind to the same host:port as the main process. A robust solution might be some kind of auto-port incrementing algorithm for the children, but that seems like it can become a rather complicated bit of logic.

This at least gets us moving forward in a way that still allows us debug our main app and have the job processors pick up their work.