### PR TITLE
fix: rate limiter improvement

### DIFF
--- a/lib/commands/moveToActive-8.lua
+++ b/lib/commands/moveToActive-8.lua
@@ -68,7 +68,7 @@ local rateLimit = function(jobId, maxJobs)
 
     if numLimitedJobs > 0 then
       -- Note, add some slack to compensate for drift.
-      delay = ((numLimitedJobs * ARGV[7] * 1.1) /  maxJobs) + tonumber(rcall("PTTL", rateLimiterKey))
+      delay = tonumber(rcall("PTTL", rateLimiterKey)) + ARGV[7] * math.floor(numLimitedJobs / maxJobs)
     end
   end
 
@@ -80,7 +80,7 @@ local rateLimit = function(jobId, maxJobs)
   if (delay == 0) and (jobCounter >= maxJobs) then
     -- Seems like there are no current rated limited jobs, but the jobCounter has exceeded the number of jobs for this unit of time so we need to rate limit this job.
     local exceedingJobs = jobCounter - maxJobs
-    delay = tonumber(rcall("PTTL", rateLimiterKey)) + ((exceedingJobs) * ARGV[7]) / maxJobs
+    delay = tonumber(rcall("PTTL", rateLimiterKey)) + ARGV[7] * math.floor(exceedingJobs / maxJobs)
   end
 
   if delay > 0 then


### PR DESCRIPTION
As described in https://github.com/OptimalBits/bull/issues/2235, the current rate limiter will "lag behind" on processing of jobs once the rate limit has been exceeded. This is because the current implementation will throttle jobs purely based whether there are any delayed jobs, and attempts to "space" out jobs according to the set `max` and `duration`. However, this strategy means that if new jobs come in while processing jobs that have been delayed due to rate limiting, these jobs will be rate limited also, even if the new jobs would not result in the rate limit being exceeded.

The diagram below tries to depict this scenario:

<img src="https://user-images.githubusercontent.com/2518/232035088-5bd03a9a-eb57-425a-9a01-89075fcb79c5.png" width=800>

The proposed solution instead stacks up delayed jobs at the beginning of the next rate limiter "windows".

<img src="https://user-images.githubusercontent.com/2518/232037900-7813f2f2-1114-4d07-9ef5-94403aad5e2e.png" width=800>

The current tests do not expose this behaviour, as this bug does not surface with `max = 1`. I've included tests with combinations of `max`, `duration` and job counts (`numJobs`), which fail with the current implementation, but pass with the proposed solution. They rely on the fact that processing `numJobs` for a specific `max` and `duration` should be processed in a duration from`(Math.ceil(numJobs/max) - 1) * duration)` to `Math.ceil(numJobs/max) * duration`.