### PR TITLE
fix: avoid calling handleFailed(undefined)

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1114,7 +1114,11 @@ Queue.prototype.processJob = function(job, notFetch = false) {
 
     return jobPromise
       .then(handleCompleted)
-      .catch(handleFailed)
+      .catch(err => {
+        if (err) {
+          return handleFailed(err);
+        }
+      })
       .finally(() => {
         stopTimer();
       });


### PR DESCRIPTION
We've seen this error show up in production a couple of times:

```
TypeError: Cannot read property 'message' of undefined
  File "/app/node_modules/bull/lib/job.js", line 273, in Job.moveToFailed
      this.failedReason = err.message;
  File "/app/node_modules/bull/lib/queue.js", line 1084, in handleFailed
        return job.moveToFailed(err).then(jobData => {
  File "<anonymous>", line unknown, in runMicrotasks
  File "internal/process/task_queues.js", line 93, in processTicksAndRejections
```

It seems to happen while the server instance is shutting down or after an uncaught exception, so maybe there's a method somewhere (or ioredis) that's returning a promise that gets rejected with `undefined`. The best I can come up with is to try to harden against it here.