### PR TITLE
Add processOne method to the library

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -186,7 +186,7 @@ Job.prototype.releaseLock = function() {
  * @param ignoreLock {boolean} True when wanting to ignore the redis lock on this job.
  * @returns {Promise} Returns the jobData of the next job in the waiting queue.
  */
-Job.prototype.moveToCompleted = function(returnValue, ignoreLock) {
+Job.prototype.moveToCompleted = function(returnValue, ignoreLock, notFetch) {
   this.returnvalue = returnValue || 0;
 
   returnValue = utils.tryCatch(JSON.stringify, JSON, [returnValue]);
@@ -199,7 +199,8 @@ Job.prototype.moveToCompleted = function(returnValue, ignoreLock) {
     this,
     returnValue,
     this.opts.removeOnComplete,
-    ignoreLock
+    ignoreLock,
+    notFetch
   );
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -649,7 +649,10 @@ Queue.prototype.process = function(name, concurrency, handler) {
 */
 Queue.prototype.processOne = function() {
   var _this = this;
-  return this.getNextJob(true).then(function(job) {
+  var opts = {
+    doNotBlock: true
+  };
+  return this.getNextJob(opts).then(function(job) {
     if (job) {
       _this
         .processJob()
@@ -1088,10 +1091,11 @@ Queue.prototype.multi = function() {
 /**
   Returns a promise that resolves to the next job in queue.
 
-  If param 'notDelay' is true, the method uses rpoplpush and does not wait for drained queues.
+  If param 'opts.doNotDelay' is true, the method uses rpoplpush and does not wait for drained queues.
 */
-Queue.prototype.getNextJob = function(notDelay) {
+Queue.prototype.getNextJob = function(opts) {
   var _this = this;
+  var doNotBlock = opts ? opts.doNotBlock : false;
 
   if (this.closing) {
     return Promise.resolve();
@@ -1100,41 +1104,28 @@ Queue.prototype.getNextJob = function(notDelay) {
     //
     // Waiting for new jobs to arrive
     //
-    if (!notDelay) {
+    var jobRetrieved = function(jobId) {
+      if (jobId) {
+        return _this.moveToActive(jobId);
+      }
+    };
+    var errorRetrieving = function(err) {
+      // Swallow error
+      if (err.message !== 'Connection is closed.') {
+        console.error('(B)RPOPLPUSerrorRetryTimerH', err);
+      }
+    };
+    if (!doNotBlock) {
       return this.bclient
         .brpoplpush(this.keys.wait, this.keys.active, _this.settings.drainDelay)
-        .then(
-          function(jobId) {
-            if (jobId) {
-              return _this.moveToActive(jobId);
-            }
-          },
-          function(err) {
-            // Swallow error
-            if (err.message !== 'Connection is closed.') {
-              console.error('BRPOPLPUSerrorRetryTimerH', err);
-            }
-          }
-        )
+        .then(jobRetrieved, errorRetrieving)
         .catch(function(err) {
           console.error(err);
         });
     } else {
       return this.bclient
         .rpoplpush(this.keys.wait, this.keys.active)
-        .then(
-          function(jobId) {
-            if (jobId) {
-              return _this.moveToActive(jobId);
-            }
-          },
-          function(err) {
-            // Swallow error
-            if (err.message !== 'Connection is closed.') {
-              console.error('RPOPLPUSerrorRetryTimerH', err);
-            }
-          }
-        )
+        .then(jobRetrieved, errorRetrieving)
         .catch(function(err) {
           console.error(err);
         });

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1091,7 +1091,7 @@ Queue.prototype.multi = function() {
 /**
   Returns a promise that resolves to the next job in queue.
 
-  If param 'opts.doNotDelay' is true, the method uses rpoplpush and does not wait for drained queues.
+  If param 'opts.doNotBlock' is true, the method uses rpoplpush and does not wait for drained queues.
 */
 Queue.prototype.getNextJob = function(opts) {
   var _this = this;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -647,7 +647,7 @@ Queue.prototype.process = function(name, concurrency, handler) {
 
   @method processOnce
 */
-Queue.prototype.processOnce = function() {
+Queue.prototype.processOne = function() {
   var _this = this;
   return this.getNextJob(true).then(function(job) {
     if (job) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -649,34 +649,27 @@ Queue.prototype.process = function(name, concurrency, handler) {
 */
 Queue.prototype.processOnce = function() {
   var _this = this;
-  return new Promise(function(resolve, reject) {
-    _this
-      .getNextJob(true)
-      .then(function(job) {
-        if (job) {
-          _this
-            .processJob()
-            .then(function() {
-              job
-                .moveToCompleted(null, true, true)
-                .then(function() {
-                  resolve(job);
-                })
-                .catch(function(error) {
-                  reject(error);
-                });
-            })
-            .catch(function(error) {
-              reject(error);
-            });
-        } else {
-          resolve(null);
-        }
-      })
-      .catch(function(error) {
-        reject(error);
-      });
-  });
+  return this.getNextJob(true)
+    .then(function(job) {
+      if (job) {
+        _this
+          .processJob()
+          .then(function() {
+            return job.moveToCompleted(null, true, true);
+          })
+          .then(function() {
+            return job;
+          })
+          .catch(function(error) {
+            throw error;
+          });
+      } else {
+        return null;
+      }
+    })
+    .catch(function(error) {
+      throw error;
+    });
 };
 
 Queue.prototype.start = function(concurrency) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -642,6 +642,43 @@ Queue.prototype.process = function(name, concurrency, handler) {
   });
 };
 
+/**
+  Processes only one job from the queue. 
+
+  @method processOnce
+*/
+Queue.prototype.processOnce = function() {
+  var _this = this;
+  return new Promise(function(resolve, reject) {
+    _this
+      .getNextJob()
+      .then(function(job) {
+        if (job) {
+          _this
+            .processJob()
+            .then(function() {
+              job
+                .moveToCompleted(null, true, true)
+                .then(function() {
+                  resolve(job);
+                })
+                .catch(function(error) {
+                  reject(error);
+                });
+            })
+            .catch(function(error) {
+              reject(error);
+            });
+        } else {
+          resolve(null);
+        }
+      })
+      .catch(function(error) {
+        reject(error);
+      });
+  });
+};
+
 Queue.prototype.start = function(concurrency) {
   var _this = this;
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -645,7 +645,7 @@ Queue.prototype.process = function(name, concurrency, handler) {
 /**
   Processes only one job from the queue. 
 
-  @method processOnce
+  @method processOne
 */
 Queue.prototype.processOne = function() {
   var _this = this;

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1112,7 +1112,7 @@ Queue.prototype.getNextJob = function(opts) {
     var errorRetrieving = function(err) {
       // Swallow error
       if (err.message !== 'Connection is closed.') {
-        console.error('(B)RPOPLPUSerrorRetryTimerH', err);
+        console.error('(B)RPOPLPUSH', err);
       }
     };
     if (!doNotBlock) {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -651,7 +651,7 @@ Queue.prototype.processOnce = function() {
   var _this = this;
   return new Promise(function(resolve, reject) {
     _this
-      .getNextJob()
+      .getNextJob(true)
       .then(function(job) {
         if (job) {
           _this
@@ -1101,8 +1101,10 @@ Queue.prototype.multi = function() {
 
 /**
   Returns a promise that resolves to the next job in queue.
+
+  If param 'notDelay' is true, the method uses rpoplpush and does not wait for drained queues.
 */
-Queue.prototype.getNextJob = function() {
+Queue.prototype.getNextJob = function(notDelay) {
   var _this = this;
 
   if (this.closing) {
@@ -1112,21 +1114,45 @@ Queue.prototype.getNextJob = function() {
     //
     // Waiting for new jobs to arrive
     //
-    return this.bclient
-      .brpoplpush(this.keys.wait, this.keys.active, _this.settings.drainDelay)
-      .then(
-        function(jobId) {
-          if (jobId) {
-            return _this.moveToActive(jobId);
+    if (!notDelay) {
+      return this.bclient
+        .brpoplpush(this.keys.wait, this.keys.active, _this.settings.drainDelay)
+        .then(
+          function(jobId) {
+            if (jobId) {
+              return _this.moveToActive(jobId);
+            }
+          },
+          function(err) {
+            // Swallow error
+            if (err.message !== 'Connection is closed.') {
+              console.error('BRPOPLPUSerrorRetryTimerH', err);
+            }
           }
-        },
-        function(err) {
-          // Swallow error
-          if (err.message !== 'Connection is closed.') {
-            console.error('BRPOPLPUSH', err);
+        )
+        .catch(function(err) {
+          console.error(err);
+        });
+    } else {
+      return this.bclient
+        .rpoplpush(this.keys.wait, this.keys.active)
+        .then(
+          function(jobId) {
+            if (jobId) {
+              return _this.moveToActive(jobId);
+            }
+          },
+          function(err) {
+            // Swallow error
+            if (err.message !== 'Connection is closed.') {
+              console.error('RPOPLPUSerrorRetryTimerH', err);
+            }
           }
-        }
-      );
+        )
+        .catch(function(err) {
+          console.error(err);
+        });
+    }
   } else {
     return this.moveToActive();
   }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -649,27 +649,20 @@ Queue.prototype.process = function(name, concurrency, handler) {
 */
 Queue.prototype.processOnce = function() {
   var _this = this;
-  return this.getNextJob(true)
-    .then(function(job) {
-      if (job) {
-        _this
-          .processJob()
-          .then(function() {
-            return job.moveToCompleted(null, true, true);
-          })
-          .then(function() {
-            return job;
-          })
-          .catch(function(error) {
-            throw error;
-          });
-      } else {
-        return null;
-      }
-    })
-    .catch(function(error) {
-      throw error;
-    });
+  return this.getNextJob(true).then(function(job) {
+    if (job) {
+      _this
+        .processJob()
+        .then(function() {
+          return job.moveToCompleted(null, true, true);
+        })
+        .then(function() {
+          return job;
+        });
+    } else {
+      return null;
+    }
+  });
 };
 
 Queue.prototype.start = function(concurrency) {

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -154,7 +154,8 @@ var scripts = {
     propVal,
     shouldRemove,
     target,
-    ignoreLock
+    ignoreLock,
+    notFetch
   ) {
     var args = scripts.moveToFinishedArgs(
       job,
@@ -162,7 +163,8 @@ var scripts = {
       propVal,
       shouldRemove,
       target,
-      ignoreLock
+      ignoreLock,
+      notFetch
     );
     return job.queue.client.moveToFinished(args).then(function(result) {
       if (result < 0) {
@@ -184,14 +186,21 @@ var scripts = {
   },
 
   // TODO: add a retention argument for completed and finished jobs (in time).
-  moveToCompleted: function(job, returnvalue, removeOnComplete, ignoreLock) {
+  moveToCompleted: function(
+    job,
+    returnvalue,
+    removeOnComplete,
+    ignoreLock,
+    notFetch
+  ) {
     return scripts.moveToFinished(
       job,
       returnvalue,
       'returnvalue',
       removeOnComplete,
       'completed',
-      ignoreLock
+      ignoreLock,
+      notFetch
     );
   },
 


### PR DESCRIPTION
As discussed in #519, #892 and across different commits, the Bull library lacks a method to process the queue consuming individual jobs instead of doing the same retrieving all the jobs available sequentially. 

This PRs proposes a `processOne` method to do this task, allowing users to retrieve one job from the queue in each call for the function. To implement this, we have continued some methods yet available in Bull as described in https://github.com/OptimalBits/bull/issues/519#issuecomment-421407186, https://github.com/OptimalBits/bull/issues/519#issuecomment-422060733, and https://github.com/OptimalBits/bull/issues/519#issuecomment-422790555

@pacomf, @jelcaf and me co-author this PR. 