### PR TITLE
Provide the Job to the custom backoff strategy

### DIFF
--- a/lib/backoffs.js
+++ b/lib/backoffs.js
@@ -40,11 +40,11 @@ module.exports = {
     }
   },
 
-  calculate: function(backoff, attemptsMade, customStrategies, err) {
+  calculate: function(backoff, attemptsMade, customStrategies, err, job) {
     if (backoff) {
       var strategy = lookupStrategy(backoff, customStrategies);
 
-      return strategy(attemptsMade, err);
+      return strategy(attemptsMade, err, job);
     }
   }
 };

--- a/lib/job.js
+++ b/lib/job.js
@@ -228,7 +228,8 @@ Job.prototype.moveToFailed = function(err, ignoreLock) {
         _this.opts.backoff,
         _this.attemptsMade,
         _this.queue.settings.backoffStrategies,
-        err
+        err,
+        _this
       );
 
       if (delay) {


### PR DESCRIPTION
This request adds the job as an additional parameter to the custom backoff strategy.

Use Case:
We are using the Gmail API to batch process archives / deletes etc.  The API will respond with a status for each request in the batch, some of which may have failed while others succeeded.  We only want to retry the failed items, not the entire batch.  Adding the job as a parameter to the backoff strategy allows us to do this, by updating the job data with the failed ids (as per the simplified example in PATTERNS.md of this pull request)