### PR TITLE
Fix return type of getJobCountByTypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -855,7 +855,7 @@ declare namespace Bull {
     /**
      * Returns a promise that resolves with the job counts for the given queue of the given job statuses.
      */
-    getJobCountByTypes(types: JobStatus[] | JobStatus): Promise<JobCounts>;
+    getJobCountByTypes(types: JobStatus[] | JobStatus): Promise<number>;
 
     /**
      * Returns a promise that resolves with the quantity of completed jobs.


### PR DESCRIPTION
The return type of `getJobCountByTypes(types: JobStatus[] | JobStatus)` is invalid;
It is a number, not a JobCounts;

Another proof is that function `count()` uses `getJobCountByTypes` and yet returns a number;