### PR TITLE
async version of process.send for master progress and log

### DIFF
--- a/lib/process/master.js
+++ b/lib/process/master.js
@@ -146,11 +146,10 @@ function wrapJob(job) {
       // so that we can return it from this process synchronously.
       progressValue = progress;
       // Send message to update job progress.
-      process.send({
+      return processSendAsync({
         cmd: 'progress',
         value: progress
       });
-      return Promise.resolve();
     } else {
       // Return the last known progress value.
       return progressValue;
@@ -160,7 +159,7 @@ function wrapJob(job) {
    * Emulate the real job `log` function.
    */
   job.log = function(row) {
-    process.send({
+    return processSendAsync({
       cmd: 'log',
       value: row
     });


### PR DESCRIPTION
Rather than use an empty promise and ignoring the error from `process.send()`, the async version is used and returned directly for both master progress and logs.  This allows the function calling progress/logs to receive the rejection rather than having it emitted somewhere else.