### PR TITLE
Fix #1148 job dropping when rate-limiter hits during discard mode

### DIFF
--- a/lib/commands/moveToActive-8.lua
+++ b/lib/commands/moveToActive-8.lua
@@ -62,9 +62,12 @@ if jobId then
         -- put job into delayed queue
         rcall("ZADD", KEYS[7], timestamp * 0x1000 + bit.band(jobCounter, 0xfff), jobId)
         rcall("PUBLISH", KEYS[7], timestamp)
+        -- remove from active queue
+        rcall("LREM", KEYS[2], 1, jobId)
+        return
       end
-      -- remove from active queue
-      rcall("LREM", KEYS[2], 1, jobId)
+      -- move from active to wait
+      rcall("RPOPLPUSH", KEYS[2], KEYS[1])
       return
     else
       jobCounter = rcall("INCR", rateLimiterKey)

--- a/test/test_rate_limiter.js
+++ b/test/test_rate_limiter.js
@@ -143,8 +143,8 @@ describe('Rate limiter', function() {
       ]).then(function() {
         return newQueue.getDelayedCount().then(function(delayedCount) {
           expect(delayedCount).to.eq(0);
-          return newQueue.getActiveCount().then(function(waitingCount) {
-            expect(waitingCount).to.eq(1);
+          return newQueue.getWaitingCount().then(function(waitingCount) {
+            expect(waitingCount).to.eq(3);
           });
         });
       });


### PR DESCRIPTION
### Notes
- This is a fix for #1148
- Fixed the issue where when rate limit hits, the jobs were been dropped
- Fixed the original test case for `should not put a job into the delayed queue when discard is true`, where it was equating `getActiveCount` instead of `getWaitingCount`

cc: @aleccool213 