### PR TITLE
Update REFERENCE.md - Add missing createClient option in Queue docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -65,6 +65,7 @@ interface QueueOptions {
   redis?: RedisOpts;
   prefix?: string = 'bull'; // prefix for all queue keys.
   defaultJobOptions?: JobOpts;
+  createClient?: (type: enum('client', 'subscriber'), redisOpts?: RedisOpts) => redisClient,
   settings?: AdvancedSettings;
 }
 ```


### PR DESCRIPTION
I noticed the `createClient` option in missing in the `QueueOptions` reference.

Not sure if this is the right syntax, but just thought I should add it, since it took me quite some time to figure out.

Happy to change this if needed, just let me know!