### PR TITLE
Fix copy paste mistake for stacktrace in job toData

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -143,7 +143,7 @@ Job.prototype.toData = function() {
 
   json.data = JSON.stringify(json.data);
   json.opts = JSON.stringify(json.opts);
-  json.stacktrace = JSON.stringify(json.opts);
+  json.stacktrace = JSON.stringify(json.stacktrace);
   json.failedReason = JSON.stringify(json.failedReason);
   json.returnvalue = JSON.stringify(json.returnvalue);
 


### PR DESCRIPTION
I do believe this is a small mistake by copy paste but forgot to modify, which spotted when I read the code.
It does not hurt since the stacktrace will be overridden when error.
But still I think it should be corrected.