### PR TITLE
Fix/enable init child pool on init

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -108,6 +108,7 @@ interface AdvancedSettings {
   backoffStrategies: {}; // A set of custom backoff strategies keyed by name.
   drainDelay: number = 5; // A timeout for when the queue is in drained state (empty waiting for jobs).
   isSharedChildPool: boolean = false; // enables multiple queues on the same instance of child pool to share the same instance.
+  initChildPool: boolean = false // enables childPool class to be initialized in constructor
 }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3,6 +3,7 @@
 - [Queue](#queue)
 
   - [Queue#process](#queueprocess)
+  - [Queue#initChildPool](#queueinitchildpool)
   - [Queue#add](#queueadd)
   - [Queue#addBulk](#queueaddBulk)
   - [Queue#pause](#queuepause)
@@ -108,7 +109,6 @@ interface AdvancedSettings {
   backoffStrategies: {}; // A set of custom backoff strategies keyed by name.
   drainDelay: number = 5; // A timeout for when the queue is in drained state (empty waiting for jobs).
   isSharedChildPool: boolean = false; // enables multiple queues on the same instance of child pool to share the same instance.
-  initChildPool: boolean = false // enables childPool class to be initialized in constructor
 }
 ```
 
@@ -252,6 +252,13 @@ queue.process(function (job) {
 });
 ```
 
+---
+
+### Queue#initChildPool
+```ts
+initChildPool(processorFile: string): Promise<ChildProcess>
+```
+Manually adds a forked child to be used by sandbox processes. Normally the forked child is lazy-loaded, but by running this function it can manually, so it is available at start
 ---
 
 ### Queue#add

--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -41,27 +41,39 @@ const convertExecArgv = function(execArgv) {
 
 ChildPool.prototype.retain = function(processFile) {
   const _this = this;
-  let child = _this.getFree(processFile).pop();
+  const child = _this.getFree(processFile).pop();
 
   if (child) {
     _this.retained[child.pid] = child;
     return Promise.resolve(child);
   }
 
-  return convertExecArgv(process.execArgv).then(execArgv => {
-    child = fork(path.join(__dirname, './master.js'), {
-      execArgv
-    });
-    child.processFile = processFile;
-
+  return this.forkChild(processFile).then(child => {
     _this.retained[child.pid] = child;
-
-    child.on('exit', _this.remove.bind(_this, child));
 
     return initChild(child, child.processFile).then(() => {
       return child;
     });
   });
+};
+
+ChildPool.prototype.addFreeChild = function(processFile) {
+  return this.forkChild(processFile).then(child => {
+    this.getFree(child.processFile).push(child);
+    return initChild(child, child.processFile).then(() => child);
+    })
+};
+
+ChildPool.prototype.forkChild =  function(processFile) {
+  const _this = this;
+  return convertExecArgv(process.execArgv).then(execArgv => {
+    const child = fork(path.join(__dirname, './master.js'), {
+      execArgv
+    });
+    child.processFile = processFile;
+    child.on('exit', _this.remove.bind(_this, child));
+    return child;
+  })
 };
 
 ChildPool.prototype.release = function(child) {
@@ -70,7 +82,9 @@ ChildPool.prototype.release = function(child) {
 };
 
 ChildPool.prototype.remove = function(child) {
-  delete this.retained[child.pid];
+  if(child.pid in this.retained) {
+    delete this.retained[child.pid];
+  }
 
   const free = this.getFree(child.processFile);
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -72,7 +72,6 @@ const MINIMUM_REDIS_VERSION = '2.8.18';
       retryProcessDelay?: number = 5000,
       drainDelay?: number = 5
       isSharedChildPool?: boolean = false
-      initChildPool?: boolean = false
     }
   }
 
@@ -219,16 +218,10 @@ const Queue = function Queue(name, url, opts) {
     drainDelay: 5,
     backoffStrategies: {},
     isSharedChildPool: false,
-    initChildPool: false
   });
 
   this.settings.lockRenewTime =
     this.settings.lockRenewTime || this.settings.lockDuration / 2;
-
-  if(this.settings.initChildPool === true) {
-    const isSharedChildPool = this.settings.isSharedChildPool;
-    this.childPool = this.getChildPool(isSharedChildPool)
-  }
 
   this.on('error', () => {
     // Dummy handler to avoid process to exit with an unhandled exception.
@@ -651,10 +644,6 @@ Queue.prototype.start = function(concurrency, name) {
     throw err;
   });
 };
-
-Queue.prototype.getChildPool = function(isSharedChildPool) {
-  return this.childPool || require('./process/child-pool')(isSharedChildPool);
-}
 
 Queue.prototype.setHandler = function(name, handler) {
   if (!handler) {
@@ -1318,6 +1307,16 @@ Queue.prototype.whenCurrentJobsFinished = function() {
     () => forcedReconnection
   );
 };
+
+Queue.prototype.getChildPool = function(isSharedChildPool) {
+  return this.childPool || require('./process/child-pool')(isSharedChildPool);
+}
+
+Queue.prototype.initChildPool = function (processFile) {
+  const isSharedChildPool = this.settings.isSharedChildPool;
+  this.childPool = this.getChildPool(isSharedChildPool);
+  return this.childPool.addFreeChild(processFile)
+}
 
 //
 // Private local functions

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -72,6 +72,7 @@ const MINIMUM_REDIS_VERSION = '2.8.18';
       retryProcessDelay?: number = 5000,
       drainDelay?: number = 5
       isSharedChildPool?: boolean = false
+      initChildPool?: boolean = false
     }
   }
 
@@ -218,10 +219,16 @@ const Queue = function Queue(name, url, opts) {
     drainDelay: 5,
     backoffStrategies: {},
     isSharedChildPool: false,
+    initChildPool: false
   });
 
   this.settings.lockRenewTime =
     this.settings.lockRenewTime || this.settings.lockDuration / 2;
+
+  if(this.settings.initChildPool === true) {
+    const isSharedChildPool = this.settings.isSharedChildPool;
+    this.childPool = this.getChildPool(isSharedChildPool)
+  }
 
   this.on('error', () => {
     // Dummy handler to avoid process to exit with an unhandled exception.
@@ -645,6 +652,10 @@ Queue.prototype.start = function(concurrency, name) {
   });
 };
 
+Queue.prototype.getChildPool = function(isSharedChildPool) {
+  return this.childPool || require('./process/child-pool')(isSharedChildPool);
+}
+
 Queue.prototype.setHandler = function(name, handler) {
   if (!handler) {
     throw new Error('Cannot set an undefined handler');
@@ -665,8 +676,7 @@ Queue.prototype.setHandler = function(name, handler) {
       throw new Error('File ' + processorFile + ' does not exist');
     }
     const isSharedChildPool = this.settings.isSharedChildPool;
-    this.childPool =
-      this.childPool || require('./process/child-pool')(isSharedChildPool);
+    this.childPool = this.getChildPool(isSharedChildPool);
 
     const sandbox = require('./process/sandbox');
     this.handlers[name] = sandbox(handler, this.childPool).bind(this);

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1313,10 +1313,16 @@ Queue.prototype.getChildPool = function(isSharedChildPool) {
 }
 
 Queue.prototype.initChildPool = function (processFile) {
-  const isSharedChildPool = this.settings.isSharedChildPool;
-  this.childPool = this.getChildPool(isSharedChildPool);
-  return this.childPool.addFreeChild(processFile)
+  if(!this.childPool) {
+    const isSharedChildPool = this.settings.isSharedChildPool;
+    this.childPool = this.getChildPool(isSharedChildPool);
+  }
+  if(Object.keys(this.childPool).length === 0 ||
+    this.childPool.getFree(processFile).length === 0) {
+    return this.childPool.addFreeChild(processFile)
+  }
 }
+
 
 //
 // Private local functions

--- a/test/test_sandboxed_process.js
+++ b/test/test_sandboxed_process.js
@@ -485,4 +485,33 @@ describe('sandboxed process', () => {
 
     expect(queueA.childPool).to.not.be.equal(queueB.childPool);
   })
+
+  it('should initialized childPool if initChildPool is passed in the constructor', async () => {
+    const queue = await utils.newQueue('queue', { settings: { initChildPool: true } });
+
+    expect(queue.childPool).to.not.be.null
+  })
+
+  it('should not initialized childPool if initChildPool is false', async () => {
+    const queue = await utils.newQueue('queue', { settings: { initChildPool: false } });
+
+    expect(queue.childPool).to.be.undefined
+  })
+
+  it('should initialized childPool and still be able to process jobs', async () => {
+    const queue = await utils.newQueue('queue', { settings: { initChildPool: true } });
+
+    expect(queue.childPool).to.not.be.null
+
+    const processFile = __dirname + '/fixtures/fixture_processor.js';
+
+    queue.process(processFile)
+
+    queue.add({ foo: 'bar' });
+
+    const { job, value } = await utils.waitForQueueToProcessJob(queue);
+
+    expect(job.data).to.be.eql({ foo: 'bar' });
+    expect(value).to.be.eql(42);
+  })
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -49,11 +49,14 @@ function sleep(ms) {
   });
 }
 
-function waitForQueueToProcessJob(queue) {
-  return new Promise(resolve => {
+function waitForQueueToCompleteJob(queue) {
+  return new Promise((resolve, reject) => {
     queue.on('completed', (job, value) => {
       resolve({ job, value })
     })
+    queue.on('failed', (job, err) => {
+      reject({job, err})
+    });
   });
 }
 
@@ -64,5 +67,5 @@ module.exports = {
   newQueue,
   cleanupQueues,
   sleep,
-  waitForQueueToProcessJob
+  waitForQueueToCompleteJob
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -49,11 +49,20 @@ function sleep(ms) {
   });
 }
 
+function waitForQueueToProcessJob(queue) {
+  return new Promise(resolve => {
+    queue.on('completed', (job, value) => {
+      resolve({ job, value })
+    })
+  });
+}
+
 module.exports = {
   simulateDisconnect,
   buildQueue,
   cleanupQueue,
   newQueue,
   cleanupQueues,
-  sleep
+  sleep,
+  waitForQueueToProcessJob
 };


### PR DESCRIPTION
* my team needed the ability to load the child pool process and have it available before we start consuming jobs.
* Below in the PR or changes to enable the child poor class to initialize a forked process manually.
* It is infamously known that forking and NodeJS is slow and by having the child process ready at runtime we hope to reduce the time it takes to consume the first job. 