### PR TITLE
docs: Update phrasing to clarify promise usage over done callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ imageQueue.add({ image: 'http://example.com/image1.tiff' });
 
 #### Using promises
 
-Alternatively, you can use return promises instead of using the `done` callback:
+Alternatively, you can return promises instead of using the `done` callback:
 
 ```javascript
 videoQueue.process(function (job) { // don't forget to remove the done callback!


### PR DESCRIPTION
This PR updates the documentation to improve clarity on using promises instead of the done callback. The original phrasing had a slight grammatical issue. This update corrects the grammar and makes the sentence clearer.