### PR TITLE
Only pass `err.cause` to `failed` handlers if it's a Bluebird error

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1024,7 +1024,13 @@ Queue.prototype.processJob = function(job) {
   }
 
   function handleFailed(err) {
-    var error = err.cause || err; //Handle explicit rejection
+    var error = err;
+    if (
+      error instanceof Promise.OperationalError &&
+      error.cause instanceof Error
+    ) {
+      error = error.cause; //Handle explicit rejection
+    }
 
     return job.moveToFailed(err).then(function(jobData) {
       _this.emit('failed', job, error, 'active');


### PR DESCRIPTION
Hiding the internal `Bluebird.OperationalError` makes sense, but Bull should not unwrap user-supplied errors.

Fixes #1077