### PR TITLE
Throwing error when trying to insert object with existing ID

### DIFF
--- a/lib/commands/addJob-6.lua
+++ b/lib/commands/addJob-6.lua
@@ -47,7 +47,7 @@ else
   jobId = ARGV[2]
   jobIdKey = ARGV[1] .. jobId
   if rcall("EXISTS", jobIdKey) == 1 then
-    return jobId .. "" -- convert to string
+    error("A job with ID " .. jobId .. " already exists")
   end
 end
 


### PR DESCRIPTION
Now we can do something like 

```
  try {
    const job = await JobQueue.add('storyJob', data, {jobId: `${id}:${lastMod}`});
    res.json({message: `storyID ${id}`});
  } catch (e) {
    console.log(`Error adding job!: ${e}`);
    res.status(500).json({message: `${e}`});
  }
```