### PR TITLE
Clarify that the limiter max is the number of jobs, not their 1/1000ths.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -174,7 +174,7 @@ as well as some other useful settings. All these settings are described in Bull'
 It is possible to create queues that limit the number of jobs processed in a unit of time. The limiter is defined per queue, independently of the number of workers, so you can scale horizontally and still limiting the rate of processing easily:
 
 ```js
-// Limit queue to max 1.000 jobs per 5 seconds.
+// Limit queue to max 1000 jobs per 5000 milliseconds.
 const myRateLimitedQueue = new Queue('rateLimited', {
   limiter: {
     max: 1000,
@@ -274,4 +274,3 @@ There are some important considerations regarding repeatable jobs:
 - Bull is smart enough not to add the same repeatable job if the repeat options are the same. (CAUTION: A job id is part of the repeat options since: https://github.com/OptimalBits/bull/pull/603, therefore passing job ids will allow jobs with the same cron to be inserted in the queue)
 - If there are no workers running, repeatable jobs will not accumulate next time a worker is online.
 - repeatable jobs can be removed using the [removeRepeatable](https://github.com/OptimalBits/bull/blob/master/REFERENCE.md#queueremoverepeatable) method.
-


### PR DESCRIPTION
The thousands separator confused me for a little while --- in the United States, a `.` usually indicates a decimal separator. This changes the explanation so that its references to the values are identical to the values in the code example.

This should be the correct interpretation of what's written, since it's the interpretation that the test 'should obey the rate limit' in test_rate_limiter.js verifies.