### PR TITLE
Reset 'failedReason', 'finishedOn' and 'processedOn' fields on job retry

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -307,18 +307,31 @@ Job.prototype.promote = function() {
 Job.prototype.retry = function() {
   var _this = this;
   return this.queue.isReady().then(function() {
-    return scripts
-      .reprocessJob(_this, { state: 'failed' })
-      .then(function(result) {
-        if (result === 1) {
-          return;
-        } else if (result === 0) {
-          throw new Error(errors.Messages.RETRY_JOB_NOT_EXIST);
-        } else if (result === -1) {
-          throw new Error(errors.Messages.RETRY_JOB_IS_LOCKED);
-        } else if (result === -2) {
-          throw new Error(errors.Messages.RETRY_JOB_NOT_FAILED);
-        }
+    _this.failedReason = null;
+    _this.finishedOn = null;
+    _this.processedOn = null;
+
+    return _this.queue.client
+      .hdel(
+        _this.queue.toKey(_this.id),
+        'finishedOn',
+        'processedOn',
+        'failedReason'
+      )
+      .then(function(redisResult) {
+        return scripts
+          .reprocessJob(_this, { state: 'failed' })
+          .then(function(result) {
+            if (result === 1) {
+              return;
+            } else if (result === 0) {
+              throw new Error(errors.Messages.RETRY_JOB_NOT_EXIST);
+            } else if (result === -1) {
+              throw new Error(errors.Messages.RETRY_JOB_IS_LOCKED);
+            } else if (result === -2) {
+              throw new Error(errors.Messages.RETRY_JOB_NOT_FAILED);
+            }
+          });
       });
   });
 };

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -1411,7 +1411,17 @@ describe('Queue', function() {
         expect(job.data.foo).to.be.eql('bar');
         expect(err).to.be.eql(notEvenErr);
         failedOnce = true;
-        job.retry();
+        job.retry().then(function() {
+          expect(job.failedReason).to.be.null;
+          expect(job.processedOn).to.be.null;
+          expect(job.finishedOn).to.be.null;
+
+          retryQueue.getJob(job.id).then(function(updatedJob) {
+            expect(updatedJob.failedReason).to.be.undefined;
+            expect(updatedJob.processedOn).to.be.undefined;
+            expect(updatedJob.finishedOn).to.be.undefined;
+          });
+        });
       });
 
       retryQueue.once('completed', function() {


### PR DESCRIPTION
The class members will be reset to null, failedReason field will be removed from Redis and the other two will be set to null.