### PR TITLE
Fix opts recomposition order

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -687,7 +687,7 @@ Queue.prototype.add = function(name, data, opts) {
     data = name;
     name = Job.DEFAULT_JOB_NAME;
   }
-  opts = { ...opts, ...this.defaultJobOptions };
+  opts = { ...this.defaultJobOptions, ...opts };
 
   opts.jobId = jobIdForGroup(this.limiter, opts, data);
 


### PR DESCRIPTION
Default options, if set, were overriding passed options.