### PR TITLE
feat(job): implement Job#retriedOn

### DIFF
--- a/lib/commands/reprocessJob-4.lua
+++ b/lib/commands/reprocessJob-4.lua
@@ -9,6 +9,8 @@
 
     ARGV[1] job.id,
     ARGV[2] (job.opts.lifo ? 'R' : 'L') + 'PUSH'
+    ARGV[3] token
+    ARGV[4] timestamp
 
   Output:
     1 means the operation was a success
@@ -21,6 +23,9 @@
 ]]
 if (redis.call("EXISTS", KEYS[1]) == 1) then
   if (redis.call("EXISTS", KEYS[2]) == 0) then
+    redis.call("HDEL", KEYS[1], "finishedOn", "processedOn", "failedReason")
+    redis.call("HSET", KEYS[1], "retriedOn", ARGV[4])
+
     if (redis.call("ZREM", KEYS[3], ARGV[1]) == 1) then
       redis.call(ARGV[2], KEYS[4], ARGV[1])
       redis.call(ARGV[2], KEYS[4] .. ":added", ARGV[1])

--- a/lib/job.js
+++ b/lib/job.js
@@ -335,20 +335,19 @@ Job.prototype.retry = function() {
     this.retriedOn = Date.now();
 
     return this.queue.client
+      .multi()
       .hdel(
         this.queue.toKey(this.id),
         'finishedOn',
         'processedOn',
         'failedReason'
       )
+      .hset(this.queue.toKey(this.id), 'retriedOn', this.retriedOn)
+      .exec()
       .then((/*redisResult*/) => {
         return scripts.reprocessJob(this, { state: 'failed' }).then(result => {
           if (result === 1) {
-            return this.queue.client.hset(
-              this.queue.toKey(this.id),
-              'retriedOn',
-              this.retriedOn
-            );
+            return;
           } else if (result === 0) {
             throw new Error(errors.Messages.RETRY_JOB_NOT_EXIST);
           } else if (result === -1) {

--- a/lib/job.js
+++ b/lib/job.js
@@ -332,14 +332,18 @@ Job.prototype.retry = function() {
     this.failedReason = null;
     this.finishedOn = null;
     this.processedOn = null;
+    this.retriedOn = Date.now();
 
     return this.queue.client
+      .multi()
       .hdel(
         this.queue.toKey(this.id),
         'finishedOn',
         'processedOn',
         'failedReason'
       )
+      .hset(this.queue.toKey(this.id), 'retriedOn', this.retriedOn)
+      .exec()
       .then((/*redisResult*/) => {
         return scripts.reprocessJob(this, { state: 'failed' }).then(result => {
           if (result === 1) {
@@ -589,6 +593,10 @@ Job.fromJSON = function(queue, json, jobId) {
 
   if (json.processedOn) {
     job.processedOn = parseInt(json.processedOn);
+  }
+
+  if (json.retriedOn) {
+    job.retriedOn = parseInt(json.retriedOn);
   }
 
   job.failedReason = json.failedReason;

--- a/lib/job.js
+++ b/lib/job.js
@@ -334,29 +334,17 @@ Job.prototype.retry = function() {
     this.processedOn = null;
     this.retriedOn = Date.now();
 
-    return this.queue.client
-      .multi()
-      .hdel(
-        this.queue.toKey(this.id),
-        'finishedOn',
-        'processedOn',
-        'failedReason'
-      )
-      .hset(this.queue.toKey(this.id), 'retriedOn', this.retriedOn)
-      .exec()
-      .then((/*redisResult*/) => {
-        return scripts.reprocessJob(this, { state: 'failed' }).then(result => {
-          if (result === 1) {
-            return;
-          } else if (result === 0) {
-            throw new Error(errors.Messages.RETRY_JOB_NOT_EXIST);
-          } else if (result === -1) {
-            throw new Error(errors.Messages.RETRY_JOB_IS_LOCKED);
-          } else if (result === -2) {
-            throw new Error(errors.Messages.RETRY_JOB_NOT_FAILED);
-          }
-        });
-      });
+    return scripts.reprocessJob(this, { state: 'failed' }).then(result => {
+      if (result === 1) {
+        return;
+      } else if (result === 0) {
+        throw new Error(errors.Messages.RETRY_JOB_NOT_EXIST);
+      } else if (result === -1) {
+        throw new Error(errors.Messages.RETRY_JOB_IS_LOCKED);
+      } else if (result === -2) {
+        throw new Error(errors.Messages.RETRY_JOB_NOT_FAILED);
+      }
+    });
   });
 };
 

--- a/lib/job.js
+++ b/lib/job.js
@@ -335,19 +335,20 @@ Job.prototype.retry = function() {
     this.retriedOn = Date.now();
 
     return this.queue.client
-      .multi()
       .hdel(
         this.queue.toKey(this.id),
         'finishedOn',
         'processedOn',
         'failedReason'
       )
-      .hset(this.queue.toKey(this.id), 'retriedOn', this.retriedOn)
-      .exec()
       .then((/*redisResult*/) => {
         return scripts.reprocessJob(this, { state: 'failed' }).then(result => {
           if (result === 1) {
-            return;
+            return this.queue.client.hset(
+              this.queue.toKey(this.id),
+              'retriedOn',
+              this.retriedOn
+            );
           } else if (result === 0) {
             throw new Error(errors.Messages.RETRY_JOB_NOT_EXIST);
           } else if (result === -1) {

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -448,7 +448,12 @@ const scripts = {
       queue.toKey('wait')
     ];
 
-    const args = [job.id, (job.opts.lifo ? 'R' : 'L') + 'PUSH', queue.token];
+    const args = [
+      job.id,
+      (job.opts.lifo ? 'R' : 'L') + 'PUSH',
+      queue.token,
+      Date.now()
+    ];
 
     return queue.client.reprocessJob(keys.concat(args));
   }

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -428,17 +428,40 @@ describe('Job', () => {
       });
 
       queue.once('failed', job => {
-        let retryPromise;
         queue.once('global:waiting', jobId2 => {
-          retryPromise.then(() => {
-            Job.fromId(queue, jobId2).then(job2 => {
-              expect(job2.data.foo).to.be.equal('bar');
-              cb();
-            });
+          Job.fromId(queue, jobId2).then(job2 => {
+            expect(job2.data.foo).to.be.equal('bar');
+            cb();
           });
         });
         queue.once('registered:global:waiting', () => {
-          retryPromise = job.retry();
+          job.retry();
+        });
+      });
+    });
+
+    it('sets retriedOn to a timestamp', cb => {
+      queue.add({ foo: 'bar' });
+      queue.process((job, done) => {
+        done(new Error('the job failed'));
+      });
+
+      queue.once('failed', job => {
+        queue.once('global:waiting', jobId2 => {
+          const now = Date.now();
+          expect(job.retriedOn)
+            .to.be.a('number')
+            .and.to.be.within(now - 1000, now);
+
+          Job.fromId(queue, jobId2).then(job2 => {
+            expect(job2.retriedOn)
+              .to.be.a('number')
+              .and.to.be.within(now - 1000, now);
+            cb();
+          });
+        });
+        queue.once('registered:global:waiting', () => {
+          job.retry();
         });
       });
     });


### PR DESCRIPTION
Add a `retriedOn` property to jobs so "waiting time in queue" metrics can be based on that when the job has been retried.

Use case described in https://github.com/OptimalBits/bull/issues/1867

Fixes #1867