### PR TITLE
fixed the wrong invocation parameters in a dead function

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -208,11 +208,8 @@ const scripts = {
     const args = scripts.moveToFailedArgs(
       job,
       failedReason,
-      'failedReason',
       removeOnFailed,
-      'failed',
-      ignoreLock,
-      true
+      ignoreLock
     );
     return scripts.moveToFinished(args);
   },


### PR DESCRIPTION
Luckily `scripts#moveToFailed` has never been called, because it invokes `scripts#moveToFailedArgs` with wrong parameters. Seems like a copy&paste mistake :)