### PR TITLE
add support for a staggered interval

### DIFF
--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -16,6 +16,7 @@ module.exports = function(Queue) {
     const client = this.client;
     const repeat = opts.repeat;
     const prevMillis = opts.prevMillis || 0;
+    const stagger = opts.stagger || 0;
 
     if (!prevMillis && opts.jobId) {
       repeat.jobId = opts.jobId;
@@ -30,7 +31,7 @@ module.exports = function(Queue) {
     let now = Date.now();
     now = prevMillis < now ? now : prevMillis;
 
-    const nextMillis = getNextMillis(now, repeat);
+    const nextMillis = getNextMillis(now, repeat) + stagger;
     if (nextMillis) {
       const jobId = repeat.jobId ? repeat.jobId + ':' : ':';
       const repeatJobKey = getRepeatKey(name, repeat, jobId);


### PR DESCRIPTION
it would be nice to introduce an initial stagger/offset, for the case where you have many jobs being enqueued at the same time with repeatable schedules, and perhaps they are all set to the same interval, but you want them evenly spread over that interval, so you could then specify a `stagger: Math.random()*interval` to act as a delay that will offset when jobs of similar intervals get started, so they don't all start at the same time every time.

see also: https://github.com/OptimalBits/bull/issues/883#issuecomment-505552546

my use case is, i have 50 jobs running on a one minute interval, and without this change, the consumer's CPU utilization spikes at the beginning of every minute, and is idle after that. not as efficient.