### PR TITLE
(DOCS) Update REFERENCE.md to note a performance footgun

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -833,7 +833,7 @@ Returns a promise that resolves to a Metrics object.
 clean(grace: number, status?: string, limit?: number): Promise<number[]>
 ```
 
-Tells the queue remove jobs of a specific type created outside of a grace period.
+Tells the queue remove jobs of a specific type created outside of a grace period. **Note:** this operation is expensive and _should not_ be utilized on large queues (e.g., queues with over 100,000 tasks).
 
 #### Example
 


### PR DESCRIPTION
At my company, we ran `queue.clean(0, "waiting");` on a queue with 1.5 million tasks enqueued (we know this is the original sin, but it happened). Locally, on a couple thousand tasks, this method worked almost instantly. But in our lower environments, the Lua script it runs pinned our Redis server to 100% CPU for **over 18 hours** while it worked. The database stopped responding to any commands, and we could not shut it off, even through the GCP hosted databases console.

We had to replace our Redis database (the service stopped responding entirely) for the environment. Luckily, we did not run this on production, or we would have been EXTRA boned. I only blocked the company for around 3 hours before we were able to recover. 😢

Note: as of 10:40am central US time, the script is still running, and the server won't respond to commands. If this wasn't blocking our developers and QA team, we might be interested to see how danged long it takes.