### PR TITLE
Update feature comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There are a few third-party UIs that you can use for monitoring:
 **Bull v3**
 
 - [Taskforce](https://taskforce.sh)
-- [Arena](https://github.com/mixmaxhq/arena)
+- [Arena](https://github.com/bee-queue/arena)
 
 **Bull <= v2**
 
@@ -113,15 +113,15 @@ Since there are a few job queue solutions, here is a table comparing them:
 | Backend         | redis         | redis |redis| mongo  |
 | Priorities      | ✓             |  ✓    |     |   ✓    |
 | Concurrency     | ✓             |  ✓    |  ✓  |   ✓    |
-| Delayed jobs    | ✓             |  ✓    |     |   ✓    |
-| Global events   | ✓             |  ✓    |     |        |
+| Delayed jobs    | ✓             |  ✓    |  ✓  |   ✓    |
+| Global events   | ✓             |  ✓    |  ✓  |        |
 | Rate Limiter    | ✓             |       |     |        |
 | Pause/Resume    | ✓             |  ✓    |     |        |
 | Sandboxed worker| ✓             |       |     |        |
 | Repeatable jobs | ✓             |       |     |   ✓    |
 | Atomic ops      | ✓             |       |  ✓  |        |
 | Persistence     | ✓             |   ✓   |  ✓  |   ✓    |
-| UI              | ✓             |   ✓   |     |   ✓    |
+| UI              | ✓             |   ✓   |  ✓  |   ✓    |
 | Optimized for   | Jobs / Messages | Jobs | Messages | Jobs |
 
 


### PR DESCRIPTION
Thanks for the useful feature comparison table. I notice that Bee Queue has gained some powers since the table was created though.

Bee Queue now supports [global events](https://www.npmjs.com/package/bee-queue#queue-pubsub-events), [delaying jobs](https://www.npmjs.com/package/bee-queue#jobdelayuntildatetimestamp) and a web UI via [Arena](https://github.com/bee-queue/arena) which is now hosted in the same org.