### PR TITLE
perf: improve update delay set logic

### DIFF
--- a/lib/commands/updateDelaySet-6.lua
+++ b/lib/commands/updateDelaySet-6.lua
@@ -65,7 +65,6 @@ end
 
 local nextTimestamp = rcall("ZRANGE", KEYS[1], 0, 0, "WITHSCORES")[2]
 if(nextTimestamp ~= nil) then
-  nextTimestamp = nextTimestamp / 0x1000
-  rcall("PUBLISH", KEYS[1], nextTimestamp)
+  rcall("PUBLISH", KEYS[1], nextTimestamp / 0x1000)
 end
 return nextTimestamp

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -870,11 +870,10 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
         .then(nextTimestamp => {
           const now = Date.now();
           if (nextTimestamp) {
-            nextTimestamp = nextTimestamp < now ? now : nextTimestamp;
-          } else {
-            nextTimestamp = Number.MAX_VALUE;
+            const delay = nextTimestamp > now ? nextTimestamp - now : 0;
+            this.delayTimer = setTimeout(delayUpdate, delay);
           }
-          return this.updateDelayTimer(nextTimestamp);
+          this.delayedTimestamp = nextTimestamp || Number.MAX_VALUE;
         })
         .catch(err => {
           this.emit('error', err, 'Error updating the delay timer');

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -866,8 +866,9 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
 
     const delayUpdate = () => {
       scripts
-        .updateDelaySet(this, this.delayedTimestamp)
+        .updateDelaySet(this, Date.now())
         .then(nextTimestamp => {
+          const now = Date.now();
           if (nextTimestamp) {
             nextTimestamp = nextTimestamp < now ? now : nextTimestamp;
           } else {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -853,25 +853,33 @@ Queue.prototype.run = function(concurrency) {
 */
 Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
   const now = Date.now();
+
   newDelayedTimestamp = Math.round(newDelayedTimestamp);
-  if (
-    newDelayedTimestamp < this.delayedTimestamp &&
-    newDelayedTimestamp < MAX_TIMEOUT_MS + now
-  ) {
+  if (newDelayedTimestamp < this.delayedTimestamp) {
     clearTimeout(this.delayTimer);
     this.delayedTimestamp = newDelayedTimestamp;
 
     const nextDelayedJob = newDelayedTimestamp - now;
     const delay = nextDelayedJob <= 0 ? 0 : nextDelayedJob;
 
+    const update = delay => {
+      if (delay) {
+        delay = delay < MAX_TIMEOUT_MS ? delay : MAX_TIMEOUT_MS;
+        this.delayTimer = setTimeout(delayUpdate, delay);
+      } else {
+        delayUpdate();
+      }
+    };
+
     const delayUpdate = () => {
       scripts
         .updateDelaySet(this, Date.now())
         .then(nextTimestamp => {
-          const now = Date.now();
           if (nextTimestamp) {
+            nextTimestamp /= 4096;
+            const now = Date.now();
             const delay = nextTimestamp > now ? nextTimestamp - now : 0;
-            this.delayTimer = setTimeout(delayUpdate, delay);
+            update(delay);
           }
           this.delayedTimestamp = nextTimestamp || Number.MAX_VALUE;
         })
@@ -881,14 +889,9 @@ Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
         .then(() => {
           return null;
         });
-      this.delayedTimestamp = Number.MAX_VALUE;
     };
 
-    if (delay) {
-      this.delayTimer = setTimeout(delayUpdate, delay);
-    } else {
-      delayUpdate();
-    }
+    update(delay);
   }
   return null;
 };

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -137,6 +137,7 @@ describe('repeat', () => {
   });
 
   it('should repeat every 2 seconds', function(done) {
+    this.timeout(20000);
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
@@ -363,7 +364,7 @@ describe('repeat', () => {
     const date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
 
-    const nextTick = 2 * ONE_SECOND;
+    const nextTick = 2 * ONE_SECOND + 250;
     const repeat = { cron: '*/2 * * * * *' };
 
     queue.add('remove', { foo: 'bar' }, { repeat }).then(() => {
@@ -422,7 +423,7 @@ describe('repeat', () => {
     const date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
 
-    const nextTick = 2 * ONE_SECOND;
+    const nextTick = 2 * ONE_SECOND + 250;
     const repeat = { cron: '*/2 * * * * *' };
 
     queue.add({ foo: 'bar' }, { repeat: repeat, jobId: 'xxxx' }).then(() => {
@@ -462,7 +463,7 @@ describe('repeat', () => {
   it('should not re-add a repeatable job after it has been removed', function() {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    const nextTick = 2 * ONE_SECOND;
+    const nextTick = 2 * ONE_SECOND + 250;
     const repeat = { cron: '*/2 * * * * *' };
     const nextRepeatableJob = queue.nextRepeatableJob;
     this.clock.tick(date.getTime());
@@ -596,13 +597,16 @@ describe('repeat', () => {
     let currentPriority = 1;
     const nextTick = 1000;
 
-    jobAdds.push(queue.add({ p: 1 }, { priority: 1, delay: nextTick * 3 }));
-    jobAdds.push(queue.add({ p: 2 }, { priority: 2, delay: nextTick * 2 }));
-    jobAdds.push(queue.add({ p: 3 }, { priority: 3, delay: nextTick }));
+    const date = new Date('2017-02-07 9:24:00');
+    this.clock.tick(date.getTime());
 
-    _this.clock.tick(nextTick * 3);
+    jobAdds.push(queue.add({ p: 1 }, { priority: 1, delay: nextTick * 2 }));
+    jobAdds.push(queue.add({ p: 3 }, { priority: 3, delay: nextTick * 2 }));
+    jobAdds.push(queue.add({ p: 2 }, { priority: 2, delay: nextTick * 2 }));
 
     Promise.all(jobAdds).then(() => {
+      _this.clock.tick(nextTick * 3);
+
       queue.process((job, jobDone) => {
         try {
           expect(job.id).to.be.ok;
@@ -620,7 +624,7 @@ describe('repeat', () => {
   });
 
   // Skip test that only fails on travis
-  it.skip('should use ".every" as a valid interval', function(done) {
+  it('should use ".every" as a valid interval', function(done) {
     const _this = this;
     const interval = ONE_SECOND * 2;
     const date = new Date('2017-02-07 9:24:00');
@@ -688,7 +692,7 @@ describe('repeat', () => {
   });
 
   // This tests works well locally but fails in travis for some unknown reason.
-  it.skip('should emit a waiting event when adding a repeatable job to the waiting list', function(done) {
+  it('should emit a waiting event when adding a repeatable job to the waiting list', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
     this.clock.tick(date.getTime());
@@ -715,7 +719,7 @@ describe('repeat', () => {
     const _this = this;
 
     queue.add({ foo: 'bar' }, { repeat: { every: 1000 } }).then(() => {
-      _this.clock.tick(ONE_SECOND);
+      _this.clock.tick(ONE_SECOND + 10);
     });
 
     queue.process(job => {


### PR DESCRIPTION
possibly fixes #1110 

This PR improves the way delayed jobs are moved to the wait queue. Instead of just moving one at a time it moves as much as 1000 in one call, making it several orders of magnitud faster than previous implementation.