### PR TITLE
:sparkles: support custom async backoff

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -237,7 +237,6 @@ Job.prototype.discard = function() {
  */
 Job.prototype.moveToFailed = function(err, ignoreLock) {
   this.failedReason = err.message;
-  // comment for travis build
   return new Promise(async (resolve, reject) => {
     let command;
     const multi = this.queue.client.multi();

--- a/lib/job.js
+++ b/lib/job.js
@@ -237,6 +237,7 @@ Job.prototype.discard = function() {
  */
 Job.prototype.moveToFailed = function(err, ignoreLock) {
   this.failedReason = err.message;
+  // comment for travis build
   return new Promise(async (resolve, reject) => {
     let command;
     const multi = this.queue.client.multi();

--- a/lib/job.js
+++ b/lib/job.js
@@ -237,7 +237,7 @@ Job.prototype.discard = function() {
  */
 Job.prototype.moveToFailed = function(err, ignoreLock) {
   this.failedReason = err.message;
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     let command;
     const multi = this.queue.client.multi();
     this._saveAttempt(multi, err);
@@ -246,7 +246,7 @@ Job.prototype.moveToFailed = function(err, ignoreLock) {
     let moveToFailed = false;
     if (this.attemptsMade < this.opts.attempts && !this._discarded) {
       // Check if backoff is needed
-      const delay = backoffs.calculate(
+      const delay = await backoffs.calculate(
         this.opts.backoff,
         this.attemptsMade,
         this.queue.settings.backoffStrategies,


### PR DESCRIPTION
This PR introduces a support for async backoff strategies. Sometimes we need to make calls to some external apis etc to determine if a job should be restarted or not, for example checking if the file was already processed etc.