### PR TITLE
Add more detail about timeouts and startDate to the reference

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -110,7 +110,7 @@ interface AdvancedSettings {
 }
 ```
 
-**Custom or Shared IORedis Connections**
+#### Custom or Shared IORedis Connections
 
 `createClient` is passed a `type` to specify the type of connection that Bull is trying to create, and some options that `bull` would like to set for that connection.
 
@@ -123,7 +123,7 @@ Redis connections somewhere and disconnect them after you shut down all the queu
 The `bclient` connection however is a "blocking client" and is used to wait for new jobs on a single queue at a time.  For this reason it cannot be shared and a
 new connection should be returned each time.
 
-**Advanced Settings**
+#### Advanced Settings
 
 **Warning:** Do not override these advanced settings unless you understand the internals of the queue.
 
@@ -781,7 +781,7 @@ clean(grace: number, status?: string, limit?: number): Promise<number[]>
 
 Tells the queue remove jobs of a specific type created outside of a grace period.
 
-**Example**
+#### Example
 
 ```js
 queue.on('cleaned', function (jobs, type) {
@@ -810,7 +810,7 @@ is performed iterativelly. However the queue is always paused during this proces
 if the queue gets unpaused during the obliteration by another script, the call
 will fail with the removed items it managed to remove until the failure.
 
-**Example**
+#### Example
 
 ```js
 // Removes everything but only if there are no active jobs
@@ -836,7 +836,7 @@ progress(progress?: number | object): Promise
 Updates a job progress if called with an argument.
 Return a promise resolving to the current job's progress if called without argument.
 
-**Arguments**
+#### Arguments
 
 ```js
   progress: number; Job progress number or any serializable object representing progress or similar.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -305,7 +305,8 @@ and the job's promise is rejected, but Bull has no way to stop the processor fun
 If you need to a job to stop processing after it times out, here are a couple suggestions:
  - Have the job itself periodically check `job.getStatus()`, and exit if the status becomes `'failed'`
  - Implement the job as a _cancelable promise_. If the processor's promise has a `cancel()` method, it will
-   be called when a job times out, and the job can respond accordingly.
+   be called when a job times out, and the job can respond accordingly. (Note: currently this only works for
+   native Promises, see [#2203](https://github.com/OptimalBits/bull/issues/2203)
  - If you have a way to externally stop a job, add a listener for the `failed` event and do so there.
 
 #### Repeated Job Details

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -297,7 +297,9 @@ interface JobOpts {
 }
 ```
 
-Note that jobs are _not_ proactively stopped after the given `timeout`. The job is marked as failed
+#### Timeout Implementation
+
+It is important to note that jobs are _not_ proactively stopped after the given `timeout`. The job is marked as failed
 and the job's promise is rejected, but Bull has no way to stop the processor function externally.
 
 If you need to a job to stop processing after it times out, here are a couple suggestions:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -306,6 +306,7 @@ If you need to a job to stop processing after it times out, here are a couple su
  - Have the job itself periodically check `job.getStatus()`, and exit if the status becomes `'failed'`
  - Implement the job as a _cancelable promise_. If the processor's promise has a `cancel()` method, it will
    be called when a job times out, and the job can respond accordingly.
+ - If you have a way to externally stop a job, add a listener for the `failed` event and do so there.
 
 #### Repeated Job Details
 ```typescript


### PR DESCRIPTION
It was unclear what happens when a job times out, and one might assume the job is somehow stopped, which is impossible for non-sandboxed jobs, and not implemented for sandboxed jobs. Add a little explainer to make this clear.

Relevant issues: https://github.com/OptimalBits/bull/issues/2166, https://github.com/OptimalBits/bull/issues/479