### PR TITLE
Fix: ts declaration

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -199,7 +199,7 @@ myQueue.add({ foo: 'bar' }, {
   attempts: 10,
   backoff: {
     type: 'binaryExponential',
-    options: {
+    strategyOptions: {
       delay: 500,
       truncate: 5
     }

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -388,6 +388,7 @@ await queue.add({}, { jobId: 'example' }) // Will not be created, conflicts with
 interface BackoffOpts {
   type: string; // Backoff type, which can be either `fixed` or `exponential`. A custom backoff strategy can also be specified in `backoffStrategies` on the queue settings.
   delay: number; // Backoff delay, in milliseconds.
+  strategyOptions?: any; // Options for custom strategies
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,12 @@ declare namespace Bull {
     limiter?: RateLimiter | undefined;
 
     defaultJobOptions?: JobOptions | undefined;
+
+    metrics?: MetricsOpts; // Configure metrics
+  }
+
+  interface MetricsOpts {
+    maxDataPoints?: number; //  Max number of data points to collect, granularity is fixed at one minute.
   }
 
   interface AdvancedSettings {
@@ -886,6 +892,27 @@ declare namespace Bull {
       status?: JobStatusClean,
       limit?: number
     ): Promise<Array<Job<T>>>;
+
+    /**
+     * Returns a promise that resolves to a Metrics object.
+     * @param type Job metric type either 'completed' or 'failed'
+     * @param start Start point of the metrics, where 0 is the newest point to be returned.
+     * @param end End point of the metrics, where -1 is the oldest point to be returned.
+     * @returns - Returns an object with queue metrics.
+     */
+    getMetrics(
+      type: 'completed' | 'failed', 
+      start?: number, 
+      end?: number
+    ) : Promise<{
+      meta: {
+        count: number;
+        prevTS: number;
+        prevCount: number;
+      };
+      data: number[];
+      count: number;
+    }>
 
     /**
      * Returns a promise that marks the start of a transaction block.


### PR DESCRIPTION
The metrics option and the getMetrics function are missing from the typescript declaration which causes ts errors in projects that use bull. plus the backoff strategyOptions are named "option" in the PATTERNS and in the REFERENCE but in the ts declaration they are called "strategyOptions" which also causes ts to be unhappy.