### PR TITLE
fix: resolve repeatable test suite breakage with ioredis 4.19.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cron-parser": "^2.13.0",
     "debuglog": "^1.0.0",
     "get-port": "^5.1.1",
-    "ioredis": "4.18.0",
+    "ioredis": "^4.19.2",
     "lodash": "^4.17.19",
     "p-timeout": "^3.2.0",
     "promise.prototype.finally": "^3.1.2",

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -198,7 +198,7 @@ describe('repeat', () => {
     this.timeout(20000);
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 2 * ONE_SECOND + 500;
 
     queue
@@ -230,7 +230,7 @@ describe('repeat', () => {
   it('should repeat every 2 seconds with startDate in future', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 2 * ONE_SECOND + 500;
     const delay = 5 * ONE_SECOND + 500;
 
@@ -272,7 +272,7 @@ describe('repeat', () => {
   it('should repeat every 2 seconds with startDate in past', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 2 * ONE_SECOND + 500;
 
     queue
@@ -313,7 +313,7 @@ describe('repeat', () => {
   it('should repeat once a day for 5 days', function(done) {
     const _this = this;
     const date = new Date('2017-05-05 13:12:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = ONE_DAY;
 
     queue
@@ -359,9 +359,10 @@ describe('repeat', () => {
   });
 
   it('should repeat 7:th day every month at 9:25', function(done) {
+    this.timeout(20000);
     const _this = this;
     const date = new Date('2017-02-02 7:21:42');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     function nextTick() {
       const now = moment();
@@ -420,7 +421,7 @@ describe('repeat', () => {
   it('should allow removing a named repeatable job', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     const nextTick = 2 * ONE_SECOND + 250;
     const repeat = { cron: '*/2 * * * * *' };
@@ -492,7 +493,7 @@ describe('repeat', () => {
   it('should allow removing a customId repeatable job', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     const nextTick = 2 * ONE_SECOND + 250;
     const repeat = { cron: '*/2 * * * * *' };
@@ -537,7 +538,7 @@ describe('repeat', () => {
     const nextTick = 2 * ONE_SECOND + 250;
     const repeat = { cron: '*/2 * * * * *' };
     const nextRepeatableJob = queue.nextRepeatableJob;
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     const afterRemoved = new Promise(resolve => {
       queue.process(() => {
@@ -631,7 +632,7 @@ describe('repeat', () => {
   it('should not repeat more than 5 times', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = ONE_SECOND + 500;
 
     queue
@@ -669,7 +670,7 @@ describe('repeat', () => {
     const nextTick = 1000;
 
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
 
     jobAdds.push(queue.add({ p: 1 }, { priority: 1, delay: nextTick * 2 }));
     jobAdds.push(queue.add({ p: 3 }, { priority: 3, delay: nextTick * 2 }));
@@ -702,7 +703,7 @@ describe('repeat', () => {
 
     // Quantize time
     const time = Math.floor(date.getTime() / interval) * interval;
-    this.clock.tick(time);
+    this.clock.setSystemTime(time);
 
     const nextTick = ONE_SECOND * 2 + 500;
 
@@ -766,7 +767,7 @@ describe('repeat', () => {
   it('should emit a waiting event when adding a repeatable job to the waiting list', function(done) {
     const _this = this;
     const date = new Date('2017-02-07 9:24:00');
-    this.clock.tick(date.getTime());
+    this.clock.setSystemTime(date);
     const nextTick = 2 * ONE_SECOND + 500;
 
     queue.on('waiting', jobId => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2226,16 +2226,17 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-ioredis@4.18.0:
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.18.0.tgz#40785bb76d30b2a50698dd9bb8d8add2a88fbef7"
-  integrity sha512-wXlB60wD+ayJxbD7t+RFBanXinhHyYpfKUxTEEXNOpd0wb+nC8GLH2r7SaZ6sSBOxr8x6jDfBiuMaiK3bPYABw==
+ioredis@^4.19.2:
+  version "4.19.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.19.2.tgz#e3eab394c653cea5aea07c0c784d8c772dce8801"
+  integrity sha512-SZSIwMrbd96b7rJvJwyTWSP6XQ0m1kAIIqBnwglJKrIJ6na7TeY4F2EV2vDY0xm/fLrUY8cEg81dR7kVFt2sKA==
   dependencies:
     cluster-key-slot "^1.1.0"
     debug "^4.1.1"
     denque "^1.1.0"
     lodash.defaults "^4.2.0"
     lodash.flatten "^4.4.0"
+    p-map "^2.1.0"
     redis-commands "1.6.0"
     redis-errors "^1.2.0"
     redis-parser "^3.0.0"
@@ -3465,7 +3466,7 @@ p-map@^1.1.1:
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
   integrity sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==
 
-p-map@^2.0.0:
+p-map@^2.0.0, p-map@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==


### PR DESCRIPTION
This PR resolves failures in the [repeatable job](https://github.com/OptimalBits/bull/blob/dbc08f23e93147c5c6b2b04fdad5a0c92d746654/test/test_repeat.js#L16) test suite brought about by upgrading [`ioredis`](https://github.com/luin/ioredis) to 4.19.0+, as mentioned in the comments for https://github.com/OptimalBits/bull/commit/6fe29283e85a64c07586fe8463de065ae7480513 and https://github.com/OptimalBits/bull/issues/758.

The precise change in `ioredis` which yields breakage is the introduction of a new script cleanup helper interval, intended to periodically purge a dictionary used for tracking scripts loaded for the purpose of pipelining. See [here](https://github.com/luin/ioredis/blob/d94f97d6950035818a666c08447a9d5e0ef5f8c7/lib/redis/index.ts#L299-L301), or observe the excerpt below.

```ts
      this._addedScriptHashesCleanInterval = setInterval(() => {
        this._addedScriptHashes = {};
      }, this.options.maxScriptsCachingTime);
```

Nothing is intrinsically wrong with what `ioredis` has done here. We only see breakage within the Bull tests due to a chance interaction with the new cleanup interval, brought about by extremely taxing usage of [`sinon`](https://github.com/sinonjs/sinon).

During the test setup phase, `sinon` is used to spoof timing functions, applying a base time equivalent to the Unix epoch.
https://github.com/OptimalBits/bull/blob/dbc08f23e93147c5c6b2b04fdad5a0c92d746654/test/test_repeat.js#L21

Within some tests, the same `sinon` clock is advanced by massive amounts at once (over 47 years).
https://github.com/OptimalBits/bull/blob/dbc08f23e93147c5c6b2b04fdad5a0c92d746654/test/test_repeat.js#L200-L201

These `clock.tick(...)` calls result in a punishing number of executions (around 25 million) of the aforementioned interval. This all takes quite a while, leading to timeouts in the end, and ultimately being the root of test failures.

The solution for this thankfully appears to be a simple one: merely swapping out `clock.tick` with `clock.setSystemTime`.