### PR TITLE
Add getPuased() function to getters

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -115,6 +115,10 @@ module.exports = function(Queue) {
     return this.getJobs('failed', start, end, false);
   };
 
+  Queue.prototype.getPaused = function(start, end) {
+    return this.getJobs('paused', start, end, false);
+  };
+
   Queue.prototype.getRanges = function(types, start, end, asc) {
     start = _.isUndefined(start) ? 0 : start;
     end = _.isUndefined(end) ? -1 : end;


### PR DESCRIPTION
I notice that **bull** still provides function `Queue.pause()` to get tasks into state **paused**. But when I trying to look up tasks in a queue with **bull-arena**, I got an error: 
```
WRONGTYPE Operation against a key holding the wrong kind of value
```

I check out [this PR](https://github.com/bee-queue/arena/pull/133) in *bull-arena*. The author modified in `src/server/views/dashboard/index.js`. However, after I modified, the new error occurred:
```
UnhandledPromiseRejectionWarning: TypeError: queue[(("get" + (intermediate value)) + "")] is not a function
```
**bull-arena** cannot map getPaused to function in **bull**. 
