### PR TITLE
Remove ";" from event code example

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -835,7 +835,7 @@ A queue emits also some useful events:
 
 .on('waiting', function(jobId){
   // A Job is waiting to be processed as soon as a worker is idling.
-});
+})
 
 .on('active', function(job, jobPromise){
   // A job has started. You can use `jobPromise.cancel()`` to abort it.


### PR DESCRIPTION
The `;` prevents the code example from being valid code.