### PR TITLE
fix(types): add missing keys to repeat opts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -389,6 +389,11 @@ declare namespace Bull {
      * Number of times the job should repeat at max.
      */
     limit?: number | undefined;
+    
+    /**
+     * The start value for the repeat iteration count.
+     */
+    count?: number | undefined;
   }
 
   interface CronRepeatOptions extends RepeatOptions {
@@ -431,7 +436,14 @@ declare namespace Bull {
     /**
      * Repeat job according to a cron specification
      */
-    repeat?: CronRepeatOptions | EveryRepeatOptions | undefined;
+    repeat?:
+      | ((CronRepeatOptions | EveryRepeatOptions) & {
+          /**
+           * The key for the repeatable job metadata in Redis.
+           */
+          readonly key: string;
+        })
+      | undefined;
 
     /**
      * Backoff setting for automatic retries if the job fails


### PR DESCRIPTION
Add missing keys to `RepeatOptions` in accordance with [docs](https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#repeated-job-details). Fixes #2506.