### PR TITLE
fix: unhandled promise warning

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -842,6 +842,11 @@ Queue.prototype.updateDelayTimer = function() {
         // or the next guard time
         this.delayTimer = setTimeout(() => this.updateDelayTimer(), delay);
       }
+
+      // Silence warnings about promise created but not returned.
+      // This isn't an issue since we emit errors.
+      // See http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
+      return null;
     })
     .catch(err => {
       this.emit('error', err, 'Error updating the delay timer');


### PR DESCRIPTION
By returning null, a warning won't be generated about unhandled promise.

I'm not totally sure how to reproduce this, but I think it happens when using a version of `ioredis` that returns Bluebird promises. I do not have a minimal test case, but I can reproduce it reliably. This change fixes it 100% of the time.

Alternatively, https://github.com/OptimalBits/bull/blob/c0ee6be03c6d47d60465d2bae0d2566d5bf0d661/lib/queue.js#L839 should potentially return the promise. But I'm not sure if not returning it is intentional.