### PR TITLE
fix(types): rename strategyOptions to options for CustomBackoff

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -199,7 +199,7 @@ myQueue.add({ foo: 'bar' }, {
   attempts: 10,
   backoff: {
     type: 'binaryExponential',
-    strategyOptions: {
+    options: {
       delay: 500,
       truncate: 5
     }

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -388,7 +388,7 @@ await queue.add({}, { jobId: 'example' }) // Will not be created, conflicts with
 interface BackoffOpts {
   type: string; // Backoff type, which can be either `fixed` or `exponential`. A custom backoff strategy can also be specified in `backoffStrategies` on the queue settings.
   delay: number; // Backoff delay, in milliseconds.
-  strategyOptions?: any; // Options for custom strategies
+  options?: any; // Options for custom strategies
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ declare namespace Bull {
      * Options passed into the `ioredis` constructor's `options` parameter.
      * `connectionName` is overwritten with `Queue.clientName()`. other properties are copied
      */
-    redis?: Redis.RedisOptions | string| undefined;
+    redis?: Redis.RedisOptions | string | undefined;
 
     /**
      * When specified, the `Queue` will use this function to create new `ioredis` client connections.
@@ -377,7 +377,7 @@ declare namespace Bull {
     /**
      * Options for custom strategies
      */
-    strategyOptions?: any;
+    options?: any;
   }
 
   interface RepeatOptions {
@@ -395,7 +395,7 @@ declare namespace Bull {
      * Number of times the job should repeat at max.
      */
     limit?: number | undefined;
-    
+
     /**
      * The start value for the repeat iteration count.
      */
@@ -913,10 +913,10 @@ declare namespace Bull {
      * @returns - Returns an object with queue metrics.
      */
     getMetrics(
-      type: 'completed' | 'failed', 
-      start?: number, 
+      type: 'completed' | 'failed',
+      start?: number,
       end?: number
-    ) : Promise<{
+    ): Promise<{
       meta: {
         count: number;
         prevTS: number;
@@ -924,7 +924,7 @@ declare namespace Bull {
       };
       data: number[];
       count: number;
-    }>
+    }>;
 
     /**
      * Returns a promise that marks the start of a transaction block.


### PR DESCRIPTION
This PR align the type definition and the docs with the source code for the custom strategy options.

Fix #2602

I run prettier on save, so some space as been removed in the `index.d.ts` file. I can revert it if it cause any trouble.
