### PR TITLE
Document ioredis' lazyConnect misbehavior with Bull

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -97,6 +97,8 @@ interface RateLimiter {
 `RedisOpts` are passed directly to ioredis constructor, check [ioredis](https://github.com/luin/ioredis/blob/master/API.md)
 for details. We document here just the most important ones.
 
+> Note however that enabling `lazyConnect` does not seem to play along well with Bull as referenced in [several](https://github.com/OptimalBits/bull/issues/1945#issuecomment-1008548693) [issues](https://github.com/OptimalBits/bull/issues/2242#issuecomment-1008548166).
+
 ```typescript
 interface RedisOpts {
   port?: number = 6379;


### PR DESCRIPTION
This is a tiny PR in order to reference ioredis's `lazyConnect` misbehavior when used with Bull.

As mentionned in a couple of issues (e.g. https://github.com/OptimalBits/bull/issues/1945 https://github.com/OptimalBits/bull/issues/2242), this PR adds a mention in `REFERENCES.md` for ioredis' `lazyConnect` option, and how it does not seem to work with Bull.