### PR TITLE
Grouped rate limiting

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,10 +73,10 @@ interface QueueOptions {
 
 ```typescript
 interface RateLimiter {
-  max: number,      // Max number of jobs processed
-  duration: number, // per duration in milliseconds
+  max: number; // Max number of jobs processed
+  duration: number; // per duration in milliseconds
   bounceBack: boolean = false; // When jobs get rate limited, they stay in the waiting queue and are not moved to the delayed queue
-  key: string // optional - allows the grouping of jobs with the specified key
+  key: string; // optional - allows the grouping of jobs with the specified key from the data object passed to the Queue#add (ex. "networkHandle.handle")
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -76,6 +76,7 @@ interface RateLimiter {
   max: number,      // Max number of jobs processed
   duration: number, // per duration in milliseconds
   bounceBack: boolean = false; // When jobs get rate limited, they stay in the waiting queue and are not moved to the delayed queue
+  key: string // optional - allows the grouping of jobs with the specified key
 }
 ```
 
@@ -446,7 +447,7 @@ parameter. If the specified job cannot be located, the promise will be resolved 
 getJobs(types: JobStatus[], start?: number, end?: number, asc?: boolean): Promise<Job[]>
 ```
 
-Returns a promise that will return an array of job instances of the given job statuses. Optional parameters for range and ordering are provided. 
+Returns a promise that will return an array of job instances of the given job statuses. Optional parameters for range and ordering are provided.
 
 Note: The `start` and `end` options are applied **per job statuses**. For example, if there are 10 jobs in state `completed` and 10 jobs in state `active`, `getJobs(['completed', 'active'], 0, 4)` will yield an array with 10 entries, representing the first 5 completed jobs (0 - 4) and the first 5 active jobs (0 - 4).
 

--- a/lib/commands/moveToActive-8.lua
+++ b/lib/commands/moveToActive-8.lua
@@ -55,6 +55,9 @@ if jobId then
     -- local jobCounter = tonumber(rcall("GET", rateLimiterKey))
     if(ARGV[9]) then
       local handle = string.match(jobId, "[^:]+$");
+      if(handle == nil) then
+        return
+      end
       rateLimiterKey = KEYS[6] .. ":" .. handle;
     end
     local jobCounter = tonumber(rcall("INCR", rateLimiterKey));

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -80,6 +80,8 @@ const MINIMUM_REDIS_VERSION = '2.8.18';
   interface RateLimiter {
     max: number,      // Number of jobs
     duration: number, // per duration milliseconds
+    bounceBack: boolean, // When jobs get rate limited, they stay in the waiting queue and are not moved to the delayed queue
+    key: string // key to limit the queue by
   }
 */
 
@@ -705,6 +707,9 @@ Queue.prototype.add = function(name, data, opts) {
   opts = _.cloneDeep(opts || {});
   _.defaults(opts, this.defaultJobOptions);
 
+  if (this.limiter.key) {
+    opts.jobId = Date.now() + ":" + data[this.limiter.key];
+  }
   if (opts.repeat) {
     return this.isReady().then(() => {
       return this.nextRepeatableJob(name, data, opts, true);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -707,8 +707,8 @@ Queue.prototype.add = function(name, data, opts) {
   opts = _.cloneDeep(opts || {});
   _.defaults(opts, this.defaultJobOptions);
 
-  if (this.limiter.key) {
-    opts.jobId = Date.now() + ":" + data[this.limiter.key];
+  if (this.limiter && this.limiter.key) {
+    opts.jobId = Date.now() + ":" + _.get(data, this.limiter.key);
   }
   if (opts.repeat) {
     return this.isReady().then(() => {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -708,8 +708,13 @@ Queue.prototype.add = function(name, data, opts) {
   _.defaults(opts, this.defaultJobOptions);
 
   if (this.limiter && this.limiter.key) {
-    opts.jobId = Date.now() + ":" + _.get(data, this.limiter.key);
+    if (!opts.jobId) {
+      opts.jobId = uuid() + ':' + _.get(data, this.limiter.key);
+    } else {
+      opts.jobId = opts.jobId + ':' + _.get(data, this.limiter.key);
+    }
   }
+
   if (opts.repeat) {
     return this.isReady().then(() => {
       return this.nextRepeatableJob(name, data, opts, true);
@@ -731,6 +736,14 @@ Queue.prototype.addBulk = function(jobs) {
 
     if (typeof job.name !== 'string') {
       job.name = Job.DEFAULT_JOB_NAME;
+    }
+
+    if (this.limiter && this.limiter.key) {
+      if (!job.opts.jobId) {
+        job.opts.jobId = uuid() + ':' + _.get(job.data, this.limiter.key);
+      } else {
+        job.opts.jobId = job.opts.jobId + ':' + _.get(job.data, this.limiter.key);
+      }
     }
   }
 

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -81,7 +81,8 @@ const scripts = {
       args.push(
         queue.limiter.max,
         queue.limiter.duration,
-        !!queue.limiter.bounceBack
+        !!queue.limiter.bounceBack,
+        queue.limiter.key
       );
     }
     return queue.client.moveToActive(keys.concat(args)).then(raw2jobData);


### PR DESCRIPTION
This commit adds a `key` property to the `limiter` and allows you to define a key from the `data` object passed to `Queue#add` method so that when doing rate limiting it will group and limit the entries by that key.
`key` property should be a string and can also define a nested key