### PR TITLE
fix: call Queue.isReady() before job promote is called

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -304,12 +304,13 @@ Job.prototype.moveToDelayed = function(timestamp, ignoreLock) {
 Job.prototype.promote = function() {
   const queue = this.queue;
   const jobId = this.id;
-
-  return scripts.promote(queue, jobId).then(result => {
-    if (result === -1) {
-      throw new Error('Job ' + jobId + ' is not in a delayed state');
-    }
-  });
+  return queue.isReady().then(() =>
+    scripts.promote(queue, jobId).then(result => {
+      if (result === -1) {
+        throw new Error('Job ' + jobId + ' is not in a delayed state');
+      }
+    })
+  );
 };
 
 /**


### PR DESCRIPTION
The issue is described here: https://github.com/OptimalBits/bull/issues/1231
