### PR TITLE
fix for issue #903

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -90,9 +90,10 @@ module.exports = function(Queue) {
   };
 
   Queue.prototype.getWaitingCount = function() {
-    return this.getJobCountByTypes('wait');
+    return this.getJobCountByTypes('wait', 'paused');
   };
 
+  // TO BE DEPRECATED
   Queue.prototype.getPausedCount = function() {
     return this.getJobCountByTypes('paused');
   };


### PR DESCRIPTION
```getWaitingCount``` should now return both waiting and paused jobs (since it is the same list in fact, just renamed depending on the current state)