### PR TITLE
feat: add getPrioritizedJobCounts

### DIFF
--- a/lib/getters.js
+++ b/lib/getters.js
@@ -70,6 +70,28 @@ module.exports = function(Queue) {
     });
   };
 
+  /**
+   * Returns waiting job counts for each of the given priorities.
+   * By nature this only counts jobs currently in waiting state.
+   *
+   */
+  Queue.prototype.getPrioritizedJobCounts = function(priorities) {
+    const multi = this.multi();
+
+    const priorityKey = this.toKey("priority");
+    _.each(priorities, (priority) => {
+      multi.zcount(priorityKey, priority, priority)
+    });
+
+    return multi.exec().then(res => {
+      const counts = {};
+      res.forEach((res, index) => {
+        counts[priorities[index]] = res[1] || 0;
+      });
+      return counts;
+    });
+  };
+
   Queue.prototype.getCompletedCount = function() {
     return this.getJobCountByTypes('completed');
   };

--- a/test/test_getters.js
+++ b/test/test_getters.js
@@ -35,6 +35,22 @@ describe('Jobs getters', function() {
       });
   });
 
+  it('should get prioritized job counts', () => {
+    return Promise.all([
+      queue.add({ foo: 'bar' }, { priority: 2 }),
+      queue.add({ baz: 'qux' }, { priority: 2 }),
+      queue.add({ baz: 'foo' }, { priority: 3 }),
+    ]).then(() => {
+      return queue.getPrioritizedJobCounts([1, 2, 3]).then(priorityCounts => {
+        expect(priorityCounts).to.deep.equal({
+          [1]: 0,
+          [2]: 2,
+          [3]: 1
+        });
+      });
+    });
+  });
+
   it('should get waiting jobs', () => {
     return Promise.all([
       queue.add({ foo: 'bar' }),


### PR DESCRIPTION
Adds a method to get prioritized job counts. Currently the function requires passing all the priorities you want to query for, since priorities can be pretty much anything.

Fixes #1939