### PR TITLE
perf: Speed up performance of queue.clean when called with a limit

### DIFF
--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -31,16 +31,16 @@ if setName == "wait" or setName == "active" or setName == "paused" then
 end
 
 local limit = tonumber(limitStr)
-local range_limit = -1
-local range_start = 0
+local rangeLimit = -1
+local rangeStart = 0
 
 -- If we're only deleting _n_ items, avoid retrieving all items
 -- for faster performance
 if limit > 0 then
-  range_limit = limit
+  rangeLimit = limit
 end
 
-local jobIds = rcall(command, setKey, range_start, range_limit)
+local jobIds = rcall(command, setKey, rangeStart, rangeLimit)
 local deleted = {}
 local deletedCount = 0
 local jobTS
@@ -91,8 +91,8 @@ while ((limit <= 0 or deletedCount < limit) and next(jobIds, nil) ~= nil) do
 
   if deletedCount < limit then
     -- We didn't delete enough. Look for more to delete
-    range_start = range_start + range_limit
-    jobIds = rcall(command, setKey, range_start, range_limit)
+    rangeStart = rangeStart + rangeLimit
+    jobIds = rcall(command, setKey, rangeStart, rangeLimit)
   end
 end
 

--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -20,10 +20,18 @@ if ARGV[4] == "wait" or ARGV[4] == "active" or ARGV[4] == "paused" then
   isList = true
 end
 
-local jobIds = rcall(command, KEYS[1], 0, -1)
+local limit = tonumber(ARGV[3])
+local range_limit = -1
+
+-- If we're only deleting _n_ items, avoid retrieving all items
+-- for faster performance
+if limit > 0 then
+  range_limit = limit
+end
+
+local jobIds = rcall(command, KEYS[1], 0, range_limit)
 local deleted = {}
 local deletedCount = 0
-local limit = tonumber(ARGV[3])
 local jobTS
 for _, jobId in ipairs(jobIds) do
   if limit > 0 and deletedCount >= limit then

--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -31,16 +31,16 @@ if setName == "wait" or setName == "active" or setName == "paused" then
 end
 
 local limit = tonumber(limitStr)
-local rangeLimit = -1
 local rangeStart = 0
+local rangeEnd = -1
 
 -- If we're only deleting _n_ items, avoid retrieving all items
 -- for faster performance
 if limit > 0 then
-  rangeLimit = limit
+  rangeEnd = limit - 1
 end
 
-local jobIds = rcall(command, setKey, rangeStart, rangeLimit)
+local jobIds = rcall(command, setKey, rangeStart, rangeEnd)
 local deleted = {}
 local deletedCount = 0
 local jobTS
@@ -91,8 +91,9 @@ while ((limit <= 0 or deletedCount < limit) and next(jobIds, nil) ~= nil) do
 
   if deletedCount < limit then
     -- We didn't delete enough. Look for more to delete
-    rangeStart = rangeStart + rangeLimit
-    jobIds = rcall(command, setKey, rangeStart, rangeLimit)
+    rangeStart = rangeStart + limit
+    rangeEnd = rangeEnd + limit
+    jobIds = rcall(command, setKey, rangeStart, rangeEnd)
   end
 end
 

--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -36,8 +36,12 @@ local rangeEnd = -1
 
 -- If we're only deleting _n_ items, avoid retrieving all items
 -- for faster performance
+--
+-- Start from the tail of the list, since that's where oldest elements
+-- are generally added for FIFO lists
 if limit > 0 then
-  rangeEnd = limit - 1
+  rangeStart = -1 - limit + 1
+  rangeEnd = -1
 end
 
 local jobIds = rcall(command, setKey, rangeStart, rangeEnd)
@@ -91,8 +95,8 @@ while ((limit <= 0 or deletedCount < limit) and next(jobIds, nil) ~= nil) do
 
   if deletedCount < limit then
     -- We didn't delete enough. Look for more to delete
-    rangeStart = rangeStart + limit
-    rangeEnd = rangeEnd + limit
+    rangeStart = rangeStart - limit
+    rangeEnd = rangeEnd - limit
     jobIds = rcall(command, setKey, rangeStart, rangeEnd)
   end
 end

--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -11,17 +11,28 @@
     ARGV[3]  limit the number of jobs to be removed. 0 is unlimited
     ARGV[4]  set name, can be any of 'wait', 'active', 'paused', 'delayed', 'completed', or 'failed'
 ]]
+
+local setKey = KEYS[1]
+local priorityKey = KEYS[2]
+local rateLimiterKey = KEYS[3]
+
+local jobKeyPrefix = ARGV[1]
+local maxTimestamp = ARGV[2]
+local limitStr = ARGV[3]
+local setName = ARGV[4]
+
 local command = "ZRANGE"
 local isList = false
 local rcall = redis.call
 
-if ARGV[4] == "wait" or ARGV[4] == "active" or ARGV[4] == "paused" then
+if setName == "wait" or setName == "active" or setName == "paused" then
   command = "LRANGE"
   isList = true
 end
 
-local limit = tonumber(ARGV[3])
+local limit = tonumber(limitStr)
 local range_limit = -1
+local range_start = 0
 
 -- If we're only deleting _n_ items, avoid retrieving all items
 -- for faster performance
@@ -29,41 +40,59 @@ if limit > 0 then
   range_limit = limit
 end
 
