### PR TITLE
fix(pause): don't initialize bclient if not waiting for jobs to finish

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -779,6 +779,11 @@ Queue.prototype.pause = function(isLocal, doNotWaitActive) {
           });
         }
 
+        if (!this.bclientInitialized) {
+          // bclient not yet initialized, so no jobs to wait for
+          return;
+        }
+
         if (doNotWaitActive) {
           // Force reconnection of blocking connection to abort blocking redis call immediately.
           return redisClientDisconnect(this.bclient).then(() => {

--- a/test/test_pause.js
+++ b/test/test_pause.js
@@ -399,6 +399,17 @@ describe('.pause', () => {
           'getNextJob should return without getting job'
         );
       });
+
+      it('should not initialize blocking client if not already initialized', async () => {
+        const createClient = sinon.spy(() => client);
+        const queue = utils.buildQueue('pause-queue', { createClient });
+
+        await queue.pause(true, true);
+        const bClientCalls = createClient
+          .getCalls()
+          .filter(c => c.args[0] === 'bclient');
+        expect(bClientCalls).to.have.lengthOf(0);
+      });
     });
   });
 });


### PR DESCRIPTION
This is the same change as #1347 but for `pause(true, true)`.

Fixes https://github.com/OptimalBits/bull/issues/1553