### PR TITLE
fix(options): merge redis options with parsed url

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -90,7 +90,7 @@ const Queue = function Queue(name, url, opts) {
   }
 
   if (_.isString(url)) {
-    opts = _.extend(
+    opts = _.merge(
       {},
       {
         redis: redisOptsFromUrl(url)


### PR DESCRIPTION
With this improvement we can pass Redis TLS options and use url parameter at the same time.
Example:
```javascript
const tls = { key: "", cert:"", ca:"" };
const redis_url = "redis://localhost:6379";
const queue = new Queue(name, redis_url, { redis: { tls } });
```