### PR TITLE
fix(queue): possible infinite loop when disconnect fixes #1746

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -554,7 +554,10 @@ Queue.prototype.close = function(doNotWaitJobs) {
       }
       return cleanPromise;
     })
-    .then(async () => this.disconnect(), err => console.error(err))
+    .then(
+      async () => this.disconnect(),
+      err => console.error(err)
+    )
     .finally(() => {
       this.closed = true;
       this.emit('close');
@@ -994,16 +997,17 @@ Queue.prototype._processJobOnNextTick = function(
         return (this.processing[index] = gettingNextJob
           .then(this.processJob)
           .then(processJobs, err => {
-            this.emit('error', err, 'Error processing job');
+            if (!(this.closing && err.message === 'Connection is closed.')) {
+              this.emit('error', err, 'Error processing job');
 
-            //
-            // Wait before trying to process again.
-            //
-            clearTimeout(this.errorRetryTimer[index]);
-            this.errorRetryTimer[index] = setTimeout(() => {
-              processJobs();
-            }, this.settings.retryProcessDelay);
-
+              //
+              // Wait before trying to process again.
+              //
+              clearTimeout(this.errorRetryTimer[index]);
+              this.errorRetryTimer[index] = setTimeout(() => {
+                processJobs();
+              }, this.settings.retryProcessDelay);
+            }
             return null;
           }));
       })
@@ -1124,9 +1128,9 @@ Queue.prototype.getNextJob = function() {
           }
         },
         err => {
-          // Swallow error
-          if (err.message !== 'Connection is closed.') {
-            console.error('BRPOPLPUSH', err);
+          // Swallow error if locally paused since we did force a disconnection
+          if (!(this.paused && err.message === 'Connection is closed.')) {
+            throw err;
           }
         }
       );


### PR DESCRIPTION
When we close a queue we may have blocking connections to redis. In order to close the queue we need to force disconnect such connections. Before this PR we could enter an infinite loop if the queue was disconnected in a different scenario than when closing the queue.
