### PR TITLE
chore: update ubuntu build version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write # for release publishing
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 18.04 is deprecated. Didn't test this, but since the action doesn't use any os specific actions, like installing packages, this should work just fine.

![image](https://github.com/OptimalBits/bull/assets/2822030/de64440e-01ab-424a-bdd0-527fa012f3e9)
