### PR TITLE
Add skipImmediate attribute to RepeatOpts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -281,6 +281,7 @@ interface RepeatOpts {
   tz?: string; // Timezone
   startDate?: Date | string | number; // Start date when the repeat job should start repeating (only with cron).
   endDate?: Date | string | number; // End date when the repeat job should stop repeating.
+  skipImmediate?: boolean; // the repeat job should start right now or wait for the time
   limit?: number; // Number of times the job should repeat at max.
   every?: number; // Repeat every millis (cron setting cannot be used together with this setting.)
   count?: number; // The start value for the repeat iteration count.

--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -30,7 +30,7 @@ module.exports = function(Queue) {
     let now = Date.now();
     now = prevMillis < now ? now : prevMillis;
 
-    const nextMillis = getNextMillis(now, repeat);
+    const nextMillis = (skipCheckExists && !repeat.skipImmediate) ? now : getNextMillis(now, repeat);
     if (nextMillis) {
       const jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       const repeatJobKey = getRepeatKey(name, repeat, jobId);


### PR DESCRIPTION
#1239 As this issue said, it's better to have a skipImmediate attribute in RepeatOpts.