### PR TITLE
feat: emit event on job lock extend failure

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -955,7 +955,7 @@ A queue emits also some useful events:
   // workers that crash or pause the event loop.
 })
 
-.on('lockExtendingFailed', function (job) {
+.on('lock-extension-failed', function (job) {
   // A job failed to extend lock. This will be useful to debug redis 
   // connection issues and jobs getting restarted because workers
   // are not able to extend locks.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -955,6 +955,12 @@ A queue emits also some useful events:
   // workers that crash or pause the event loop.
 })
 
+.on('lockExtendingFailed', function (job) {
+  // A job failed to extend lock. This will be useful to debug redis 
+  // connection issues and jobs getting restarted because workers
+  // are not able to extend locks.
+});
+
 .on('progress', function (job, progress) {
   // A job's progress was updated!
 })

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -955,7 +955,7 @@ A queue emits also some useful events:
   // workers that crash or pause the event loop.
 })
 
-.on('lock-extension-failed', function (job) {
+.on('lock-extension-failed', function (job, err) {
   // A job failed to extend lock. This will be useful to debug redis 
   // connection issues and jobs getting restarted because workers
   // are not able to extend locks.

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1065,7 +1065,7 @@ Queue.prototype.processJob = function(job, notFetch = false) {
             }
           })
           .catch(err => {
-            this.emit('lockExtendingFailed', job, err);
+            this.emit('lock-extension-failed', job, err);
           });
       }
     );

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1064,8 +1064,8 @@ Queue.prototype.processJob = function(job, notFetch = false) {
               lockExtender();
             }
           })
-          .catch((/*err*/) => {
-            // Somehow tell the worker this job should stop processing...
+          .catch(err => {
+            this.emit('lockExtendingFailed', job, err);
           });
       }
     );

--- a/test/test_events.js
+++ b/test/test_events.js
@@ -211,6 +211,26 @@ describe('events', () => {
     });
   });
 
+  it('should emit an event if a job fails to extend lock', done => {
+    const LOCK_RENEW_TIME = 1;
+    queue = utils.buildQueue('queue fails to extend lock', {
+      settings: {
+        lockRenewTime: LOCK_RENEW_TIME
+      }
+    });
+    queue.once('lockExtendingFailed', lockingFailedJob => {
+      expect(lockingFailedJob.data.foo).to.be.equal('lockingFailedJobFoo');
+      queue.close().then(done);
+    });
+    queue.isReady().then(() => {
+      queue.process(() => {
+        utils.simulateDisconnect(queue);
+        return delay(LOCK_RENEW_TIME + 0.25);
+      });
+      queue.add({ foo: 'lockingFailedJobFoo' });
+    });
+  });
+
   it('should listen to global events', done => {
     const queue1 = utils.buildQueue();
     const queue2 = utils.buildQueue();

--- a/test/test_events.js
+++ b/test/test_events.js
@@ -218,7 +218,7 @@ describe('events', () => {
         lockRenewTime: LOCK_RENEW_TIME
       }
     });
-    queue.once('lockExtendingFailed', lockingFailedJob => {
+    queue.once('lock-extension-failed', lockingFailedJob => {
       expect(lockingFailedJob.data.foo).to.be.equal('lockingFailedJobFoo');
       queue.close().then(done);
     });

--- a/test/test_events.js
+++ b/test/test_events.js
@@ -218,8 +218,9 @@ describe('events', () => {
         lockRenewTime: LOCK_RENEW_TIME
       }
     });
-    queue.once('lock-extension-failed', lockingFailedJob => {
+    queue.once('lock-extension-failed', (lockingFailedJob, error) => {
       expect(lockingFailedJob.data.foo).to.be.equal('lockingFailedJobFoo');
+      expect(error.message).to.be.equal('Connection is closed.');
       queue.close().then(done);
     });
     queue.isReady().then(() => {


### PR DESCRIPTION
Existing: When a job fails to extend its lock in redis, there is no way to debug or do find it out.

Change: When a job fails to extend its lock in redis, a new event `lockExtendingFailed` will be emitted.

Reason: In our use-case, each job processes data from a socket continuously and sends signals based on it when the jobs conditions are met. It is a long job(runs for days). We have multiple workers processing jobs. As already clearly mentioned in the Readme, if lock extension fails, it will lead to double processing of jobs.

Using this event, if extending lock fails, I will disconnect the socket so that it will stop duplicate processing.