### PR TITLE
feat(sandbox): kill child workers gracefully

### DIFF
--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -4,6 +4,9 @@ const fork = require('child_process').fork;
 const path = require('path');
 const _ = require('lodash');
 const getPort = require('get-port');
+const { killAsync } = require('./utils');
+
+const CHILD_KILL_TIMEOUT = 30000;
 
 const ChildPool = function ChildPool() {
   if (!(this instanceof ChildPool)) {
@@ -78,20 +81,20 @@ ChildPool.prototype.remove = function(child) {
 };
 
 ChildPool.prototype.kill = function(child, signal) {
-  child.kill(signal || 'SIGKILL');
   this.remove(child);
+  return killAsync(child, signal || 'SIGKILL', CHILD_KILL_TIMEOUT);
 };
 
 ChildPool.prototype.clean = function() {
   const children = _.values(this.retained).concat(this.getAllFree());
-
-  children.forEach(child => {
-    // TODO: We may want to use SIGKILL if the process does not die after some time.
-    this.kill(child, 'SIGTERM');
-  });
-
   this.retained = {};
   this.free = {};
+
+  const allKillPromises = [];
+  children.forEach(child => {
+    allKillPromises.push(this.kill(child, 'SIGTERM'));
+  });
+  return Promise.all(allKillPromises).then(() => {});
 };
 
 ChildPool.prototype.getFree = function(id) {
@@ -102,10 +105,20 @@ ChildPool.prototype.getAllFree = function() {
   return _.flatten(_.values(this.free));
 };
 
-const initChild = function(child, processFile) {
-  return new Promise(resolve => {
-    child.send({ cmd: 'init', value: processFile }, resolve);
+async function initChild(child, processFile) {
+  const onComplete = new Promise(resolve => {
+    const onMessageHandler = msg => {
+      if (msg.cmd === 'init-complete') {
+        resolve();
+        child.off('message', onMessageHandler);
+      }
+    };
+    child.on('message', onMessageHandler);
   });
-};
 
+  await new Promise(resolve =>
+    child.send({ cmd: 'init', value: processFile }, resolve)
+  );
+  await onComplete;
+}
 module.exports = ChildPool;

--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -7,11 +7,19 @@
 
 let status;
 let processor;
+let currentJobPromise;
 
 //TODO remove for node >= 10
 require('promise.prototype.finally').shim();
 
 const promisify = require('util.promisify');
+
+// same as process.send but waits until the send is complete
+
+// the async version is used below because otherwise
+// the termination handler may exit before the parent
+// process has recived the messages it requires
+const processSendAsync = promisify(process.send.bind(process));
 
 // https://stackoverflow.com/questions/18391212/is-it-not-possible-to-stringify-an-error-using-json-stringify
 if (!('toJSON' in Error.prototype)) {
@@ -29,6 +37,20 @@ if (!('toJSON' in Error.prototype)) {
     writable: true
   });
 }
+
+async function waitForCurrentJobAndExit() {
+  status = 'TERMINATING';
+  try {
+    await currentJobPromise;
+  } finally {
+    // it's an exit handler
+    // eslint-disable-next-line no-process-exit
+    process.exit(process.exitCode || 0);
+  }
+}
+
+process.on('SIGTERM', waitForCurrentJobAndExit);
+process.on('SIGINT', waitForCurrentJobAndExit);
 
 process.on('message', msg => {
   switch (msg.cmd) {
@@ -51,6 +73,9 @@ process.on('message', msg => {
         };
       }
       status = 'IDLE';
+      process.send({
+        cmd: 'init-complete'
+      });
       break;
 
     case 'start':
@@ -61,27 +86,27 @@ process.on('message', msg => {
         });
       }
       status = 'STARTED';
-      Promise.resolve(processor(wrapJob(msg.job)) || {})
-        .then(
-          result => {
-            process.send({
-              cmd: 'completed',
-              value: result
-            });
-          },
-          err => {
-            if (!err.message) {
-              err = new Error(err);
-            }
-            process.send({
-              cmd: 'failed',
-              value: err
-            });
+      currentJobPromise = (async () => {
+        try {
+          const result = (await processor(wrapJob(msg.job))) || {};
+          await processSendAsync({
+            cmd: 'completed',
+            value: result
+          });
+        } catch (err) {
+          if (!err.message) {
+            // eslint-disable-next-line no-ex-assign
+            err = new Error(err);
           }
-        )
-        .finally(() => {
+          await processSendAsync({
+            cmd: 'failed',
+            value: err
+          });
+        } finally {
           status = 'IDLE';
-        });
+          currentJobPromise = null;
+        }
+      })();
       break;
     case 'stop':
       break;

--- a/lib/process/utils.js
+++ b/lib/process/utils.js
@@ -1,0 +1,45 @@
+'use strict';
+
+function hasProcessExited(child) {
+  return !!(child.exitCode !== null || child.signalCode);
+}
+
+function onExitOnce(child) {
+  return new Promise(resolve => {
+    child.once('exit', () => resolve());
+  });
+}
+
+/**
+ * Sends a kill signal to a child resolving when the child has exited,
+ * resorting to SIGKILL if the given timeout is reached
+ *
+ * @param {ChildProcess} child
+ * @param {'SIGTERM' | 'SIGKILL'} [signal] initial signal to use
+ * @param {number} [timeoutMs] time to wait until sending SIGKILL
+ *
+ * @returns {Promise<void>} the killed child
+ */
+function killAsync(child, signal, timeoutMs) {
+  if (hasProcessExited(child)) {
+    return Promise.resolve(child);
+  }
+
+  // catch any new on exit
+  const onExit = onExitOnce(child);
+
+  child.kill(signal || 'SIGKILL');
+
+  if (timeoutMs === 0 || isFinite(timeoutMs)) {
+    setTimeout(() => {
+      if (!hasProcessExited(child)) {
+        child.kill('SIGKILL');
+      }
+    }, timeoutMs);
+  }
+  return onExit;
+}
+
+module.exports = {
+  killAsync
+};

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -564,6 +564,18 @@ Queue.prototype.close = function(doNotWaitJobs) {
     .then(() => {
       return this.pause(true, doNotWaitJobs);
     })
+    .then(() => {
+      if (!this.childPool) {
+        return;
+      }
+      const cleanPromise = this.childPool.clean().catch(() => {
+        // Ignore this error and try to close anyway.
+      });
+      if (doNotWaitJobs) {
+        return;
+      }
+      return cleanPromise;
+    })
     .then(
       () => {
         return this.disconnect();
@@ -573,7 +585,6 @@ Queue.prototype.close = function(doNotWaitJobs) {
       }
     )
     .finally(() => {
-      this.childPool && this.childPool.clean();
       this.closed = true;
       this.emit('close');
     }));

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -344,4 +344,39 @@ describe('sandboxed process', () => {
 
     queue.add({ foo: 'bar' });
   });
+
+  it('should allow the job to complete and then exit on clean', async function() {
+    this.timeout(1500);
+    const processFile = __dirname + '/fixtures/fixture_processor_slow.js';
+    queue.process(processFile);
+
+    // aquire and release a child here so we know it has it's full termination handler setup
+    const expectedChild = await queue.childPool.retain(processFile);
+    queue.childPool.release(expectedChild);
+    const onActive = new Promise(resolve => queue.once('active', resolve));
+    const jobAddPromise = queue.add({ foo: 'bar' });
+
+    await onActive;
+
+    // at this point the job should be active and running on the child
+    expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(1);
+    expect(queue.childPool.getAllFree()).to.have.lengthOf(0);
+    const child = Object.values(queue.childPool.retained)[0];
+    expect(child).to.equal(expectedChild);
+    expect(child.exitCode).to.equal(null);
+    expect(child.finished).to.equal(undefined);
+
+    // trigger a clean while we know it's doing work
+    await queue.childPool.clean();
+
+    // ensure the child did get cleaned up
+    expect(expectedChild.killed).to.eql(true);
+    expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
+    expect(queue.childPool.getAllFree()).to.have.lengthOf(0);
+
+    // make sure the job completed successfully
+    const job = await jobAddPromise;
+    const jobResult = await job.finished();
+    expect(jobResult).to.equal(42);
+  });
 });


### PR DESCRIPTION
Properly handle SIGTERM in the child workers by waiting for the current
job to exit, then exiting cleanly.

Queue.close now also kills the workers and waits for them to close