### PR TITLE
Remove ";" from event reference

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -835,7 +835,7 @@ A queue emits also some useful events:
 
 .on('waiting', function(jobId){
   // A Job is waiting to be processed as soon as a worker is idling.
-});
+})
 
 .on('active', function(job, jobPromise){
   // A job has started. You can use `jobPromise.cancel()`` to abort it.
@@ -869,15 +869,15 @@ A queue emits also some useful events:
 .on('cleaned', function(jobs, type) {
   // Old jobs have been cleaned from the queue. `jobs` is an array of cleaned
   // jobs, and `type` is the type of jobs cleaned.
-});
+})
 
 .on('drained', function() {
   // Emitted every time the queue has processed all the waiting jobs (even if there can be some delayed jobs not yet processed)
-});
+})
 
 .on('removed', function(job){
   // A job successfully removed.
-});
+})
 
 ```
 


### PR DESCRIPTION
These `;` prevents the code examples from being valid code.