### PR TITLE
removed a redundant parameter at Job#addJob

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -62,17 +62,11 @@ function addJob(queue, job) {
   const opts = job.opts;
 
   const jobData = job.toData();
-  return scripts.addJob(
-    queue.client,
-    queue,
-    jobData,
-    {
-      lifo: opts.lifo,
-      customJobId: opts.jobId,
-      priority: opts.priority
-    },
-    queue.token
-  );
+  return scripts.addJob(queue.client, queue, jobData, {
+    lifo: opts.lifo,
+    customJobId: opts.jobId,
+    priority: opts.priority
+  });
 }
 
 Job.create = function(queue, name, data, opts) {


### PR DESCRIPTION
`scripts#addJob` accepts 4 parameters, but the invocation at `Job#addJob` sents 5. The last `queue.token` is not used and not necessary.