### PR TITLE
Error initializing Lua scripts fix

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -29,7 +29,7 @@ module.exports = (function() {
 
   return function(client) {
     return utils.isRedisReady(client).then(() => {
-      scripts = scripts || loadScripts(__dirname);
+      scripts = scripts || loadScripts(path.dirname(require.resolve("bull")) + '/lib/commands');
 
       return scripts.then(_scripts => {
         return _scripts.forEach(command => {


### PR DESCRIPTION
changing **__dirname** to **path.dirname(require.resolve("bull")) + '/lib/commands'**  because webpack has different behaviour and its generate error **Error: Error initializing Lua scripts\n at**