### PR TITLE
docs: add link to prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ There are a few third-party UIs that you can use for monitoring:
 
 ---
 
+### Monitoring & Alerting
+
+- With Prometheus [Bull Queue Exporter](https://github.com/UpHabit/bull_exporter)
+
+---
+
 ### Feature Comparison
 
 Since there are a few job queue solutions, here a table comparing them to help you use the one that


### PR DESCRIPTION
We created a Prometheus exporter for bull,
we've been using in prod for several months now and think more users would benefit from it.

https://github.com/UpHabit/bull_exporter