### PR TITLE
fix(queue): allow inline options to override jobDefaultOptions

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -687,7 +687,7 @@ Queue.prototype.add = function(name, data, opts) {
     data = name;
     name = Job.DEFAULT_JOB_NAME;
   }
-  opts = { ...opts, ...this.defaultJobOptions };
+  opts = { ...this.defaultJobOptions, ...opts };
 
   opts.jobId = jobIdForGroup(this.limiter, opts, data);
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -352,6 +352,18 @@ describe('Queue', () => {
       queue.close().then(done, done);
     });
 
+    it('local options should override defaultJobOptions', done => {
+      const defaultJobOptions = { delay: 0 };
+      const queue = new Queue('custom', {
+        defaultJobOptions
+      });
+
+      queue.add('test', {}, { delay: 1000 }).then(job => {
+        expect(job.delay).to.be.eql(1000);
+      });
+      queue.close().then(done, done);
+    });
+
     describe('bulk jobs', () => {
       it('should default name of job', () => {
         const queue = new Queue('custom');


### PR DESCRIPTION
Allows options passed to `queue.add` to override queue's jobDefaultOptions.

fixes #1904