### PR TITLE
Don't use `latest` for get-port version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1518,9 +1518,9 @@
       "dev": true
     },
     "get-port": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.1.0.tgz",
-      "integrity": "sha512-4/fqAYrzrzOiqDrdeZRKXGdTGgbkfTEumGlNQPeP6Jy8w0PzN9mzeNQ3XgHaTNie8pQ3hOUkrwlZt2Fzk5H9mA=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+      "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw=="
     },
     "get-stdin": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "cron-parser": "^2.7.3",
     "debuglog": "^1.0.0",
-    "get-port": "latest",
+    "get-port": "^4.2.0",
     "ioredis": "^4.5.1",
     "lodash": "^4.17.11",
     "p-timeout": "^2.0.1",


### PR DESCRIPTION
This fixes churn in package-lock.json as well as preventing future breakage when get-port releases a backwards incompatible version.

The `get-port` dependency was added in #1168.