### PR TITLE
feat: have Queue#clean consult job.{finishedOn,processedOn}

### DIFF
--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -60,7 +60,20 @@ while ((limit <= 0 or deletedCount < limit) and next(jobIds, nil) ~= nil) do
 
     local jobKey = jobKeyPrefix .. jobId
     if (rcall("EXISTS", jobKey .. ":lock") == 0) then
-      jobTS = rcall("HGET", jobKey, "timestamp")
+      -- Find the right timestamp of the job to compare to maxTimestamp:
+      -- * finishedOn says when the job was completed, but it isn't set unless the job has actually completed
+      -- * processedOn represents when the job was last attempted, but it doesn't get populated until the job is first tried
+      -- * timestamp is the original job submission time
+      -- Fetch all three of these (in that order) and use the first one that is set so that we'll leave jobs that have been active within the grace period:
+      for _, ts in ipairs(rcall("HMGET", jobKey, "finishedOn", "processedOn", "timestamp")) do
+        if (ts) then
+          jobTS = ts
+          break
+        end
+      end
+      if (not jobTS) then
+        jobTS = rcall("HGET", jobKey, "timestamp")
+      end
       if (not jobTS or jobTS < maxTimestamp) then
         if isList then
           rcall("LREM", setKey, 0, jobId)

--- a/lib/commands/cleanJobsInSet-3.lua
+++ b/lib/commands/cleanJobsInSet-3.lua
@@ -71,9 +71,6 @@ while ((limit <= 0 or deletedCount < limit) and next(jobIds, nil) ~= nil) do
           break
         end
       end
-      if (not jobTS) then
-        jobTS = rcall("HGET", jobKey, "timestamp")
-      end
       if (not jobTS or jobTS < maxTimestamp) then
         if isList then
           rcall("LREM", setKey, 0, jobId)

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2876,10 +2876,12 @@ describe('Queue', () => {
       queue.on(
         'completed',
         _.after(2, () => {
-          queue.clean(0).then(jobs => {
-            expect(jobs.length).to.be.eql(2);
-            done();
-          }, done);
+          delay(200).then(() => {
+            queue.clean(0).then(jobs => {
+              expect(jobs.length).to.be.eql(2);
+              done();
+            }, done);
+          });
         })
       );
     });

--- a/test/test_queue.js
+++ b/test/test_queue.js
@@ -2911,6 +2911,29 @@ describe('Queue', () => {
         });
     });
 
+    it('should leave a job that was queued before but processed within the grace period', done => {
+      queue.process((job, jobDone) => {
+        jobDone();
+      });
+      queue.add({ some: 'data' });
+      queue.add({ some: 'data' }, { delay: 100 });
+      delay(200)
+        .then(() => {
+          // At this point both jobs have executed, but the delayed one was only processed about 100 milliseconds ago:
+          return queue.clean(150);
+        })
+        .then(() => {
+          return queue.getCompleted();
+        })
+        .then(jobs => {
+          expect(jobs.length).to.be.eql(1);
+          return queue.empty();
+        })
+        .then(() => {
+          done();
+        });
+    });
+
     it('should clean all failed jobs', done => {
       queue.add({ some: 'data' });
       queue.add({ some: 'data' });


### PR DESCRIPTION
Background: In our bull installation we're cleaning out failed jobs after 24 hours by periodically running `await queue.clean(24 * 60 * 60 * 1000, 'failed');`. Yesterday we had a big workload and ran into some fairly troublesome jobs that had to be tried multiple times, but still failed in the end. This morning I was expecting that they were still around so I could make some tweaks and retry them, but I found that they had been cleaned out despite having been attempted within the last 24 hours.

I looked into it and found that `Queue#clean` always compares [uses the job's `timestamp` when determining whether it falls within the grace period](https://github.com/OptimalBits/bull/blob/develop/lib/commands/cleanJobsInSet-3.lua#L63). That feels undesirable in a situation like the above. Seems fairly easy to also have it look at when the job was last processed and when it finished, so I went ahead and implemented that.

LMK what you think 🤗 