### PR TITLE
Implement 'onCancel' callback in sandbox environment

### DIFF
--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -10,7 +10,7 @@ module.exports = function(processFile, childPool) {
         job: job
       });
 
-      var done = new Promise(function(resolve, reject) {
+      var done = new Promise(function(resolve, reject, onCancel) {
         function handler(msg) {
           switch (msg.cmd) {
             case 'completed':
@@ -30,10 +30,22 @@ module.exports = function(processFile, childPool) {
           }
         }
 
+        onCancel(() => {
+          child.removeListener('message', handler);
+          reject(new Error('cancelled'));
+        });
+
         child.on('message', handler);
       });
 
       return done.finally(function() {
+        if (done.isCancelled()) {
+          job.discard();
+          job
+            .moveToFailed(new Error('cancelled'), true)
+            .then(() => child.kill());
+        }
+
         childPool.release(child);
       });
     });


### PR DESCRIPTION
The onCancel callback will automatically discard the job, move it to failed state and kill the child process.