### PR TITLE
fix(repeat): prevent repeat limit reset

### DIFF
--- a/lib/repeatable.js
+++ b/lib/repeatable.js
@@ -75,17 +75,13 @@ module.exports = function(Queue) {
         });
       };
 
-      if (skipCheckExists) {
-        return createNextJob();
-      }
-
       // Check that the repeatable job hasn't been removed
       // TODO: a lua script would be better here
       return client
         .zscore(this.keys.repeat, repeatKey)
         .then(repeatableExists => {
           // The job could have been deleted since this check
-          if (repeatableExists) {
+          if (!repeatableExists !== !skipCheckExists) {
             return createNextJob();
           }
           return Promise.resolve();

--- a/test/test_repeat.js
+++ b/test/test_repeat.js
@@ -645,15 +645,18 @@ describe('repeat', () => {
     this.clock.setSystemTime(date);
     const nextTick = ONE_SECOND + 500;
 
-    queue
-      .add(
-        'repeat',
-        { foo: 'bar' },
-        { repeat: { limit: 5, cron: '*/1 * * * * *' } }
-      )
-      .then(() => {
-        _this.clock.tick(nextTick);
-      });
+    const addThenTick = () =>
+      queue
+        .add(
+          'repeat',
+          { foo: 'bar' },
+          { repeat: { limit: 5, cron: '*/1 * * * * *' } }
+        )
+        .then(() => {
+          _this.clock.tick(nextTick);
+        });
+
+    addThenTick();
 
     queue.process('repeat', () => {
       // dummy
@@ -664,6 +667,7 @@ describe('repeat', () => {
       _this.clock.tick(nextTick);
       counter++;
       if (counter == 5) {
+        addThenTick();
         utils.sleep(nextTick * 2).then(() => {
           done();
         }, nextTick * 2);


### PR DESCRIPTION
There is a bug with #852 where the counter would reset when app is restarted after limit is reached. In other words, after a repeatable job with limit is added and is repeated until exhaustion, if app is restarted the repeatable job is added again with counter reset to 1 and is repeated again.

I have updated the corresponding test to reflect this bug. The fix is quite easy, just skip adding the repeatable job if it is already added.