-local jobIds = rcall(command, KEYS[1], 0, range_limit)
+local jobIds = rcall(command, setKey, range_start, range_limit)
 local deleted = {}
 local deletedCount = 0
 local jobTS
-for _, jobId in ipairs(jobIds) do
-  if limit > 0 and deletedCount >= limit then
+
+-- Run this loop:
+-- - Once, if limit is -1 or 0
+-- - As many times as needed if limit is positive
+while ((limit <= 0 or deletedCount < limit) and next(jobIds, nil) ~= nil) do
+  for _, jobId in ipairs(jobIds) do
+    if limit > 0 and deletedCount >= limit then
+      break
+    end
+
+    local jobKey = jobKeyPrefix .. jobId
+    if (rcall("EXISTS", jobKey .. ":lock") == 0) then
+      jobTS = rcall("HGET", jobKey, "timestamp")
+      if (not jobTS or jobTS < maxTimestamp) then
+        if isList then
+          rcall("LREM", setKey, 0, jobId)
+        else
+          rcall("ZREM", setKey, jobId)
+        end
+        rcall("ZREM", priorityKey, jobId)
+        rcall("DEL", jobKey)
+        rcall("DEL", jobKey .. ":logs")
+
+        -- delete keys related to rate limiter
+        -- NOTE: this code is unncessary for other sets than wait, paused and delayed.
+        local limiterIndexTable = rateLimiterKey .. ":index"
+        local limitedSetKey = rcall("HGET", limiterIndexTable, jobId)
+
+        if limitedSetKey then
+          rcall("SREM", limitedSetKey, jobId)
+          rcall("HDEL", limiterIndexTable, jobId)
+        end
+
+        deletedCount = deletedCount + 1
+        table.insert(deleted, jobId)
+      end
+    end
+  end
+
+  -- If we didn't have a limit, return immediately. We should have deleted
+  -- all the jobs we can
+  if limit <= 0 then
     break
   end
 
-  local jobKey = ARGV[1] .. jobId
-  if (rcall("EXISTS", jobKey .. ":lock") == 0) then
-    jobTS = rcall("HGET", jobKey, "timestamp")
-    if (not jobTS or jobTS < ARGV[2]) then
-      if isList then
-        rcall("LREM", KEYS[1], 0, jobId)
-      else
-        rcall("ZREM", KEYS[1], jobId)
-      end
-      rcall("ZREM", KEYS[2], jobId)
-      rcall("DEL", jobKey)
-      rcall("DEL", jobKey .. ":logs")
-
-      -- delete keys related to rate limiter
-      -- NOTE: this code is unncessary for other sets than wait, paused and delayed.
-      local limiterIndexTable = KEYS[3] .. ":index"
-      local limitedSetKey = rcall("HGET", limiterIndexTable, jobId)
-
-      if limitedSetKey then
-        rcall("SREM", limitedSetKey, jobId)
-        rcall("HDEL", limiterIndexTable, jobId)
-      end
-
-      deletedCount = deletedCount + 1
-      table.insert(deleted, jobId)
-    end
+  if deletedCount < limit then
+    -- We didn't delete enough. Look for more to delete
+    range_start = range_start + range_limit
+    jobIds = rcall(command, setKey, range_start, range_limit)
   end
 end
 

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2853,6 +2853,18 @@ describe('Queue', () => {
       expect(len).to.be.eql(2);
     });
 
+    it('shouldn\'t clean anything if all jobs are in grace period', async () => {
+      await queue.add({ some: 'data' });
+      await queue.add({ some: 'data' });
+
+      const cleaned = await queue.clean(5000, 'wait', 1);
+      expect(cleaned.length).to.be.eql(0);
+
+      const cleaned2 = await queue.clean(5000, 'wait');
+      expect(cleaned2.length).to.be.eql(0);
+      expect(await queue.count()).to.be.eql(2);
+    });
+
     it('should properly clean jobs from the priority set', done => {
       const client = new redis(6379, '127.0.0.1', {});
       queue.add({ some: 'data' }, { priority: 5 });


### PR DESCRIPTION
### Motivation

I was trying to clean a large queue with millions of entries. Originally, I ran:

```js
import Queue from 'bull';
const queue = new Queue(...);
queue.clean(0, 'completed');
```

But this blocked Redis from saving any other records with the error message:

> BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE

I switched this to something more like:

```js
import Queue from 'bull';
const queue = new Queue(...);

async function run() {
  let count = null;
  while (count == null || count >= 100) {
    count = (await queue.clean(0, 'completed', 100)).length;
  }
}
```

But each loop of 100 still took a really long time. Digging into the script, regardless of how many we try to delete, we're listing all the keys on every run of `.clean()`

https://github.com/OptimalBits/bull/blob/019d6125bea8a195d7690d52707b4e7089a92f16/lib/commands/cleanJobsInSet-3.lua#L23

### Changes

- Change the cleanJobsInSet script so that:
  - If we're trying to clean _n_ entries, only fetch _n_ keys at a time
  - (Note that we might have to loop through this if the first _n_ entries don't have all the timestamps we need, but this should generally still be an improvement)
- **Cleanup**: make cleanJobsInSet's variables be all named for slightly easier readability

### Testing

Tested in production with my queue -- this sped it up a lot! Also ran it on empty queues to make sure that we ended properly

Also added an automated test for some pagination edge cases

### Note for reviewers

It's a lot easier to see changes with "Hide whitespace changes" turned on: https://github.com/OptimalBits/bull/pull/2205/files?diff=split&w=1