### PR TITLE
Replace cron debugger link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ A job can be added to a queue and processed repeatedly according to a cron speci
 ```
 
 As a tip, check your expressions here to verify they are correct:
-[cron expression descriptor](http://cronexpressiondescriptor.azurewebsites.net/)
+[cron expression generator](https://crontab.cronhub.io)
 
 #### Pause / Resume
 


### PR DESCRIPTION
Replace dead cron debugger link with one that works.

Not sure if it's the best one, but it looks nice, works, and the site is open source.