### PR TITLE
fix: prevent exceeding the maximum stack call size when emptying large queues

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -750,7 +750,9 @@ Queue.prototype.empty = function() {
     if (jobKeys.length) {
       multi = this.multi();
 
-      multi.del.apply(multi, jobKeys);
+      for (let i = 0; i < jobKeys.length; i += 10000) {
+        multi.del.apply(multi, jobKeys.slice(i, i + 10000));
+      }
       return multi.exec();
     }
   });


### PR DESCRIPTION
regarding https://github.com/OptimalBits/bull/issues/1658