### PR TITLE
Update patterns with fix for v4

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -78,16 +78,22 @@ Notes:
 const { REDIS_URL } = process.env;
 
 const Redis = require('ioredis');
-const client = new Redis(REDIS_URL);
-const subscriber = new Redis(REDIS_URL);
+let client;
+let subscriber;
 
 const opts = {
   // redisOpts here will contain at least a property of connectionName which will identify the queue based on its name
   createClient: function (type, redisOpts) {
     switch (type) {
       case 'client':
+        if (!client) {
+          client = new Redis(REDIS_URL, redisOpts);
+        }
         return client;
       case 'subscriber':
+        if (!subscriber) {
+          subscriber = new Redis(REDIS_URL, redisOpts);
+        }
         return subscriber;
       case 'bclient':
         return new Redis(REDIS_URL, redisOpts);


### PR DESCRIPTION
Ensure opts are passed into redis in the example code for reusing redis connections.  