### PR TITLE
feat: expose repeatable queue functions

### DIFF
--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -30,10 +30,10 @@ module.exports = function(Queue) {
     let now = Date.now();
     now = prevMillis < now ? now : prevMillis;
 
-    const nextMillis = getNextMillis(now, repeat);
+    const nextMillis = this.getNextMillis(now, repeat);
     if (nextMillis) {
       const jobId = repeat.jobId ? repeat.jobId + ':' : ':';
-      const repeatJobKey = getRepeatKey(name, repeat, jobId);
+      const repeatJobKey = this.getRepeatKey(name, repeat, jobId);
 
       const createNextJob = () => {
         return client
@@ -42,7 +42,7 @@ module.exports = function(Queue) {
             //
             // Generate unique job id for this iteration.
             //
-            const customId = getRepeatJobId(
+            const customId = this.getRepeatJobId(
               name,
               jobId,
               nextMillis,
@@ -99,8 +99,13 @@ module.exports = function(Queue) {
 
     return this.isReady().then(() => {
       const jobId = repeat.jobId ? repeat.jobId + ':' : ':';
-      const repeatJobKey = getRepeatKey(name, repeat, jobId);
-      const repeatJobId = getRepeatJobId(name, jobId, '', md5(repeatJobKey));
+      const repeatJobKey = this.getRepeatKey(name, repeat, jobId);
+      const repeatJobId = this.getRepeatJobId(
+        name,
+        jobId,
+        '',
+        md5(repeatJobKey)
+      );
       const queueKey = this.keys[''];
       return this.client.removeRepeatable(
         this.keys.repeat,
@@ -117,7 +122,7 @@ module.exports = function(Queue) {
     const queueKey = this.keys[''];
 
     const jobId = repeatMeta.id ? repeatMeta.id + ':' : ':';
-    const repeatJobId = getRepeatJobId(
+    const repeatJobId = this.getRepeatJobId(
       repeatMeta.name || Job.DEFAULT_JOB_NAME,
       jobId,
       '',
@@ -178,11 +183,16 @@ module.exports = function(Queue) {
     return this.client.zcard(this.toKey('repeat'));
   };
 
-  function getRepeatJobId(name, jobId, nextMillis, namespace) {
+  Queue.prototype.getRepeatJobId = function(
+    name,
+    jobId,
+    nextMillis,
+    namespace
+  ) {
     return 'repeat:' + md5(name + jobId + namespace) + ':' + nextMillis;
-  }
+  };
 
-  function getRepeatKey(name, repeat, jobId) {
+  Queue.prototype.getRepeatKey = function(name, repeat, jobId) {
     const endDate = repeat.endDate
       ? new Date(repeat.endDate).getTime() + ':'
       : ':';
@@ -190,9 +200,9 @@ module.exports = function(Queue) {
     const suffix = repeat.cron ? tz + repeat.cron : String(repeat.every);
 
     return name + ':' + jobId + endDate + suffix;
-  }
+  };
 
-  function getNextMillis(millis, opts) {
+  Queue.prototype.getNextMillis = function(millis, opts) {
     if (opts.cron && opts.every) {
       throw new Error(
         'Both .cron and .every options are defined for this repeatable job'
@@ -222,7 +232,7 @@ module.exports = function(Queue) {
     } catch (e) {
       // Ignore error
     }
-  }
+  };
 
   function md5(str) {
     return crypto


### PR DESCRIPTION
* getNextMillis
* getRepeatJobId
* getRepeatKey

## Use cases

### custom getNextMillis
_use at your own risk_
```javascript
queue = new Bull('randomIntervalQueue');
queue.getNextMillis = function(millis, opts) {
          if (opts.cron) {
            throw new Error(
              '.cron options are not supported in this queue'
            );
          }

          if (!opts.every) {
            throw new Error(
              '.every options must be provided in this queue'
            );
          }

          return Math.floor(Math.floor(millis / opts.every) * opts.every + opts.every + Math.random() * opts.every);
        };
```
### getRepeatKey for removing repeatable job

```javascript
const [job] = await queue.getRepeatableJobs();
const jobKey = queue.getRepeatKey(job.name, job.opts.repeat, job.opts.repeat.jobId + ':');
await queue.removeRepeatableByKey(jobKey);
```

### getRepeatJobId for getting job

```javascript
const [job] = await queue.getRepeatableJobs();
const jobId = queue.getRepeatJobId(job.name, job.id + ':', job.next, md5(job.key));
const fullJob = queue.getJob(jobId);
```