### PR TITLE
Add undocumented 'removed' queue event to REFERENCE.md

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -743,6 +743,10 @@ A queue emits also some useful events:
   // Emitted every time the queue has processed all the waiting jobs (even if there can be some delayed jobs not yet processed)
 });
 
+.on('removed', function(job){
+  // A job successfully removed.
+});
+
 ```
 
 ### Global events


### PR DESCRIPTION
This adds the undocumented `queue.on('removed')` event in the docs.

Fixes https://github.com/OptimalBits/bull/issues/846.

I also want to thank you guys for this amazing lib ! :-)