### PR TITLE
Fixes to deal with removing correctly in priority queues

### DIFF
--- a/lib/commands/removeJob-8.lua
+++ b/lib/commands/removeJob-8.lua
@@ -10,8 +10,7 @@
       KEYS[5] 'completed',
       KEYS[6] 'failed',
       KEYS[7] 'priority',
-      KEYS[8] 'id', 
-      KEYS[9] jobId
+      KEYS[8] jobId
 
       ARGV[1]  jobId
       ARGV[2]  lock token
@@ -22,7 +21,7 @@
 
 -- TODO PUBLISH global event 'removed'
 
-local lockKey = KEYS[9] .. ':lock'
+local lockKey = KEYS[8] .. ':lock'
 local lock = redis.call("GET", lockKey)
 if not lock then             -- or (lock == ARGV[2])) then
   redis.call("LREM", KEYS[1], 0, ARGV[1])
@@ -32,8 +31,7 @@ if not lock then             -- or (lock == ARGV[2])) then
   redis.call("ZREM", KEYS[5], ARGV[1])
   redis.call("ZREM", KEYS[6], ARGV[1])
   redis.call("ZREM", KEYS[7], ARGV[1])
-  redis.call("DECR", KEYS[8])
-  redis.call("DEL", KEYS[9])
+  redis.call("DEL", KEYS[8])
   return 1
 else
   return 0

--- a/lib/commands/removeJob-9.lua
+++ b/lib/commands/removeJob-9.lua
@@ -9,7 +9,9 @@
       KEYS[4] 'paused',
       KEYS[5] 'completed',
       KEYS[6] 'failed',
-      KEYS[7] jobId
+      KEYS[7] 'priority',
+      KEYS[8] 'id', 
+      KEYS[9] jobId -- Index range modified from 7 to 9
 
       ARGV[1]  jobId
       ARGV[2]  lock token
@@ -20,7 +22,7 @@
 
 -- TODO PUBLISH global event 'removed'
 
-local lockKey = KEYS[7] .. ':lock'
+local lockKey = KEYS[9] .. ':lock'
 local lock = redis.call("GET", lockKey)
 if not lock then             -- or (lock == ARGV[2])) then
   redis.call("LREM", KEYS[1], 0, ARGV[1])
@@ -29,7 +31,9 @@ if not lock then             -- or (lock == ARGV[2])) then
   redis.call("LREM", KEYS[4], 0, ARGV[1])
   redis.call("ZREM", KEYS[5], ARGV[1])
   redis.call("ZREM", KEYS[6], ARGV[1])
-  redis.call("DEL", KEYS[7])
+  redis.call("ZREM", KEYS[7], ARGV[1])
+  redis.call("DECR", KEYS[8])
+  redis.call("DEL", KEYS[9])
   return 1
 else
   return 0

--- a/lib/commands/removeJob-9.lua
+++ b/lib/commands/removeJob-9.lua
@@ -11,7 +11,7 @@
       KEYS[6] 'failed',
       KEYS[7] 'priority',
       KEYS[8] 'id', 
-      KEYS[9] jobId -- Index range modified from 7 to 9
+      KEYS[9] jobId
 
       ARGV[1]  jobId
       ARGV[2]  lock token

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -728,6 +728,8 @@ Queue.prototype.empty = function() {
   multi.del(this.toKey('paused'));
   multi.del(this.toKey('meta-paused'));
   multi.del(this.toKey('delayed'));
+  multi.del(this.toKey('priority'));
+  multi.del(this.toKey('id'));
 
   return multi.exec().spread(function(waiting, paused) {
     waiting = waiting[1];

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -729,7 +729,6 @@ Queue.prototype.empty = function() {
   multi.del(this.toKey('meta-paused'));
   multi.del(this.toKey('delayed'));
   multi.del(this.toKey('priority'));
-  multi.del(this.toKey('id'));
 
   return multi.exec().spread(function(waiting, paused) {
     waiting = waiting[1];

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -276,7 +276,16 @@ var scripts = {
 
   remove: function(queue, jobId) {
     var keys = _.map(
-      ['active', 'wait', 'delayed', 'paused', 'completed', 'failed', 'priority', 'id', jobId],
+      [
+        'active',
+        'wait',
+        'delayed',
+        'paused',
+        'completed',
+        'failed',
+        'priority',
+        jobId
+      ],
       function(name) {
         return queue.toKey(name);
       }

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -276,7 +276,7 @@ var scripts = {
 
   remove: function(queue, jobId) {
     var keys = _.map(
-      ['active', 'wait', 'delayed', 'paused', 'completed', 'failed', jobId],
+      ['active', 'wait', 'delayed', 'paused', 'completed', 'failed', 'priority', 'id', jobId],
       function(name) {
         return queue.toKey(name);
       }


### PR DESCRIPTION
These fixes are related to:

  - Fix the removal of jobs in priority queues
  - Fix the command to empty queues completely in the case of priority

This PR solves (at least in our experience) the issue #983 

Co-Authored-By: @pacomf

