### PR TITLE
Fix typo in forcedReconnection variable

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1195,7 +1195,7 @@ Queue.prototype.whenCurrentJobsFinished = function() {
     //
     // Force reconnection of blocking connection to abort blocking redis call immediately.
     //
-    var forcedReconnetion = redisClientDisconnect(_this.bclient).then(
+    var forcedReconnection = redisClientDisconnect(_this.bclient).then(
       function() {
         return _this.bclient.connect();
       }
@@ -1203,7 +1203,7 @@ Queue.prototype.whenCurrentJobsFinished = function() {
 
     Promise.all(_this.processing)
       .then(function() {
-        return forcedReconnetion;
+        return forcedReconnection;
       })
       .then(resolve, reject);
 


### PR DESCRIPTION
Just another tiny typo I saw when I was reading through the code.

I went through the code because I was wondering why there was a `default` fallback in the example how to reuse redis connections: https://github.com/OptimalBits/bull/blob/master/PATTERNS.md#reusing-redis-connections

What is `bclient` exactly and can I reuse the existing connection for that? To me it looks like it's some kind of connection to do separate requests outside of the regular job processing flow, so that they won't interfere.

```js
  const queueSettings = {
    createClient (type) {
      if (type === 'client' || type === 'bclient') return redisForMutations
      if (type === 'subscriber') return redisForSubscriptions
      throw new Error(`Requested unknown redis client instance for type '${type}'`)
    },
    settings: {retryProcessDelay: 10000}
  }
```

I could create a new issue or PR to improve the documentation.