### PR TITLE
Make sure that we are removing job from waiting list when moving to finished

### DIFF
--- a/lib/commands/moveToFinished-8.lua
+++ b/lib/commands/moveToFinished-8.lua
@@ -49,6 +49,8 @@ if rcall("EXISTS", KEYS[3]) == 1 then -- // Make sure job exists
 
   -- Remove from active list
   rcall("LREM", KEYS[1], -1, ARGV[1])
+  -- Remove from wait list
+  rcall("LREM", KEYS[4], -1, ARGV[1])
 
   -- Remove job?
   local removeJobs = tonumber(ARGV[6])


### PR DESCRIPTION
Hi
I had some specific case and found resolution so created a PR.
My case:
1. No available processors
2. New job is added to queue
3. My JS code is starting timer - max time to respond to client (some checks + addjob + processjob + parse result + sending response)
4. When my timer is fired, but no workers available I need to make sure that this job will be not started (it makes no sense to start job when new processor will be available because client already got error response)
So I call:
- job.discard()
- job.moveToFailed(error)

Without my change, job is added to failed list but is still hanging in wait list.

Have a nice day :)