### PR TITLE
support .cjs files + able to call from es6 modules

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -676,7 +676,7 @@ Queue.prototype.setHandler = function(name, handler) {
   this.setWorkerName();
 
   if (typeof handler === 'string') {
-    const supportedFileTypes = ['.js', '.ts', '.flow'];
+    const supportedFileTypes = ['.js', '.ts', '.flow', '.cjs'];
     const processorFile =
       handler +
       (supportedFileTypes.includes(path.extname(handler)) ? '' : '.js');


### PR DESCRIPTION
Fixed support for ".cjs" files which now adds the ability for sandboxed processors to be called from es6 modules. Previous default behavior was adding .js after .cjs which results in error.