### PR TITLE
Update return value of getRepeatableJobs in docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -486,7 +486,16 @@ value is the total amount of logs, useful for implementing pagination.
 ### Queue#getRepeatableJobs
 
 ```ts
-getRepeatableJobs(start?: number, end?: number, asc?: boolean): Promise <Job[]>
+getRepeatableJobs(start?: number, end?: number, asc?: boolean): Promise<{
+          key: string,
+          name: string,
+          id: number | string,
+          endDate: Date,
+          tz: string,
+          cron: string,
+          every: number,
+          next: number
+        }[]>
 ```
 
 Returns a promise that will return an array of Repeatable Job configurations. Optional parameters for range and ordering are provided.


### PR DESCRIPTION
It does not, as indicated, return an array of Job instances, but of configuration data (as noted in the text).

I'm not sure what the best way to notate this is (perhaps just `Promise<Object[]>`?), but `Job[]` is not correct.