### PR TITLE
fix(types): add paused to JobCounts interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -507,6 +507,7 @@ declare namespace Bull {
     failed: number;
     delayed: number;
     waiting: number;
+    paused: number;
   }
 
   interface JobInformation {


### PR DESCRIPTION
The `JobCounts` interface is missing the `paused` key. The following code will reproduce the issue:

```js
const queue = new Queue();
console.log(await queue.getJobCounts());
```

Output:
```
{
  waiting: 0,
  active: 0,
  completed: 0,
  failed: 0,
  delayed: 0,
  paused: 0
}
```