### PR TITLE
fix: remove stuck as a job state

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -927,7 +927,7 @@ Adds a log row to this job specific job. Logs can be retrieved using [Queue#getJ
 getState(): Promise
 ```
 
-Returns a promise resolving to the current job's status (completed, failed, delayed etc.). Possible returns are: completed, failed, delayed, active, waiting, paused, stuck or null.
+Returns a promise resolving to the current job's status (completed, failed, delayed etc.). Possible returns are: completed, failed, delayed, active, waiting, paused, or null.
 
 Please take note that the implementation of this method is not very efficient, nor is it atomic. If your queue does have a very large quantity of jobs, you may want to avoid using this method.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -247,10 +247,6 @@ declare namespace Bull {
      */
     isPaused(): Promise<boolean>;
 
-    /**
-     * Returns a promise resolving to a boolean which, if true, current job's state is stuck
-     */
-    isStuck(): Promise<boolean>;
 
     /**
      * Returns a promise resolving to the current job's status.
@@ -258,7 +254,7 @@ declare namespace Bull {
      * it atomic. If your queue does have a very large quantity of jobs, you may want to
      * avoid using this method.
      */
-    getState(): Promise<JobStatus | 'stuck'>;
+    getState(): Promise<JobStatus>;
 
     /**
      * Update a specific job's data. Promise resolves when the job has been updated.

--- a/lib/job.js
+++ b/lib/job.js
@@ -422,12 +422,6 @@ Job.prototype.isPaused = function() {
   return this._isInList('paused');
 };
 
-Job.prototype.isStuck = function() {
-  return this.getState().then(state => {
-    return state === 'stuck';
-  });
-};
-
 Job.prototype.isDiscarded = function() {
   return this._discarded;
 };
@@ -452,10 +446,7 @@ Job.prototype.getState = function() {
           return result ? fn.state : null;
         });
       });
-    }, Promise.resolve())
-    .then(result => {
-      return result ? result : 'stuck';
-    });
+    }, Promise.resolve());
 };
 
 Job.prototype.remove = function() {

--- a/test/test_job.js
+++ b/test/test_job.js
@@ -262,11 +262,6 @@ describe('Job', () => {
           .then(stored => {
             expect(stored).to.be(null);
             return job.getState();
-          })
-          .then(state => {
-            // This check is a bit of a hack. A job that is not found in any list will return the state
-            // stuck.
-            expect(state).to.equal('stuck');
           });
       });
     });
@@ -841,11 +836,6 @@ describe('Job', () => {
     return Job.create(queue, { foo: 'baz' })
       .then(job => {
         return job
-          .isStuck()
-          .then(isStuck => {
-            expect(isStuck).to.be(false);
-            return job.getState();
-          })
           .then(state => {
             expect(state).to.be('waiting');
             return scripts.moveToActive(queue).then(() => {
@@ -895,8 +885,7 @@ describe('Job', () => {
             expect(res).to.be(1);
             return job.getState();
           })
-          .then(state => {
-            expect(state).to.be('stuck');
+          .then(() => {
             return client.rpop(queue.toKey('wait'));
           })
           .then(() => {


### PR DESCRIPTION
Removes `stuck` as a valid job state.

Removes the function to check, removes the return of 'stuck' in `getState()`, updates docs and tests to remove "stuck".`