### PR TITLE
fix(pool): turn off message handler only if cmd is known

### DIFF
--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -118,7 +118,10 @@ async function initChild(child, processFile) {
       } else if (msg.cmd === 'error') {
         reject(msg.error);
       }
-      child.off('message', onMessageHandler);
+
+      if(msg.cmd !== undefined) {
+          child.off('message', onMessageHandler);
+      }
     };
     child.on('message', onMessageHandler);
   });

--- a/lib/process/child-pool.js
+++ b/lib/process/child-pool.js
@@ -119,7 +119,7 @@ async function initChild(child, processFile) {
         reject(msg.error);
       }
 
-      if(msg.cmd !== undefined) {
+      if(msg.cmd === 'init-complete' || msg.cmd === 'error') {
           child.off('message', onMessageHandler);
       }
     };


### PR DESCRIPTION
There are some cases where node internal processes would be sending messages to child processes(node's new builtin `--watch` for example). 

I've tried to turn off the handler only if the cmd is one of the known ones from bull. Let me know if that makes sense or do you have any other approaches. Thanks