### PR TITLE
feat: add "preventParsingData" option of job to prevent data parsing

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -556,8 +556,10 @@ Job.prototype._saveAttempt = function(multi, err) {
 };
 
 Job.fromJSON = function(queue, json, jobId) {
-  const data = JSON.parse(json.data || '{}');
   const opts = JSON.parse(json.opts || '{}');
+  const data = opts.preventParsingData
+    ? json.data
+    : JSON.parse(json.data || '{}');
 
   const job = new Job(queue, json.name || Job.DEFAULT_JOB_NAME, data, opts);
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -670,7 +670,8 @@ interface JobOptions
   repeat: {
     tz?: string,
     endDate?: Date | string | number
-  }
+  },
+  preventParsingData: boolean;
 }
 */
 

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -976,4 +976,27 @@ describe('Job', () => {
         );
     });
   });
+
+  describe('.fromJSON', () => {
+    let data;
+
+    beforeEach(() => {
+      data = { foo: 'bar' };
+    });
+
+    it('should parse JSON data by default', async () => {
+      const job = await Job.create(queue, data, {});
+      const jobParsed = Job.fromJSON(queue, job.toData());
+
+      expect(jobParsed.data).to.eql(data);
+    });
+
+    it('should not parse JSON data if "preventParsingData" option is specified', async () => {
+      const job = await Job.create(queue, data, { preventParsingData: true });
+      const jobParsed = Job.fromJSON(queue, job.toData());
+      const expectedData = JSON.stringify(data);
+
+      expect(jobParsed.data).to.be(expectedData);
+    });
+  });
 });


### PR DESCRIPTION
With this improvement we can specify a job option `{preventParsingData: true}` to preventing parsing of job data.
Close #1630 