### PR TITLE
deal with missing `name` on Queue constructor

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -89,6 +89,10 @@ const Queue = function Queue(name, url, opts) {
     return new Queue(name, url, opts);
   }
 
+  if (_.isString(name)) {
+    throw Error('name must be a string');
+  }
+  
   if (_.isString(url)) {
     opts = {
       ...opts,

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -90,7 +90,7 @@ const Queue = function Queue(name, url, opts) {
   }
 
   if (_.isString(name)) {
-    throw Error('name must be a string');
+    name = 'default';
   }
   
   if (_.isString(url)) {


### PR DESCRIPTION
closes #1965

### More info
As an old user of `kue`, after not delaing with queues for a while, I came accross a project that requires it.
I installed `bull` and started playing with it in a shell, and encountered this problem, which I thougt to be an easy fix.

However, I'm had probloms pass CI on previous attemt. Lets see how it rolls now...

### References
Unjustly closed: PR #1956, and it's Issue: #1958

