### PR TITLE
fix: add mising getMetrics type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -832,6 +832,9 @@ declare namespace Bull {
       asc?: boolean
     ): Promise<Array<Job<T>>>;
 
+    /**
+     * Returns a promise that resolves to a Metrics object.
+     */
     getMetrics(type: 'completed' | 'failed', start?: number, end?: number): Promise<{
       meta: {
         count: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -832,6 +832,16 @@ declare namespace Bull {
       asc?: boolean
     ): Promise<Array<Job<T>>>;
 
+    getMetrics(type: 'completed' | 'failed', start?: number, end?: number): Promise<{
+      meta: {
+        count: number;
+        prevTS: number;
+        prevCount: number;
+      };
+      data: number[];
+      count: number;
+    }>
+
     /**
      * Returns a promise that resolves to the next job in queue.
      */


### PR DESCRIPTION
It seems typings are missing the getMetrics method definition.

https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queuegetmetrics