### PR TITLE
Propagate stack traces from child processes

### DIFF
--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -57,9 +57,12 @@ process.on('message', function(msg) {
             });
           },
           function(err) {
+            if (!err.message) {
+              err = new Error(err);
+            }
             process.send({
               cmd: 'failed',
-              value: err.message || err
+              value: err
             });
           }
         )

--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -20,7 +20,9 @@ module.exports = function(processFile, childPool) {
             case 'failed':
             case 'error':
               child.removeListener('message', handler);
-              reject(new Error(msg.value));
+              var err = new Error();
+              Object.assign(err, msg.value);
+              reject(err);
               break;
             case 'progress':
               job.progress(msg.value);

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -230,6 +230,7 @@ describe('sandboxed process', function() {
         expect(job.data).eql({ foo: 'bar' });
         expect(job.failedReason).eql('Manually failed processor');
         expect(err.message).eql('Manually failed processor');
+        expect(err.stack).include('fixture_processor_fail.js');
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
         expect(queue.childPool.getAllFree()).to.have.lengthOf(1);
         done();


### PR DESCRIPTION
This is a followup to #894 that fixes #985 (prematurely closed because the reporter fixed the issue on a fork).

the rationale here:

the subprocess will always bubble up a JSON-serialized representation of an Error object, and we use err.message to maintain the same behavior from #894. Because we have no way of knowing what specific type this error was or even guarantee that we'd have access to that constructor (it may be a library or function that lives only in the child process), we need to create a normal Error object. However, we can use the properties that are bubbled up, including stack, message, code, etc, so we Object.assign them.