### PR TITLE
Fix for getRepeatableJobs when job type is 'every'

### DIFF
--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -125,9 +125,11 @@ module.exports = function(Queue) {
           key: result[i],
           name: data[0],
           id: data[1] || null,
+          jobId: data[1] || null,
           endDate: parseInt(data[2]) || null,
-          tz: data[3] || null,
-          cron: data[4],
+          every: data.length <= 4 ? data[3] : null,
+          tz: data.length > 4 ? data[3] : null,
+          cron: data.length > 4 ? data[4] : null,
           next: parseInt(result[i + 1])
         });
       }


### PR DESCRIPTION
I couldn't remove a repeatable job of type 'every' when obtaining its options from `getRepeatableJobs`, then took a look at `getRepeatableJobs` and the decoding process wasn't prepared for an 'every' type job.