### PR TITLE
upgrade semver version 7.3.2 to 7.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ioredis": "^5.3.2",
     "lodash": "^4.17.21",
     "msgpackr": "^1.5.2",
-    "semver": "^7.3.2",
+    "semver": "^7.5.2",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5904,6 +5904,13 @@ semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semve
   dependencies:
     lru-cache "^6.0.0"
 
+semver@^7.5.2:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
+  integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 serialize-javascript@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"


### PR DESCRIPTION
The lib semver version 7.3.2 has vulnerable (Regular Expression Denial of Service (ReDoS)), 
https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795

Please accept this request!