### PR TITLE
WIP: Replace bluebird function usages with native Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
+require('./lib/promise');
+
 module.exports = require('./lib/queue');
 module.exports.Job = require('./lib/job');

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -14,11 +14,32 @@
 
 var fs = require('fs');
 var path = require('path');
-var Bluebird = require('bluebird');
 
 var utils = require('../utils');
 
-fs = Bluebird.promisifyAll(fs);
+function readdirAsync(path) {
+  return new Promise(function(resolve, reject) {
+    fs.readdir(path, function(error, result) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+function readFileAsync(path) {
+  return new Promise(function(resolve, reject) {
+    fs.readFile(path, function(error, result) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
 
 module.exports = (function() {
   var scripts;
@@ -35,8 +56,7 @@ module.exports = (function() {
 })();
 
 function loadScripts(dir) {
-  return fs
-    .readdirAsync(dir)
+  return readdirAsync(dir)
     .filter(function(file) {
       return path.extname(file) === '.lua';
     })
@@ -45,7 +65,7 @@ function loadScripts(dir) {
       var name = longName.split('-')[0];
       var numberOfKeys = parseInt(longName.split('-')[1]);
 
-      return fs.readFileAsync(path.join(dir, file)).then(function(lua) {
+      return readFileAsync(path.join(dir, file)).then(function(lua) {
         return {
           name: name,
           options: { numberOfKeys: numberOfKeys, lua: lua.toString() }

--- a/lib/job.js
+++ b/lib/job.js
@@ -1,7 +1,8 @@
 /*eslint-env node */
 'use strict';
 
-var Bluebird = require('bluebird');
+require('./promise');
+
 var _ = require('lodash');
 var utils = require('./utils');
 var scripts = require('./scripts');
@@ -385,20 +386,18 @@ Job.prototype.getState = function() {
     { fn: 'isPaused', state: 'paused' }
   ];
 
-  return Bluebird.reduce(
-    fns,
-    function(state, fn) {
+  return Promise.resolve(fns)
+    .reduce(function(state, fn) {
       if (state) {
         return state;
       }
       return _this[fn.fn]().then(function(result) {
         return result ? fn.state : null;
       });
-    },
-    null
-  ).then(function(result) {
-    return result ? result : 'stuck';
-  });
+    }, null)
+    .then(function(result) {
+      return result ? result : 'stuck';
+    });
 };
 
 Job.prototype.remove = function() {

--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -2,7 +2,6 @@
 
 var fork = require('child_process').fork;
 var path = require('path');
-var Promise = require('bluebird');
 var _ = require('lodash');
 
 var ChildPool = function ChildPool() {
@@ -38,7 +37,9 @@ ChildPool.prototype.retain = function(processFile) {
 
   child.on('exit', _this.remove.bind(_this, child));
 
-  return initChild(child, processFile).return(child);
+  return initChild(child, processFile).then(function() {
+    return child;
+  });
 };
 
 ChildPool.prototype.release = function(child) {

--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -5,7 +5,7 @@
  */
 var status;
 var processor;
-var Promise = require('bluebird');
+var Bluebird = require('bluebird');
 
 // https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
 if (!('toJSON' in Error.prototype)) {
@@ -33,9 +33,9 @@ process.on('message', function(msg) {
         processor = processor.default;
       }
       if (processor.length > 1) {
-        processor = Promise.promisify(processor);
+        processor = Bluebird.promisify(processor);
       } else {
-        processor = Promise.method(processor);
+        processor = Bluebird.method(processor);
       }
       status = 'IDLE';
       break;

--- a/lib/process/sandbox.js
+++ b/lib/process/sandbox.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
-
 module.exports = function(processFile, childPool) {
   return function process(job) {
     return childPool.retain(processFile).then(function(child) {

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,0 +1,117 @@
+/*eslint-env node */
+'use strict';
+
+// Add `finally()` to `Promise.prototype`
+Promise.prototype.finally = function(onFinally) {
+  return this.then(
+    /* onFulfilled */
+    function(res) {
+      return Promise.resolve(onFinally()).then(function() {
+        return res;
+      });
+    },
+    /* onRejected */
+    function(err) {
+      return Promise.resolve(onFinally()).then(function() {
+        throw err;
+      });
+    }
+  );
+};
+
+// Add `.timeout()` to `Promise.prototype`
+Promise.prototype.timeout = function(ms) {
+  // Create a promise that rejects in <ms> milliseconds
+  let timeout = new Promise((resolve, reject) => {
+    let id = setTimeout(() => {
+      clearTimeout(id);
+      reject('Timed out in ' + ms + 'ms.');
+    }, ms);
+  });
+
+  // Returns a race between our timeout and the passed in promise
+  return Promise.race([this, timeout]);
+};
+
+Promise.prototype.filter = function(filterer) {
+  return this.then(function(res) {
+    if (!Array.isArray(res)) {
+      res = [res];
+    }
+
+    return Promise.resolve(res.filter(filterer));
+  });
+};
+
+Promise.prototype.map = function(mapper) {
+  return this.then(function(res) {
+    if (!Array.isArray(res)) {
+      res = [res];
+    }
+
+    return Promise.all(res.map(mapper));
+  });
+};
+
+Promise.prototype.each = function(forEach) {
+  return this.then(function(res) {
+    if (!Array.isArray(res)) {
+      res = [res];
+    }
+
+    return res
+      .reduce(function(prev, curr, i) {
+        return prev.then(function() {
+          return forEach(curr, i, res.length);
+        });
+      }, Promise.resolve())
+      .then(function() {
+        return res;
+      });
+  });
+};
+
+Promise.prototype.delay = function(ms) {
+  return this.then(function() {
+    return Promise.delay(ms);
+  });
+};
+
+Promise.delay = function(ms) {
+  return new Promise(function(resolve) {
+    setTimeout(function() {
+      resolve();
+    }, ms);
+  });
+};
+
+Promise.prototype.reduce = function(reducer, start) {
+  return this.then(function(res) {
+    if (!Array.isArray(res)) {
+      res = [res];
+    }
+
+    const length = res.length;
+
+    return res.reduce(function(promise, curr, index, arr) {
+      return promise.then(function(prev) {
+        if (prev === undefined && length === 1) {
+          return curr;
+        }
+
+        return reducer(prev, curr, index, arr);
+      });
+    }, Promise.resolve(start));
+  });
+};
+
+Promise.prototype.asCallback = function(callback) {
+  return this.then(
+    value => {
+      callback(null, value);
+    },
+    err => {
+      callback(err);
+    }
+  );
+};

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -338,7 +338,9 @@ function setGuardianTimer(queue) {
         .catch(function(err) {
           queue.emit('error', err);
         })
-        .return(null);
+        .then(function() {
+          return null;
+        });
     }
   }, queue.settings.guardInterval);
 }
@@ -392,7 +394,9 @@ Queue.prototype._initProcess = function() {
             }
             return null;
           })
-          .return(null);
+          .then(function() {
+            return null;
+          });
       })
       .then(function() {
         //
@@ -895,7 +899,9 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
         .catch(function(err) {
           _this.emit('error', err, 'Error updating the delay timer');
         })
-        .return(null);
+        .then(function() {
+          return null;
+        });
       _this.delayedTimestamp = Number.MAX_VALUE;
     };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,23 +1,7 @@
 /*eslint-env node */
 'use strict';
 
-// Add `finally()` to `Promise.prototype`
-Promise.prototype.finally = function(onFinally) {
-  return this.then(
-    /* onFulfilled */
-    function(res) {
-      return Promise.resolve(onFinally()).then(function() {
-        return res;
-      });
-    },
-    /* onRejected */
-    function(err) {
-      return Promise.resolve(onFinally()).then(function() {
-        throw err;
-      });
-    }
-  );
-};
+require('./promise');
 
 var redis = require('ioredis');
 var EventEmitter = require('events');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -771,7 +771,7 @@ Queue.prototype.empty = function() {
   multi.del(this.toKey('delayed'));
   multi.del(this.toKey('priority'));
 
-  return multi.exec().spread(function(waiting, paused) {
+  return multi.exec().then(function([waiting, paused]) {
     waiting = waiting[1];
     paused = paused[1];
     var jobKeys = paused.concat(waiting).map(_this.toKey, _this);
@@ -928,7 +928,7 @@ Queue.prototype.moveUnlockedJobsToWait = function() {
 
   return scripts
     .moveUnlockedJobsToWait(this)
-    .spread(function(failed, stalled) {
+    .then(function([failed, stalled]) {
       var handleFailedJobs = failed.map(function(jobId) {
         return _this.getJobFromId(jobId).then(function(job) {
           _this.emit(
@@ -1131,7 +1131,7 @@ Queue.prototype.getNextJob = function() {
 
 Queue.prototype.moveToActive = function(jobId) {
   var _this = this;
-  return scripts.moveToActive(_this, jobId).spread(function(jobData, jobId) {
+  return scripts.moveToActive(_this, jobId).then(function([jobData, jobId]) {
     return _this.nextJobFromJobData(jobData, jobId);
   });
 };

--- a/lib/timer-manager.js
+++ b/lib/timer-manager.js
@@ -1,7 +1,6 @@
 /*eslint-env node */
 'use strict';
 
-var Promise = require('bluebird');
 var _ = require('lodash');
 var uuid = require('uuid');
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "singleQuote": true
   },
   "eslintConfig": {
+    "env": {
+      "es6": true
+    },
     "rules": {
       "valid-jsdoc": 0,
       "func-style": 0,

--- a/test/fixtures/fixture_processor.js
+++ b/test/fixtures/fixture_processor.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(/*job*/) {
   return Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_bar.js
+++ b/test/fixtures/fixture_processor_bar.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(/*job*/) {
   return Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_callback.js
+++ b/test/fixtures/fixture_processor_callback.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(job, done) {
   Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_callback_fail.js
+++ b/test/fixtures/fixture_processor_callback_fail.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(job, done) {
   Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_crash.js
+++ b/test/fixtures/fixture_processor_crash.js
@@ -3,8 +3,6 @@
  *
  */
 
-var Promise = require('bluebird');
-
 module.exports = function(job) {
   setTimeout(function() {
     if (typeof job.data.exitCode !== 'number') {

--- a/test/fixtures/fixture_processor_exit.js
+++ b/test/fixtures/fixture_processor_exit.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(/*job*/) {
   return Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_fail.js
+++ b/test/fixtures/fixture_processor_fail.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(/*job*/) {
   return Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_foo.js
+++ b/test/fixtures/fixture_processor_foo.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(/*job*/) {
   return Promise.delay(500).then(function() {

--- a/test/fixtures/fixture_processor_progress.js
+++ b/test/fixtures/fixture_processor_progress.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(job) {
   return Promise.delay(50)

--- a/test/fixtures/fixture_processor_slow.js
+++ b/test/fixtures/fixture_processor_slow.js
@@ -3,7 +3,7 @@
  *
  */
 
-var Promise = require('bluebird');
+require('../../lib/promise');
 
 module.exports = function(/*job*/) {
   return Promise.delay(1000).then(function() {

--- a/test/test_events.js
+++ b/test/test_events.js
@@ -3,7 +3,6 @@
 
 var utils = require('./utils');
 var redis = require('ioredis');
-var Bluebird = require('bluebird');
 
 var Queue = require('../');
 var Job = require('../lib/job');
@@ -57,7 +56,7 @@ describe('events', function() {
     });
 
     queue.process(function(/*job*/) {
-      return Bluebird.delay(250);
+      return Promise.delay(250);
     });
 
     queue.add({ foo: 'bar' });
@@ -84,7 +83,7 @@ describe('events', function() {
     });
 
     queue.process(function(/*job*/) {
-      return Bluebird.delay(250);
+      return Promise.delay(250);
     });
 
     queue.add({ foo: 'bar' });

--- a/test/test_getters.js
+++ b/test/test_getters.js
@@ -5,7 +5,6 @@ var redis = require('ioredis');
 
 var utils = require('./utils');
 var expect = require('chai').expect;
-var Promise = require('bluebird');
 
 var _ = require('lodash');
 
@@ -38,10 +37,10 @@ describe('Jobs getters', function() {
   });
 
   it('should get waiting jobs', function() {
-    return Promise.join(
+    return Promise.all([
       queue.add({ foo: 'bar' }),
       queue.add({ baz: 'qux' })
-    ).then(function() {
+    ]).then(function() {
       return queue.getWaiting().then(function(jobs) {
         expect(jobs).to.be.a('array');
         expect(jobs.length).to.be.equal(2);
@@ -53,10 +52,10 @@ describe('Jobs getters', function() {
 
   it('should get paused jobs', function() {
     return queue.pause().then(function() {
-      return Promise.join(
+      return Promise.all([
         queue.add({ foo: 'bar' }),
         queue.add({ baz: 'qux' })
-      ).then(function() {
+      ]).then(function() {
         return queue.getWaiting().then(function(jobs) {
           expect(jobs).to.be.a('array');
           expect(jobs.length).to.be.equal(2);

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -5,7 +5,6 @@ var Job = require('../lib/job');
 var Queue = require('../lib/queue');
 var expect = require('expect.js');
 var redis = require('ioredis');
-var Bluebird = require('bluebird');
 var uuid = require('uuid');
 
 describe('Job', function() {
@@ -725,7 +724,7 @@ describe('Job', function() {
   describe('.finished', function() {
     it('should resolve when the job has been completed', function(done) {
       queue.process(function() {
-        return Bluebird.delay(500);
+        return Promise.delay(500);
       });
       queue
         .add({ foo: 'bar' })
@@ -737,7 +736,7 @@ describe('Job', function() {
 
     it('should resolve when the job has been completed and return object', function(done) {
       queue.process(function(/*job*/) {
-        return Bluebird.delay(500).then(function() {
+        return Promise.delay(500).then(function() {
           return { resultFoo: 'bar' };
         });
       });
@@ -755,14 +754,14 @@ describe('Job', function() {
 
     it('should resolve when the job has been delayed and completed and return object', function(done) {
       queue.process(function(/*job*/) {
-        return Bluebird.delay(300).then(function() {
+        return Promise.delay(300).then(function() {
           return { resultFoo: 'bar' };
         });
       });
       queue
         .add({ foo: 'bar' })
         .then(function(job) {
-          return Bluebird.delay(600).then(function() {
+          return Promise.delay(600).then(function() {
             return job.finished();
           });
         })
@@ -775,14 +774,14 @@ describe('Job', function() {
 
     it('should resolve when the job has been completed and return string', function(done) {
       queue.process(function(/*job*/) {
-        return Bluebird.delay(500).then(function() {
+        return Promise.delay(500).then(function() {
           return 'a string';
         });
       });
       queue
         .add({ foo: 'bar' })
         .then(function(job) {
-          return Bluebird.delay(600).then(function() {
+          return Promise.delay(600).then(function() {
             return job.finished();
           });
         })
@@ -795,7 +794,7 @@ describe('Job', function() {
 
     it('should resolve when the job has been delayed and completed and return string', function(done) {
       queue.process(function(/*job*/) {
-        return Bluebird.delay(300).then(function() {
+        return Promise.delay(300).then(function() {
           return 'a string';
         });
       });
@@ -813,7 +812,7 @@ describe('Job', function() {
 
     it('should reject when the job has been failed', function(done) {
       queue.process(function() {
-        return Bluebird.delay(500).then(function() {
+        return Promise.delay(500).then(function() {
           return Promise.reject(new Error('test error'));
         });
       });
@@ -841,7 +840,7 @@ describe('Job', function() {
       queue
         .add({ foo: 'bar' })
         .then(function(job) {
-          return Bluebird.delay(500).then(function() {
+          return Promise.delay(500).then(function() {
             return job.finished();
           });
         })
@@ -857,7 +856,7 @@ describe('Job', function() {
       queue
         .add({ foo: 'bar' })
         .then(function(job) {
-          return Bluebird.delay(500).then(function() {
+          return Promise.delay(500).then(function() {
             return job.finished();
           });
         })

--- a/test/test_pause.js
+++ b/test/test_pause.js
@@ -4,7 +4,6 @@
 var Queue = require('../');
 
 var expect = require('chai').expect;
-var Bluebird = require('bluebird');
 var redis = require('ioredis');
 var utils = require('./utils');
 
@@ -36,7 +35,7 @@ describe('.pause', function() {
         });
       });
 
-      return Bluebird.join(
+      return Promise.all([
         queue
           .pause()
           .then(function() {
@@ -51,7 +50,7 @@ describe('.pause', function() {
             return queue.resume();
           }),
         resultPromise
-      );
+      ]);
     });
   });
 
@@ -132,7 +131,7 @@ describe('.pause', function() {
     var startProcessing = new Promise(function(resolve) {
       queue.process(function(/*job*/) {
         resolve();
-        return Bluebird.delay(200);
+        return Promise.delay(200);
       });
     });
 
@@ -255,7 +254,7 @@ describe('.pause', function() {
     var startsProcessing = new Promise(function(resolve) {
       queue.process(function(/*job*/) {
         resolve();
-        return Bluebird.delay(200);
+        return Promise.delay(200);
       });
     });
 
@@ -302,7 +301,7 @@ describe('.pause', function() {
     queue.add({});
 
     queue.on('drained', function() {
-      Bluebird.delay(500).then(function() {
+      Promise.delay(500).then(function() {
         var start = new Date().getTime();
         return queue.pause(true).finally(function() {
           var finish = new Date().getTime();
@@ -336,7 +335,7 @@ describe('.pause', function() {
           expect(counts).to.have.property('paused', 0);
           expect(counts).to.have.property('waiting', 0);
           expect(counts).to.have.property('delayed', 1);
-          return Bluebird.delay(1000);
+          return Promise.delay(1000);
         })
         .then(function() {
           return queue.getJobCounts();

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -1,7 +1,6 @@
 /*eslint-env node */
 'use strict';
 
-var Bluebird = require('bluebird');
 var expect = require('chai').expect;
 var utils = require('./utils');
 var redis = require('ioredis');
@@ -113,7 +112,7 @@ describe('sandboxed process', function() {
     });
 
     queue.add('foo', { foo: 'bar' }).then(function() {
-      Bluebird.delay(500).then(function() {
+      Promise.delay(500).then(function() {
         queue.add('bar', { bar: 'qux' });
       });
     });
@@ -276,7 +275,7 @@ describe('sandboxed process', function() {
     return queue
       .add({})
       .then(function(job) {
-        return Bluebird.resolve(job.finished()).reflect();
+        return Promise.resolve(job.finished()).reflect();
       })
       .then(function(inspection) {
         expect(inspection.isRejected()).to.be.eql(true);
@@ -290,7 +289,7 @@ describe('sandboxed process', function() {
     return queue
       .add({ exitCode: 0 })
       .then(function(job) {
-        return Bluebird.resolve(job.finished()).reflect();
+        return Promise.resolve(job.finished()).reflect();
       })
       .then(function(inspection) {
         expect(inspection.isRejected()).to.be.eql(true);
@@ -306,7 +305,7 @@ describe('sandboxed process', function() {
     return queue
       .add({ exitCode: 1 })
       .then(function(job) {
-        return Bluebird.resolve(job.finished()).reflect();
+        return Promise.resolve(job.finished()).reflect();
       })
       .then(function(inspection) {
         expect(inspection.isRejected()).to.be.eql(true);
@@ -323,7 +322,7 @@ describe('sandboxed process', function() {
       try {
         expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
         expect(queue.childPool.getAllFree()).to.have.lengthOf(1);
-        Bluebird.delay(500)
+        Promise.delay(500)
           .then(function() {
             expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
             expect(queue.childPool.getAllFree()).to.have.lengthOf(0);

--- a/test/utils.js
+++ b/test/utils.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var Queue = require('../');
-var Promise = require('bluebird');
 var STD_QUEUE_NAME = 'test queue';
 var _ = require('lodash');
 
@@ -32,13 +31,15 @@ function cleanupQueue(queue) {
 }
 
 function cleanupQueues() {
-  return Promise.map(queues, function(queue) {
-    var errHandler = function() {};
-    queue.on('error', errHandler);
-    return queue.close().catch(errHandler);
-  }).then(function() {
-    queues = [];
-  });
+  return Promise.resolve(queues)
+    .map(function(queue) {
+      var errHandler = function() {};
+      queue.on('error', errHandler);
+      return queue.close().catch(errHandler);
+    })
+    .then(function() {
+      queues = [];
+    });
 }
 
 function sleep(ms) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,11 +72,6 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-  integrity sha1-06ioOzGapneTZisT52HHkRQiMG4=
-
 ansi-escapes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
@@ -1779,21 +1774,7 @@ listr-silent-renderer@^1.1.1:
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
   integrity sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
 
-listr-update-renderer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
-  integrity sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-"listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
+listr-update-renderer@^0.4.0, "listr-update-renderer@https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update":
   version "0.4.0"
   resolved "https://github.com/okonet/listr-update-renderer/tarball/upgrade-log-update#06073fa93166277607a7814f4e1f83960081414c"
   dependencies:
@@ -1952,14 +1933,6 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
-
-log-update@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
-  integrity sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=
-  dependencies:
-    ansi-escapes "^1.0.0"
-    cli-cursor "^1.0.2"
 
 log-update@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
- [x] `.return` is a short hand by Bluebird. [Bluebird .return](http://bluebirdjs.com/docs/api/return.html)
If the ioredis client is created by the user without using Bluebird Promises the `.return` function is not available.
- [x] `.spread` is Bluebird implementation for destructuring an array of promises. [Bluebird .spread](http://bluebirdjs.com/docs/api/spread.html)
It can be replaced by ES6 destructuring.
- [x] `.timeout` [Bluebird .timeout](http://bluebirdjs.com/docs/api/timeout.html)
- [x] `.map` [Bluebird .map](http://bluebirdjs.com/docs/api/map.html)
- [x] `Promise.map` replaced by `Promise.resolve().map()`.
- [x] `.reduce` [Bluebird .reduce](http://bluebirdjs.com/docs/api/reduce.html)
- [x] `.filter` [Bluebird .filter](http://bluebirdjs.com/docs/api/filter.html)
- [x] `.each` [Bluebird .each](http://bluebirdjs.com/docs/api/each.html)
- [x] `.delay` [Bluebird .delay](http://bluebirdjs.com/docs/api/delay.html)
- [x] `Promise.delay` [Bluebird Promise.delay](http://bluebirdjs.com/docs/api/promise.delay.html)
- [x] `.asCallback` [Bluebird .asCallback](http://bluebirdjs.com/docs/api/ascallback.html)
- [ ] `.reflect` [Bluebird .reflect](http://bluebirdjs.com/docs/api/reflect.html)
- [ ] `Promise.promisify` [Bluebird Promise.promisify](http://bluebirdjs.com/docs/api/promise.promisify.html)
- [ ] `Promise.method` [Bluebird Promise.method](http://bluebirdjs.com/docs/api/promise.method.html)

Fix #1027