### PR TITLE
fix: allow cjs extension for external processors (#1861)

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -640,7 +640,7 @@ Queue.prototype.setHandler = function(name, handler) {
   this.setWorkerName();
 
   if (typeof handler === 'string') {
-    const supportedFileTypes = ['.js', '.ts', '.flow'];
+    const supportedFileTypes = ['.js', '.ts', '.flow', '.cjs'];
     const processorFile =
       handler +
       (supportedFileTypes.includes(path.extname(handler)) ? '' : '.js');

--- a/test/fixtures/fixture_processor_cjs.cjs
+++ b/test/fixtures/fixture_processor_cjs.cjs
@@ -1,0 +1,13 @@
+/**
+ * A processor file with CJS extension to be used in ES module tests.
+ *
+ */
+ 'use strict';
+
+ const delay = require('delay');
+
+ module.exports = function(/*job*/) {
+   return delay(500).then(() => {
+     return 42;
+   });
+ };

--- a/test/test_sandboxed_process_esm.mjs
+++ b/test/test_sandboxed_process_esm.mjs
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import redis from 'ioredis';
+import path from 'path';
+import utils from './utils.js';
+
+describe('sandboxed CJS process from ESM', () => {
+  let queue;
+  let client;
+
+  beforeEach(() => {
+    client = new redis();
+    return client.flushdb().then(() => {
+      queue = utils.buildQueue('test process', {
+        settings: {
+          guardInterval: 300000,
+          stalledInterval: 300000
+        }
+      });
+      return queue;
+    });
+  });
+
+  afterEach(() => {
+    return queue
+      .close()
+      .then(() => {
+        return client.flushall();
+      })
+      .then(() => {
+        return client.quit();
+      });
+  });
+
+  it('should process and complete', done => {
+    const processFile = path.resolve() + '/test/fixtures/fixture_processor_cjs.cjs';
+    queue.process(processFile);
+
+    queue.on('completed', (job, value) => {
+      try {
+        expect(job.data).to.be.eql({ foo: 'bar' });
+        expect(value).to.be.eql(42);
+        expect(Object.keys(queue.childPool.retained)).to.have.lengthOf(0);
+        expect(queue.childPool.free[processFile]).to.have.lengthOf(1);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    queue.add({ foo: 'bar' });
+
+  });
+
+});


### PR DESCRIPTION
By allowing .cjs extensions it's possible to use Bull within an ES module with an external processor.

The obvious restriction is that the external processor would have to be a CommonJS file instead of ESM,
but existing ES modules within the same code base can be used inside the CJS module through import().
