### PR TITLE
fix: emit waiting event when adding a priority job (#1134)

### DIFF
--- a/lib/commands/addJob-6.lua
+++ b/lib/commands/addJob-6.lua
@@ -79,9 +79,6 @@ else
   if priority == 0 then
       -- LIFO or FIFO
     rcall(ARGV[10], target, jobId)
-
-    -- Emit waiting event (wait..ing@token)
-    rcall("PUBLISH", KEYS[1] .. "ing@" .. ARGV[11], jobId)
   else
     -- Priority add
     rcall("ZADD", KEYS[6], priority, jobId)
@@ -96,6 +93,9 @@ else
     end
 
   end
+
+  -- Emit waiting event (wait..ing@token)
+  rcall("PUBLISH", KEYS[1] .. "ing@" .. ARGV[11], jobId)
 end
 
 return jobId .. "" -- convert to string

--- a/test/test_events.js
+++ b/test/test_events.js
@@ -154,6 +154,20 @@ describe('events', () => {
     });
   });
 
+  it('should emit an event when a new priority message is added to the queue', done => {
+    const client = new redis(6379, '127.0.0.1', {});
+    client.select(0);
+    const queue = new Queue('test pub sub');
+    queue.on('waiting', jobId => {
+      expect(parseInt(jobId, 10)).to.be.eql(1);
+      client.quit();
+      done();
+    });
+    queue.once('registered:waiting', () => {
+      queue.add({ test: 'stuff' }, { priority: 1 });
+    });
+  });
+
   it('should emit an event when a job becomes active', done => {
     const queue = utils.buildQueue();
     queue.process((job, jobDone) => {


### PR DESCRIPTION
Ensure a waiting event is sent for priority jobs and adds a test to verify this behavior.