### PR TITLE
fix(docs): correct misuse of Error constructor

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -98,7 +98,7 @@ const opts = {
       case 'bclient':
         return new Redis(REDIS_URL, redisOpts);
       default:
-        throw new Error('Unexpected connection type: ', type);
+        throw new Error('Unexpected connection type: ' + type);
     }
   }
 }


### PR DESCRIPTION
Correct the misuse of the Error constructor in the documentation. The second parameter should not be a string.
Link: https://nodejs.org/api/errors.html#class-error
