### PR TITLE
Allow cancelling of retries when using custom backoff strategy

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -131,6 +131,7 @@ Custom backoff strategy
 -----------------------
 
 When the builtin backoff strategies on retries are not sufficient, a custom strategy can be defined. Custom backoff strategies are defined by a function on the queue. The number of attempts already made to process the job is passed to this function as the first parameter, and the error that the job failed with as the second parameter.
+The function returns either the time to delay the retry with, 0 to retry immediately or -1 to fail the job immediately.
 
 ```js
 var Queue = require('bull');

--- a/lib/job.js
+++ b/lib/job.js
@@ -222,6 +222,7 @@ Job.prototype.moveToFailed = function(err, ignoreLock) {
     _this._saveAttempt(multi, err);
 
     // Check if an automatic retry should be performed
+    var moveToFailed = false;
     if (_this.attemptsMade < _this.opts.attempts && !_this._discarded) {
       // Check if backoff is needed
       var delay = backoffs.calculate(
@@ -231,7 +232,10 @@ Job.prototype.moveToFailed = function(err, ignoreLock) {
         err
       );
 
-      if (delay) {
+      if (delay === -1) {
+        // If delay is -1, we should no continue retrying
+        moveToFailed = true;
+      } else if (delay) {
         // If so, move to delayed (need to unlock job in this case!)
         var args = scripts.moveToDelayedArgs(
           _this.queue,
@@ -248,6 +252,10 @@ Job.prototype.moveToFailed = function(err, ignoreLock) {
       }
     } else {
       // If not, move to failed
+      moveToFailed = true;
+    }
+
+    if (moveToFailed) {
       var args = scripts.moveToFailedArgs(
         _this,
         err.message,


### PR DESCRIPTION
This request allows you to return -1 from a custom backoff strategy to fail the job immediately instead of retrying. Which allows us to fail immediately on certain kinds of errors.