### PR TITLE
fix: unlock job when moving it to delayed

### DIFF
--- a/lib/commands/moveToDelayed-3.lua
+++ b/lib/commands/moveToDelayed-3.lua
@@ -1,7 +1,7 @@
 --[[
   Moves job from active to delayed set.
 
-  Input: 
+  Input:
     KEYS[1] active key
     KEYS[2] delayed key
     KEYS[3] job key
@@ -21,20 +21,26 @@
 local rcall = redis.call
 
 if rcall("EXISTS", KEYS[3]) == 1 then
+  local lockKey
+  local lock
 
   -- Check for job lock
   if ARGV[3] ~= "0" then
-    local lockKey = KEYS[3] .. ':lock'
-    local lock = rcall("GET", lockKey)
+    lockKey = KEYS[3] .. ':lock'
+    lock = rcall("GET", lockKey)
     if lock ~= ARGV[3] then
       return -2
     end
   end
-  
+
   local score = tonumber(ARGV[1])
   rcall("ZADD", KEYS[2], score, ARGV[2])
   rcall("PUBLISH", KEYS[2], (score / 0x1000))
   rcall("LREM", KEYS[1], 0, ARGV[2])
+
+  if lock then
+    rcall("DEL", lockKey)
+  end
 
   return 0
 else


### PR DESCRIPTION
Hi! For various reasons I'm using a rather high `lockDuration` setting in my app, and I noticed that jobs that fail an attempt and have to be moved to `delayed` remain locked. This means that I cannot easily remove such a job from our small homegrown queue control app, as it isn't the lock-taker.

When I tried to figure out what was going on, I noticed this comment: https://github.com/OptimalBits/bull/blob/61a87a8509bfc9227775084839544c444d69994d/lib/job.js#L309

... However, it seems like the job isn't actually being unlocked by `moveToDelayed-3`, so I tried fixing that 😇 