### PR TITLE
Support for milliseconds intervals

### DIFF
--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -27,7 +27,7 @@ module.exports = function(Queue) {
     var now = Date.now();
     now = prevMillis < now ? now : prevMillis;
 
-    var nextMillis = getNextMillis(now, repeat.cron, repeat);
+    var nextMillis = getNextMillis(now, repeat);
     if (nextMillis) {
       var jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       var repeatJobKey = getRepeatKey(name, repeat, jobId);
@@ -127,13 +127,23 @@ module.exports = function(Queue) {
       ? new Date(repeat.endDate).getTime() + ':'
       : ':';
     var tz = repeat.tz ? repeat.tz + ':' : ':';
-    return name + ':' + jobId + endDate + tz + repeat.cron;
+
+    var suffix = repeat.cron
+      ? tz + repeat.cron
+      : String(repeat.milliseconds || repeat.seconds * 1000);
+
+    return name + ':' + jobId + endDate + suffix;
   }
 
-  function getNextMillis(millis, cron, opts) {
+  function getNextMillis(millis, opts) {
+    var millisInterval = opts.milliseconds || opts.seconds * 1000;
+    if (millisInterval) {
+      return new Date(millis + millisInterval);
+    }
+
     var currentDate = new Date(millis);
     var interval = parser.parseExpression(
-      cron,
+      opts.cron,
       _.defaults(
         {
           currentDate: currentDate

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -32,8 +32,6 @@ module.exports = function(Queue) {
       var jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       var repeatJobKey = getRepeatKey(name, repeat, jobId);
 
-      nextMillis = nextMillis.getTime();
-
       return client
         .zadd(_this.keys.repeat, nextMillis, repeatJobKey)
         .then(function() {
@@ -127,18 +125,22 @@ module.exports = function(Queue) {
       ? new Date(repeat.endDate).getTime() + ':'
       : ':';
     var tz = repeat.tz ? repeat.tz + ':' : ':';
-
-    var suffix = repeat.cron
-      ? tz + repeat.cron
-      : String(repeat.milliseconds || repeat.seconds * 1000);
+    var suffix = repeat.cron ? tz + repeat.cron : String(repeat.every);
 
     return name + ':' + jobId + endDate + suffix;
   }
 
   function getNextMillis(millis, opts) {
-    var millisInterval = opts.milliseconds || opts.seconds * 1000;
-    if (millisInterval) {
-      return new Date(millis + millisInterval);
+    if (opts.cron && opts.every) {
+      _this.emit(
+        'error',
+        new Error('Both .cron and .every are defined for this repeatable job')
+      );
+      return;
+    }
+
+    if (opts.every) {
+      return millis + opts.every;
     }
 
     var currentDate = new Date(millis);
@@ -153,7 +155,7 @@ module.exports = function(Queue) {
     );
 
     try {
-      return interval.next();
+      return interval.next().getTime();
     } catch (e) {
       // Ignore error
     }

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -132,11 +132,9 @@ module.exports = function(Queue) {
 
   function getNextMillis(millis, opts) {
     if (opts.cron && opts.every) {
-      _this.emit(
-        'error',
-        new Error('Both .cron and .every are defined for this repeatable job')
+      throw new Error(
+        'Both .cron and .every options are defined for this repeatable job'
       );
-      return;
     }
 
     if (opts.every) {

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -14,7 +14,7 @@ var ONE_HOUR = 60 * ONE_MINUTE;
 var ONE_DAY = 24 * ONE_HOUR;
 var MAX_INT = 2147483647;
 
-describe('repeat', function() {
+describe.only('repeat', function() {
   var queue;
   var client;
 
@@ -481,5 +481,25 @@ describe('repeat', function() {
         done();
       }
     });
+  });
+
+  it('should throw an error when using .cron and .every simutaneously', function(done) {
+    queue
+      .add(
+        'repeat',
+        { type: 'm' },
+        { repeat: { every: 5000, cron: '*/1 * * * * *' } }
+      )
+      .then(
+        function() {
+          throw new Error('The error was not thrown');
+        },
+        function(err) {
+          expect(err.message).to.be.eql(
+            'Both .cron and .every options are defined for this repeatable job'
+          );
+          done();
+        }
+      );
   });
 });

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -448,17 +448,17 @@ describe('repeat', function() {
     }, done);
   });
 
-  it('should use seconds and milliseconds as valid intervals', function(done) {
+  it('should use ".every" as a valid interval', function(done) {
     var _this = this;
     var date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
     var nextTick = ONE_SECOND + 500;
 
     queue
-      .add('repeat', { type: 'm' }, { repeat: { milliseconds: 2000 } })
+      .add('repeat', { type: 'm' }, { repeat: { every: 2000 } })
       .then(function() {
         _this.clock.tick(ONE_SECOND);
-        return queue.add('repeat', { type: 's' }, { repeat: { seconds: 2 } });
+        return queue.add('repeat', { type: 's' }, { repeat: { every: 2000 } });
       })
       .then(function() {
         _this.clock.tick(nextTick);

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -447,4 +447,39 @@ describe('repeat', function() {
       });
     }, done);
   });
+
+  it('should use seconds and milliseconds as valid intervals', function(done) {
+    var _this = this;
+    var date = new Date('2017-02-07 9:24:00');
+    this.clock.tick(date.getTime());
+    var nextTick = ONE_SECOND + 500;
+
+    queue
+      .add('repeat', { type: 'm' }, { repeat: { milliseconds: 2000 } })
+      .then(function() {
+        _this.clock.tick(ONE_SECOND);
+        return queue.add('repeat', { type: 's' }, { repeat: { seconds: 2 } });
+      })
+      .then(function() {
+        _this.clock.tick(nextTick);
+      });
+
+    queue.process('repeat', function() {
+      // dummy
+    });
+
+    var prevType;
+    var counter = 0;
+    queue.on('completed', function(job) {
+      _this.clock.tick(nextTick);
+      if (prevType) {
+        expect(prevType).to.not.be.eql(job.data.type);
+      }
+      prevType = job.data.type;
+      counter++;
+      if (counter == 20) {
+        done();
+      }
+    });
+  });
 });

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -14,7 +14,7 @@ var ONE_HOUR = 60 * ONE_MINUTE;
 var ONE_DAY = 24 * ONE_HOUR;
 var MAX_INT = 2147483647;
 
-describe.only('repeat', function() {
+describe('repeat', function() {
   var queue;
   var client;
 


### PR DESCRIPTION
With this, the interval can be defined using a more flexible manner than **cron**, which was discussed in #942

For example, when I need a job to execute every 90 minutes, I would do like that:
```javascript
queue.add({ ... }, { repeat: { seconds: 5400 } })
```

I am not sure if it is the best API design for this, maybe the contributors have a better opinion on that. I need to update the reference and the TS definitions too.

We at @rung-tools will be testing this branch with our application to see if it is stable enough, I'll report here if something is not right.