### PR TITLE
process.NODE_ENV -> process.env.NODE_ENV

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -42,8 +42,8 @@ var uuid = require('uuid');
 var commands = require('./commands/');
 
 Bluebird.config({
-  warnings: process.NODE_ENV !== 'production',
-  longStackTraces: process.NODE_ENV !== 'production',
+  warnings: process.env.NODE_ENV !== 'production',
+  longStackTraces: process.env.NODE_ENV !== 'production',
   cancellation: true
 });
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -44,7 +44,6 @@ var commands = require('./commands/');
 Bluebird.config({
   warnings: process.env.NODE_ENV !== 'production',
   longStackTraces: process.env.NODE_ENV !== 'production',
-  cancellation: true
 });
 
 /**

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -16,7 +16,7 @@ Bluebird.config({
   // Enable warnings.
   // warnings: true,
   // Enable long stack traces.
-  longStackTraces: process.NODE_ENV !== 'production',
+  longStackTraces: process.env.NODE_ENV !== 'production',
   // Enable cancellation.
   cancellation: true
 });


### PR DESCRIPTION
I'm getting errors about bluebird `longStackTraces` in production due to this typo. Is this going to be a breaking change?