### PR TITLE
fix(stalled-jobs): move stalled jobs to wait in batches

### DIFF
--- a/lib/commands/moveStalledJobsToWait-7.lua
+++ b/lib/commands/moveStalledJobsToWait-7.lua
@@ -22,6 +22,19 @@
 
 local rcall = redis.call
 
+local function batches(n, batchSize)
+  local i = 0
+
+  return function()
+    local from = i * batchSize + 1
+    i = i + 1
+    if (from <= n) then
+      local to = math.min(from + batchSize - 1, n)
+      return from, to
+    end
+  end
+end
+
 -- Check if we need to check for stalled jobs now.
 if rcall("EXISTS", KEYS[5]) == 1 then
   return {{}, {}}
@@ -77,8 +90,11 @@ end
 
 -- Mark potentially stalled jobs
 local active = rcall('LRANGE', KEYS[3], 0, -1)
-if(#active > 0) then
-  rcall('SADD', KEYS[1], unpack(active))
+
+if (#active > 0) then
+  for from, to in batches(#active, 7000) do
+    rcall('SADD', KEYS[1], unpack(active, from, to))
+  end
 end
 
 return {failed, stalled}


### PR DESCRIPTION
This is a backport of this fix from BullMQ https://github.com/taskforcesh/bullmq/pull/625


We currently encounter the following error in production:

> ERR Error running script (call to f_ff9c18634832b0b4115a19b4de5f4788a7cfbd4e): @user_script:81: user_script:81: too many results to unpack 