### PR TITLE
Add ability for cron repeatable job with startDate

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -272,8 +272,8 @@ interface JobOpts{
 interface RepeatOpts{
   cron?: string; // Cron string
   tz?: string, // Timezone
-  startDate?: Date | string | number; // Start data when the repeat job should start repeating (only with cron).
-  endDate?: Date | string | number; // End data when the repeat job should stop repeating.
+  startDate?: Date | string | number; // Start date when the repeat job should start repeating (only with cron).
+  endDate?: Date | string | number; // End date when the repeat job should stop repeating.
   limit?: number; // Number of times the job should repeat at max.
   every?: number; // Repeat every millis (cron setting cannot be used together with this setting.)
 }

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -272,6 +272,7 @@ interface JobOpts{
 interface RepeatOpts{
   cron?: string; // Cron string
   tz?: string, // Timezone
+  startDate?: Date | string | number; // Start data when the repeat job should start repeating (only with cron).
   endDate?: Date | string | number; // End data when the repeat job should stop repeating.
   limit?: number; // Number of times the job should repeat at max.
   every?: number; // Repeat every millis (cron setting cannot be used together with this setting.)

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -164,7 +164,10 @@ module.exports = function(Queue) {
       return Math.floor(millis / opts.every) * opts.every + opts.every;
     }
 
-    var currentDate = new Date(millis);
+    var currentDate =
+      opts.startDate && new Date(opts.startDate) > new Date(millis)
+        ? new Date(opts.startDate)
+        : new Date(millis);
     var interval = parser.parseExpression(
       opts.cron,
       _.defaults(

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -143,6 +143,89 @@ describe('repeat', function() {
     });
   });
 
+  it('should repeat every 2 seconds with startDate in future', function(done) {
+    var _this = this;
+    var date = new Date('2017-02-07 9:24:00');
+    this.clock.tick(date.getTime());
+    var nextTick = 2 * ONE_SECOND + 500;
+    var delay = 5 * ONE_SECOND + 500;
+
+    queue
+      .add(
+        'repeat',
+        { foo: 'bar' },
+        {
+          repeat: {
+            cron: '*/2 * * * * *',
+            startDate: new Date('2017-02-07 9:24:05')
+          }
+        }
+      )
+      .then(function() {
+        _this.clock.tick(nextTick + delay);
+      });
+
+    queue.process('repeat', function() {
+      // dummy
+    });
+
+    var prev;
+    var counter = 0;
+    queue.on('completed', function(job) {
+      _this.clock.tick(nextTick);
+      if (prev) {
+        expect(prev.timestamp).to.be.lt(job.timestamp);
+        expect(job.timestamp - prev.timestamp).to.be.gte(2000);
+      }
+      prev = job;
+      counter++;
+      if (counter == 20) {
+        done();
+      }
+    });
+  });
+
+  it('should repeat every 2 seconds with startDate in past', function(done) {
+    var _this = this;
+    var date = new Date('2017-02-07 9:24:00');
+    this.clock.tick(date.getTime());
+    var nextTick = 2 * ONE_SECOND + 500;
+
+    queue
+      .add(
+        'repeat',
+        { foo: 'bar' },
+        {
+          repeat: {
+            cron: '*/2 * * * * *',
+            startDate: new Date('2017-02-07 9:22:00')
+          }
+        }
+      )
+      .then(function() {
+        _this.clock.tick(nextTick);
+      });
+
+    queue.process('repeat', function() {
+      // dummy
+    });
+
+    var prev;
+    var counter = 0;
+    queue.on('completed', function(job) {
+      _this.clock.tick(nextTick);
+      if (prev) {
+        expect(prev.timestamp).to.be.lt(job.timestamp);
+        expect(job.timestamp - prev.timestamp).to.be.gte(2000);
+      }
+      prev = job;
+      counter++;
+      if (counter == 20) {
+        done();
+      }
+    });
+  });
+
   it('should repeat once a day for 5 days', function(done) {
     var _this = this;
     var date = new Date('2017-05-05 13:12:00');


### PR DESCRIPTION
In this following example, the repeatable job will start run at 02.02.2020, 12:00, for every 2 minutes.
```
queue
      .add(
        'repeat',
        { foo: 'bar' },
        {
          repeat: {
            cron: '*/2 * * * * *', // every 2 seconds
            startDate: new Date('2020-02-02 12:00:00')
          }
        }
      )
```

This solution handles https://github.com/OptimalBits/bull/issues/764 issue.