### PR TITLE
Fix check for supported file types

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -629,7 +629,7 @@ Queue.prototype.setHandler = function(name, handler) {
     const supportedFileTypes = ['js', 'ts', 'flow'];
     const processorFile =
       handler +
-      (supportedFileTypes.indexOf(path.extname(handler)) !== '-1' ? '' : '.js');
+      (supportedFileTypes.indexOf(path.extname(handler)) !== -1 ? '' : '.js');
 
     if (!fs.existsSync(processorFile)) {
       throw new Error('File ' + processorFile + ' does not exist');


### PR DESCRIPTION
 [There was a check for supported file types added](https://github.com/OptimalBits/bull/pull/1186) but it’s [checking](https://github.com/OptimalBits/bull/blob/7e10fd206bf6aaa8a1886170f3621d483c290b16/lib/queue.js#L632) for `supportedFileTypes.indexOf(path.extname(handler)) !== '-1' `,
`indexOf` returns a number `-1` not a string `'-1'`, so this check was always true.

Updated to  number `-1` instead of string.