### PR TITLE
fix: error is not handled

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1206,12 +1206,10 @@ Queue.prototype.getNextJob = async function() {
         return this.moveToActive(jobId);
       }
     } catch (err) {
-      err => {
-        // Swallow error if locally paused since we did force a disconnection
-        if (!(this.paused && err.message === 'Connection is closed.')) {
-          throw err;
-        }
-      };
+      // Swallow error if locally paused since we did force a disconnection
+      if (!(this.paused && err.message === 'Connection is closed.')) {
+        throw err;
+      }
     }
   } else {
     return this.moveToActive();


### PR DESCRIPTION
The inline arrow function is created, which is not returned nor executed. It prevents the proper error handling.