### PR TITLE
consider priority when promoting a job #1205

### DIFF
--- a/lib/commands/promote-3.lua
+++ b/lib/commands/promote-3.lua
@@ -1,0 +1,48 @@
+--[[
+  Promotes a job that is currently "delayed" to the "waiting" state
+
+     Input:
+      KEYS[1] 'delayed'
+      KEYS[2] 'wait'
+      KEYS[3] 'priority'
+
+      ARGV[1]  queue.toKey('')
+      ARGV[2]  jobId
+      ARGV[3]  queue token
+
+     Events:
+      'waiting'
+]]
+local rcall = redis.call;
+
+if redis.call("ZREM", KEYS[1], jobId) == 1 then
+  local priority = tonumber(rcall("HGET", ARGV[1] .. jobId, "priority")) or 0
+
+  local target = KEYS[2];
+
+  if priority == 0 then
+    -- LIFO or FIFO
+    rcall("LPUSH", target, jobId)
+  else
+    -- Priority add
+    rcall("ZADD", KEYS[3], priority, jobId)
+    local count = rcall("ZCOUNT", KEYS[3], 0, priority)
+
+    local len = rcall("LLEN", target)
+    local id = rcall("LINDEX", target, len - (count - 1))
+    if id then
+      rcall("LINSERT", target, "BEFORE", id, jobId)
+    else
+      rcall("RPUSH", target, jobId)
+    end
+  end
+
+  -- Emit waiting event (wait..ing@token)
+  rcall("PUBLISH", KEYS[2] .. "ing@" .. ARGV[3], jobId)
+
+  rcall("HSET", ARGV[1] .. jobId, "delay", 0)
+
+  return 0
+else
+  return -1
+end

--- a/lib/commands/promote-3.lua
+++ b/lib/commands/promote-3.lua
@@ -14,6 +14,7 @@
       'waiting'
 ]]
 local rcall = redis.call;
+local jobId = ARGV[2]
 
 if redis.call("ZREM", KEYS[1], jobId) == 1 then
   local priority = tonumber(rcall("HGET", ARGV[1] .. jobId, "priority")) or 0

--- a/lib/job.js
+++ b/lib/job.js
@@ -278,26 +278,11 @@ Job.prototype.promote = function() {
   const queue = this.queue;
   const jobId = this.id;
 
-  const script = [
-    'if redis.call("ZREM", KEYS[1], ARGV[1]) == 1 then',
-    ' redis.call("LPUSH", KEYS[2], ARGV[1])',
-    ' return 0',
-    'else',
-    ' return -1',
-    'end'
-  ].join('\n');
-
-  const keys = _.map(['delayed', 'wait'], name => {
-    return queue.toKey(name);
+  return scripts.promote(queue, jobId).then(result => {
+    if (result === -1) {
+      throw new Error('Job ' + jobId + ' is not in a delayed state');
+    }
   });
-
-  return queue.client
-    .eval(script, keys.length, keys[0], keys[1], jobId)
-    .then(result => {
-      if (result === -1) {
-        throw new Error('Job ' + jobId + ' is not in a delayed state');
-      }
-    });
 };
 
 /**

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -334,6 +334,14 @@ const scripts = {
     return queue.client.updateDelaySet(keys.concat(args));
   },
 
+  promote(queue, jobId) {
+    const keys = [queue.keys.delayed, queue.keys.wait, queue.keys.priority];
+
+    const args = [queue.toKey(''), jobId, queue.token];
+
+    return queue.client.promote(keys.concat(args));
+  },
+
   /**
    * Looks for unlocked jobs in the active queue.
    *

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -605,12 +605,16 @@ describe('Job', () => {
           done();
         }
       });
+      const processStarted = new Promise(resolve =>
+        queue.once('active', resolve)
+      );
 
       const add = (id, ms) =>
         queue.add({}, { jobId: id, delay: ms, priority: 1 });
 
       add('1')
         .then(() => add('2', 1))
+        .then(() => processStarted)
         .then(() => add('3', 5000))
         .then(job => {
           job.promote();

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -591,6 +591,33 @@ describe('Job', () => {
       });
     });
 
+    it('should process a promoted job according to its priority', done => {
+      queue.process(() => {
+        return delay(100);
+      });
+
+      const completed = [];
+
+      queue.on('completed', job => {
+        completed.push(job.id);
+        if (completed.length > 3) {
+          expect(completed).to.be.eql(['1', '2', '3', '4']);
+          done();
+        }
+      });
+
+      const add = (id, ms) =>
+        queue.add({}, { jobId: id, delay: ms, priority: 1 });
+
+      add('1')
+        .then(() => add('2', 1))
+        .then(() => add('3', 5000))
+        .then(job => {
+          job.promote();
+        })
+        .then(() => add('4', 1));
+    });
+
     it('should not promote a job that is not delayed', () => {
       return Job.create(queue, { foo: 'bar' }).then(job => {
         return job


### PR DESCRIPTION
`job.promote()` just `LPUSH`ed to the waiting queue.
That meant that all 'new' jobs with **any** priority were processed first.

Additionally, the `waiting` event was not emitted. I'm not sure if this was on purpose. I found it confusing. 

fixes https://github.com/OptimalBits/bull/issues/1205