### PR TITLE
Update types array to include paused

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -170,5 +170,5 @@ function parseTypeArg(args) {
 
   return types.length
     ? types
-    : ['waiting', 'paused', 'active', 'completed', 'failed', 'delayed'];
+    : ['waiting', 'active', 'completed', 'failed', 'delayed', 'paused'];
 }

--- a/lib/getters.js
+++ b/lib/getters.js
@@ -170,5 +170,5 @@ function parseTypeArg(args) {
 
   return types.length
     ? types
-    : ['waiting', 'active', 'completed', 'failed', 'delayed'];
+    : ['waiting', 'paused', 'active', 'completed', 'failed', 'delayed'];
 }


### PR DESCRIPTION
getJobsCounts without arguments didn't return paused jobs as 'paused' was not included in types array