### PR TITLE
Improve documentation for getJobs()

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -414,7 +414,7 @@ getJobs(types: string[], start?: number, end?: number, asc?: boolean): Promise<J
 
 Returns a promise that will return an array of job instances of the given types. Optional parameters for range and ordering are provided. 
 
-Note: The `start` and `end` options are applied **per job type**. For example, if there are 10 jobs in state `completed` and 10 jobs in state `active`, `getJobs(['completed', 'active'], 0, 4)` will yield an array with 10 entries, representing the first 5 completed jobs (0 - 4) and the first 5 waiting jobs (0 - 4).
+Note: The `start` and `end` options are applied **per job type**. For example, if there are 10 jobs in state `completed` and 10 jobs in state `active`, `getJobs(['completed', 'active'], 0, 4)` will yield an array with 10 entries, representing the first 5 completed jobs (0 - 4) and the first 5 active jobs (0 - 4).
 
 ---
 


### PR DESCRIPTION
Clarify use of `start` and `end` options. Fixes #1454 