### PR TITLE
fix: also populate retriedOn when loading from id with excludeData

### DIFF
--- a/lib/job.js
+++ b/lib/job.js
@@ -28,6 +28,7 @@ const jobFields = [
   'timestamp',
   'finishedOn',
   'processedOn',
+  'retriedOn',
   'failedReason',
   'attemptsMade',
   'stacktrace',


### PR DESCRIPTION
Missed this in https://github.com/OptimalBits/bull/pull/1868

There should probably be a test, but I couldn't find anything specifically testing `Job.fromId`, the `excludeData` option, or the sibling `processedOn` option. Broken window theory :man_shrugging: