### PR TITLE
Implement 'onCancel' handler in sandboxed environments

### DIFF
--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -10,7 +10,7 @@ module.exports = function(processFile, childPool) {
         job: job
       });
 
-      var done = new Promise(function(resolve, reject) {
+      var done = new Promise(function(resolve, reject, onCancel) {
         function handler(msg) {
           switch (msg.cmd) {
             case 'completed':
@@ -34,9 +34,19 @@ module.exports = function(processFile, childPool) {
         child.on('exit', function(exitCode) {
           reject(new Error('Unexpected exit code: ' + exitCode));
         });
+
+        onCancel(function() {
+          child.removeListener('message', handler);
+          job.discard();
+        });
       });
 
       return done.finally(function() {
+        if (done.isCancelled()) {
+          child.kill();
+          throw new Error('Cancelled');
+        }
+
         childPool.release(child);
       });
     });


### PR DESCRIPTION
This is my second attempt on the issue since PR #1105 wasn't correct and was breaking/affecting the flow of the library. This time cancellation will not impact the flow of the queue and the job will be cancelled nice and smoothly, plus it will ensure that the child process is killed.