### PR TITLE
assert on provided a name

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -89,6 +89,10 @@ const Queue = function Queue(name, url, opts) {
     return new Queue(name, url, opts);
   }
 
+  if (_.isString(name)) {
+    throw Error('name must be a string');
+  }
+  
   if (_.isString(url)) {
     opts = {
       ...opts,

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -90,7 +90,7 @@ const Queue = function Queue(name, url, opts) {
   }
 
   if (_.isString(name)) {
-    throw Error('name must be a string');
+    name = 'default';
   }
   
   if (_.isString(url)) {


### PR DESCRIPTION
I installed `bull` and started playing with it intuitively, but since it did not insist on a name, I did not provide any.
However, down the useage I saw rejecting promises threatening to crash the process on future versions of node.

So here...

Here's below the gist of my playground reproduction scenario.
(I was basically looking for an event that testifies that the redis has been found, or else fail-fast already on container load time)

```
c:\osher\eval-bull>node
Welcome to Node.js v12.18.4.
Type ".help" for more information.
> Q = require('bull'); r = new Q();  emit = r.emit; r.emit = (...a) => console.log(a) || emit.apply(r, a);1
1
> r.add('stam', {foo: 'bar'}).then(v => console.log('added', v));1
1
> added Job {
  opts: {
    jobId: undefined,
    attempts: 1,
    delay: 0,
    timestamp: 1610955263079,
    backoff: undefined
  },
  name: 'stam',
  ...
  ... skip a few lines ...
  ...
  id: '3'
}
> r.process('stam', (j, done) => console.log('stam job', j.data) || done(null));1
1
> (node:24088) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at Function.from (buffer.js:331:9)
    at Queue.base64Name (c:\generator\node_modules\bull\lib\worker.js:38:19)
    at Queue.clientName (c:\generator\node_modules\bull\lib\worker.js:42:40)
    at c:\generator\node_modules\bull\lib\worker.js:16:51
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:24088) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:24088) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
[ 'registered:delayed' ]
stam job { foo: 'bar' }
[
  'active',
  Job { ... 
```



