### PR TITLE
Fix: don't reschedule delay timer if closing

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -945,6 +945,10 @@ Queue.prototype.run = function(concurrency, handlerName) {
   at the next known delayed job.
 */
 Queue.prototype.updateDelayTimer = function() {
+  if (this.closing) {
+    return Promise.resolve();
+  }
+
   return scripts
     .updateDelaySet(this, Date.now())
     .then(nextTimestamp => {


### PR DESCRIPTION
It's sometimes possible the close of bull does not correctly stop the update timer. In some circumstances the update time is stil active after the close call is finished. 

Our process hangs on stopping if the timer is active. Tried multiple times with this fix, and our process always stops 