### PR TITLE
Fix Warning: cancellation is disabled

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,6 +23,12 @@ var uuid = require('uuid');
 
 var commands = require('./commands/');
 
+Promise.config({
+  warnings: process.NODE_ENV !== 'production',
+  longStackTraces: process.NODE_ENV !== 'production',
+  cancellation: true
+});
+
 /**
   Gets or creates a new Queue with the given name.
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -10,17 +10,6 @@ var _ = require('lodash');
 var uuid = require('uuid');
 var utils = require('./utils');
 
-Promise.config({ warnings: true });
-
-Promise.config({
-  // Enable warnings.
-  // warnings: true,
-  // Enable long stack traces.
-  longStackTraces: process.NODE_ENV !== 'production',
-  // Enable cancellation.
-  cancellation: true
-});
-
 describe('Queue', function() {
   var sandbox = sinon.createSandbox();
   var client;


### PR DESCRIPTION
Bluebird configuration must have cancellation enabled (false by default) in order to be able to use promise.cancel().