### PR TITLE
queue.add: deep clone opts #2633

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -732,7 +732,7 @@ Queue.prototype.add = function(name, data, opts) {
     data = name;
     name = Job.DEFAULT_JOB_NAME;
   }
-  opts = { ...this.defaultJobOptions, ...opts };
+  opts = _.cloneDeep({ ...this.defaultJobOptions, ...opts });
 
   opts.jobId = jobIdForGroup(this.limiter, opts, data);
 


### PR DESCRIPTION
fixes #2633 

p.s.: cloning only `repeat` when calling the `nextRepeatableJob` would also work if full deep `opts` clone is not an option.