### PR TITLE
Rewrite timing logic for updating delay set

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -42,7 +42,7 @@ const commands = require('./commands/');
     job -> wait -> active
        \     ^            \
         v    |             -- > failed
-        delayed 
+        delayed
 */
 
 /**
@@ -56,7 +56,6 @@ const commands = require('./commands/');
   delayed job is processed after timing out.
 */
 const MINIMUM_REDIS_VERSION = '2.8.18';
-const MAX_TIMEOUT_MS = Math.pow(2, 31) - 1; // 32 bit signed
 
 /*
   interface QueueOptions {
@@ -304,31 +303,6 @@ function redisOptsFromUrl(urlString) {
   return redisOpts;
 }
 
-function setGuardianTimer(queue) {
-  return setInterval(() => {
-    const now = Date.now();
-    if (
-      queue.delayedTimestamp < now ||
-      queue.delayedTimestamp - now > queue.settings.guardInterval
-    ) {
-      scripts
-        .updateDelaySet(queue, now)
-        .then(timestamp => {
-          if (timestamp) {
-            queue.updateDelayTimer(timestamp / 4096);
-          }
-          return null;
-        })
-        .catch(err => {
-          queue.emit('error', err);
-        })
-        .then(() => {
-          return null;
-        });
-    }
-  }, queue.settings.guardInterval);
-}
-
 util.inherits(Queue, EventEmitter);
 
 //
@@ -366,27 +340,7 @@ Queue.prototype._initProcess = function() {
         return this._registerEvent('delayed');
       })
       .then(() => {
-        //
-        // Init delay timestamp.
-        //
-        return scripts
-          .updateDelaySet(this, Date.now())
-          .then(timestamp => {
-            if (timestamp) {
-              this.updateDelayTimer(timestamp / 4096);
-            }
-            return null;
-          })
-          .then(() => {
-            return null;
-          });
-      })
-      .then(() => {
-        //
-        // Create a guardian timer to revive delayTimer if necessary
-        // This is necessary when redis connection is unstable, which can cause the pub/sub to fail
-        //
-        this.guardianTimer = setGuardianTimer(this);
+        return this.updateDelayTimer();
       });
 
     this.errorRetryTimer = {};
@@ -446,9 +400,18 @@ Queue.prototype._setupQueueEventListeners = function() {
         this.emit('global:progress', jobId, JSON.parse(progress));
         break;
       }
-      case delayedKey:
-        this.updateDelayTimer(message);
+      case delayedKey: {
+        const newDelayedTimestamp = _.ceil(message);
+        if (newDelayedTimestamp < this.delayedTimestamp) {
+          // The new delayed timestamp is before the currently newest known delayed timestamp
+          // Assume this is the new delayed timestamp and call `updateDelayTimer()` to process any delayed jobs
+          // This will also update the `delayedTimestamp`
+          this.delayedTimestamp = newDelayedTimestamp;
+
+          this.updateDelayTimer();
+        }
         break;
+      }
       case pausedKey:
       case resumedKey:
         this.emit('global:' + message);
@@ -851,49 +814,38 @@ Queue.prototype.run = function(concurrency) {
   This function updates the delay timer, which is a timer that timeouts
   at the next known delayed job.
 */
-Queue.prototype.updateDelayTimer = function(newDelayedTimestamp) {
-  const now = Date.now();
+Queue.prototype.updateDelayTimer = function() {
+  return scripts
+    .updateDelaySet(this, Date.now())
+    .then(nextTimestamp => {
+      this.delayedTimestamp = nextTimestamp
+        ? nextTimestamp / 4096
+        : Number.MAX_VALUE;
 
-  newDelayedTimestamp = Math.round(newDelayedTimestamp);
-  if (newDelayedTimestamp < this.delayedTimestamp) {
-    clearTimeout(this.delayTimer);
-    this.delayedTimestamp = newDelayedTimestamp;
-
-    const nextDelayedJob = newDelayedTimestamp - now;
-    const delay = nextDelayedJob <= 0 ? 0 : nextDelayedJob;
-
-    const update = delay => {
-      if (delay) {
-        delay = delay < MAX_TIMEOUT_MS ? delay : MAX_TIMEOUT_MS;
-        this.delayTimer = setTimeout(delayUpdate, delay);
-      } else {
-        delayUpdate();
+      // Clear any existing update delay timer
+      if (this.delayTimer) {
+        clearTimeout(this.delayTimer);
       }
-    };
 
-    const delayUpdate = () => {
-      scripts
-        .updateDelaySet(this, Date.now())
-        .then(nextTimestamp => {
-          if (nextTimestamp) {
-            nextTimestamp /= 4096;
-            const now = Date.now();
-            const delay = nextTimestamp > now ? nextTimestamp - now : 0;
-            update(delay);
-          }
-          this.delayedTimestamp = nextTimestamp || Number.MAX_VALUE;
-        })
-        .catch(err => {
-          this.emit('error', err, 'Error updating the delay timer');
-        })
-        .then(() => {
-          return null;
-        });
-    };
+      // Delay for the next update of delay set
+      const delay = _.min([
+        this.delayedTimestamp - Date.now(),
+        this.settings.guardInterval
+      ]);
 
-    update(delay);
-  }
-  return null;
+      // Schedule next processing of the delayed jobs
+      if (delay <= 0) {
+        // Next set of jobs are due right now, process them also
+        this.updateDelayTimer();
+      } else {
+        // Update the delay set when the next job is due
+        // or the next guard time
+        this.delayTimer = setTimeout(() => this.updateDelayTimer(), delay);
+      }
+    })
+    .catch(err => {
+      this.emit('error', err, 'Error updating the delay timer');
+    });
 };
 
 /**


### PR DESCRIPTION
This rewrites the logic around updating delay set to be a bit safer and simpler (imo).

In the previous code there was a race-condition due to the timer being cleared before the call to process the delay set, and in the time until the processing was done, another processing could have been started.

The new code does away with the guardian timer, and instead combines the guardian timer with the updates coming from new jobs being posted.

Refs https://github.com/OptimalBits/bull/issues/1222

