### PR TITLE
docs: mention the message queue pattern as job completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Besides helping Bull's development, you will also benefit from a constantly-impr
 
 And coming up on the roadmap...
 
-- [ ] Job completion acknowledgement.
+- [ ] Job completion acknowledgement (you can use the message queue [pattern](https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#returning-job-completions) in the meantime).
 - [ ] Parent-child jobs relationships.
 
 ---


### PR DESCRIPTION
Hi guys,

A million thanks for your work on Bull, it's a central piece of my project.

I missed having this information in the README, it pushed me towards Kue when I started. Sorry if it's obvious to you, that pattern wasn't for me. Thought this could help others.

Feel free to close :)

Let me know if you'd like me to bump the version and add this to the changelog.

In any case, thanks again for your great work! I hope you find the time to keep it up!