### PR TITLE
fix: replace the no longer supported test/mocha.opts by .mocharc.json

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "timeout": 5000,
+  "reporter": "spec",
+  "exit": true
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---reporter spec
---timeout 5000
---exit


### PR DESCRIPTION
When [mocha was upgraded to 8.x](https://github.com/OptimalBits/bull/commit/923ef0c17bf5ffeb2894f82c81007dba1a0909bd#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R47), the mocha configuration stopped applying because [`test/mocha.opts` was unsupported in 8.0.0](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#800--2020-06-10). This meant that test timeout went back to the default 2 seconds.