### PR TITLE
test: ban use of console

### DIFF
--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -5,4 +5,5 @@ env:
   mocha: true
 
 rules:
+  no-console: 2
   no-process-exit: 0

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -484,7 +484,6 @@ describe('Job', () => {
       const job = await Job.create(queue, { foo: 'bar' });
       await job.progress({ total: 120, completed: 40 });
       const storedJob = await Job.fromId(queue, job.id);
-      console.error(storedJob);
       expect(storedJob.progress()).to.eql({ total: 120, completed: 40 });
     });
   });


### PR DESCRIPTION
Logging is useful in tests to debug failures, but leaving it in leads to noise.

![image](https://user-images.githubusercontent.com/610129/68138588-d2968300-fef6-11e9-9bd7-84e734181bbc.png)
