### PR TITLE
fix: whenCurrentJobsFinished should wait for all jobs

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1191,7 +1191,7 @@ Queue.prototype.whenCurrentJobsFinished = function() {
     return this.bclient.connect();
   });
 
-  return Promise.all([this.processing[0]]).then(() => {
+  return Promise.all(this.processing).then(() => {
     return forcedReconnection;
   });
 };


### PR DESCRIPTION
We're currently only waiting for the first job to finish, not all active jobs.

See https://github.com/OptimalBits/bull/pull/1542/files#r356810178

Fixes https://github.com/OptimalBits/bull/issues/1616