### PR TITLE
test: fix mocha options

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "scripts": {
     "lint": "eslint lib test",
     "pretest": "npm run lint",
-    "test": "NODE_ENV=test mocha --exit",
+    "test": "NODE_ENV=test mocha 'test/test_*'",
     "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --exit -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "postpublish": "git push && git push --tags",
     "prettier": "prettier --config package.json --write '**/*.js'",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --reporter spec
 --timeout 5000
-test/test_*
+--exit


### PR DESCRIPTION
Having `test/test_*` in `mocha.opts` meant that it was not possible to run an individual test in isolation.

This may have been caused by the recent mocha version upgrade.