### PR TITLE
Support for bulk adding jobs

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -58,11 +58,11 @@ function setDefaultOpts(opts) {
 
 Job.DEFAULT_JOB_NAME = '__default__';
 
-function addJob(queue, job) {
+function addJob(queue, client, job) {
   const opts = job.opts;
 
   const jobData = job.toData();
-  return scripts.addJob(queue.client, queue, jobData, {
+  return scripts.addJob(client, queue, jobData, {
     lifo: opts.lifo,
     customJobId: opts.jobId,
     priority: opts.priority
@@ -75,12 +75,36 @@ Job.create = function(queue, name, data, opts) {
   return queue
     .isReady()
     .then(() => {
-      return addJob(queue, job);
+      return addJob(queue, queue.client, job);
     })
     .then(jobId => {
       job.id = jobId;
       debuglog('Job added', jobId);
       return job;
+    });
+};
+
+Job.createBulk = function(queue, jobs) {
+  jobs = jobs.map(job => new Job(queue, job.name, job.data, job.opts));
+
+  return queue
+    .isReady()
+    .then(() => {
+      const multi = queue.client.multi();
+
+      for (const job of jobs) {
+        addJob(queue, multi, job);
+      }
+
+      return multi.exec();
+    })
+    .then(res => {
+      res.forEach((res, index) => {
+        jobs[index].id = res[1];
+        debuglog('Job added', res[1]);
+      });
+
+      return jobs;
     });
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -699,6 +699,23 @@ Queue.prototype.add = function(name, data, opts) {
 };
 
 /**
+  Adds an array of jobs to the queue.
+  @method add
+  @param jobs: [] The array of jobs to add to the queue. Each job is defined by 3 properties, 'name', 'data' and 'opts'. They follow the same signature as 'Queue.add'.
+*/
+Queue.prototype.addBulk = function(jobs) {
+  for (const job of jobs) {
+    job.opts = _.cloneDeep(job.opts || {});
+    _.defaults(job.opts, this.defaultJobOptions);
+
+    if (typeof job.name !== 'string') {
+      job.name = Job.DEFAULT_JOB_NAME;
+    }
+  }
+
+  return Job.createBulk(this, jobs);
+};
+/**
   Empties the queue.
 
   Returns a promise that is resolved after the operation has been completed.


### PR DESCRIPTION
This is a sketch for adding support for posting multiple jobs at a time to the queue. I have added basic tests, but could add a few more to validate defaulting of options and names.

I wanted to check first that you think this is the right approach. This seems simpler than trying to modify the lua script, and should be the same performance.

Fixes https://github.com/OptimalBits/bull/issues/408