### PR TITLE
Remove .getTime call from non-date value

### DIFF
--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -37,8 +37,6 @@ module.exports = function(Queue) {
       var jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       var repeatJobKey = getRepeatKey(name, repeat, jobId);
 
-      nextMillis = nextMillis.getTime();
-
       if (skipCheckExists) return createNextJob();
 
       // Check that the repeatable job hasn't been removed


### PR DESCRIPTION
Hi!

In my previous PR (#944) I changed `getNextMillis` to return a number value, [following this suggestion](https://github.com/OptimalBits/bull/pull/944#discussion_r188696440). Then I took this line out, as it is not a date object anymore.

This line appeared again later, maybe after resolving a merge conflict, perhaps?