### PR TITLE
docs: fixed global listener example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -156,7 +156,7 @@ queue.on('completed', job => {
 Whereas the global version of the event can be listen to with:
 
 ```js
-queue.on('global: completed', jobId => {
+queue.on('global:completed', jobId => {
   console.log(`Job with id ${jobId} has been completed```);
   )
 })


### PR DESCRIPTION
Just checked, if you pass `"global: completed"` as event name, the callback won't be triggered. The correct is `"global:completed"`.