### PR TITLE
Update REFERENCE.md

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -249,7 +249,7 @@ interface JobOpts {
   priority: number; // Optional priority value. ranges from 1 (highest priority) to MAX_INT  (lowest priority). Note that
   // using priorities has a slight impact on performance, so do not use it if not required.
 
-  delay: number; // An amount of miliseconds to wait until this job can be processed. Note that for accurate delays, both
+  delay: number; // An amount of milliseconds to wait until this job can be processed. Note that for accurate delays, both
   // server and clients should have their clocks synchronized. [optional].
 
   attempts: number; // The total number of attempts to try the job until it completes.


### PR DESCRIPTION
docs: correct spelling of milliseconds