### PR TITLE
Add events 'completed' and 'failed' to a Job

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -190,7 +190,7 @@ const emailQueue = new Queue('email')
 emailQueue.process('sendEmail', 25, sendEmail)
 ```
 
-Specifying `*` as the process name will make it the default processor for all named jobs.  
+Specifying `*` as the process name will make it the default processor for all named jobs.
 It is frequently used to process all named jobs from one process function:
 ```js
 const differentJobsQueue = new Queue('differentJobsQueue')
@@ -744,6 +744,21 @@ A queue emits also some useful events:
 });
 
 ```
+
+A job emits some events too:
+
+```js
+.on('failed', function(job, err){
+  // The job failed with reason `err`!
+  // This is fired *after* the queue's `failed` event
+})
+
+.on('completed', function(job, result){
+  // The job successfully completed with a `result`.
+  // This is fired *after* the queue's `completed` event
+})
+```
+
 
 ### Global events
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -3,6 +3,8 @@
 
 var Promise = require('bluebird');
 var _ = require('lodash');
+var EventEmitter = require('events');
+var util = require('util');
 var utils = require('./utils');
 var scripts = require('./scripts');
 var debuglog = require('debuglog')('bull');
@@ -43,6 +45,7 @@ var Job = function(queue, name, data, opts) {
 
   this.toKey = _.bind(queue.toKey, queue);
 };
+util.inherits(Job, EventEmitter);
 
 function setDefaultOpts(opts) {
   var _opts = Object.assign({}, opts);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1002,15 +1002,16 @@ Queue.prototype.processJob = function(job) {
   function handleCompleted(result) {
     return job.moveToCompleted(result).then(function(jobData) {
       _this.emit('completed', job, result, 'active');
+      job.emit('completed', result);
       return jobData ? _this.nextJobFromJobData(jobData[0], jobData[1]) : null;
     });
   }
 
   function handleFailed(err) {
     var error = err.cause || err; //Handle explicit rejection
-
     return job.moveToFailed(err).then(function(jobData) {
       _this.emit('failed', job, error, 'active');
+      job.emit('failed', error);
       return jobData ? _this.nextJobFromJobData(jobData[0], jobData[1]) : null;
     });
   }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1009,6 +1009,7 @@ Queue.prototype.processJob = function(job) {
 
   function handleFailed(err) {
     var error = err.cause || err; //Handle explicit rejection
+
     return job.moveToFailed(err).then(function(jobData) {
       _this.emit('failed', job, error, 'active');
       job.emit('failed', error);

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2318,7 +2318,7 @@ describe('Queue', function() {
     });
 
     it('should emit Job#failed event after processing the job error', function(done) {
-      const jobError = new Error('an error');
+      var jobError = new Error('an error');
       var jobEvent = sinon.spy(function(error) {
         expect(error).to.be.eql(jobError);
         expect(jobEvent.calledAfter(queueEvent)).to.be.ok;

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2298,5 +2298,42 @@ describe('Queue', function() {
           done();
         });
     });
+
+    it('should emit Job#completed after processing the job result', function(done) {
+      var jobEvent = sinon.spy(function(result) {
+        expect(result).to.be.eql('The result');
+        expect(jobEvent.calledAfter(queueEvent)).to.be.ok;
+        done();
+      });
+      var queueEvent = sinon.spy();
+
+      queue.on('completed', queueEvent);
+
+      queue.process(function(job) {
+        job.on('completed', jobEvent);
+        return 'The result';
+      });
+
+      queue.add({ some: 'data' });
+    });
+
+    it('should emit Job#failed event after processing the job error', function(done) {
+      const jobError = new Error('an error');
+      var jobEvent = sinon.spy(function(error) {
+        expect(error).to.be.eql(jobError);
+        expect(jobEvent.calledAfter(queueEvent)).to.be.ok;
+        done();
+      });
+      var queueEvent = sinon.spy();
+
+      queue.on('failed', queueEvent);
+
+      queue.process(function(job) {
+        job.on('failed', jobEvent);
+        throw jobError;
+      });
+
+      queue.add({ some: 'data' });
+    });
   });
 });


### PR DESCRIPTION
This PR makes a Job an EventEmitter, so it can trigger events too. I implemented two events, 'completed' and 'failed'. These events are triggered *after* the queue's events, because there is little value in doing it before: in that case, you could as well run the code handling the event in the Job processor.

Our use case:

We have a WebServer that creates jobs, and a Worker that picks those jobs, generates the output, and then has to do some expensive cleanup before accepting the next job. We can control it with `pause`/`resume`, but it is hard to schedule the cleanup and not interfere with the "main loop". For example, if we use `setTimeout` inside the processor to schedule the clean up, it might end up running before the job is marked as done in Redis, delaying the whole process.

Having a event we can listen to that signals "the job has been processed and handled by the queue" is a great solution for us.



