### PR TITLE
fix: bump msgpackr to 1.1.2 to resolve ERR_BUFFER_OUT_OF_BOUNDS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "get-port": "^5.1.1",
     "ioredis": "^5.3.2",
     "lodash": "^4.17.21",
-    "msgpackr": "^1.10.1",
+    "msgpackr": "^1.11.2",
     "semver": "^7.5.2",
     "uuid": "^8.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5090,10 +5090,10 @@ msgpackr-extract@^3.0.2:
     "@msgpackr-extract/msgpackr-extract-linux-x64" "3.0.2"
     "@msgpackr-extract/msgpackr-extract-win32-x64" "3.0.2"
 
-msgpackr@^1.10.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.10.1.tgz#51953bb4ce4f3494f0c4af3f484f01cfbb306555"
-  integrity sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==
+msgpackr@^1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.11.2.tgz#4463b7f7d68f2e24865c395664973562ad24473d"
+  integrity sha512-F9UngXRlPyWCDEASDpTf6c9uNhGPTqnTeLVt7bN+bU1eajoR/8V9ys2BRaV5C/e5ihE6sJ9uPIKaYt6bFuO32g==
   optionalDependencies:
     msgpackr-extract "^3.0.2"
 


### PR DESCRIPTION
This PR updates the `msgpackr` dependency to version 1.1.2 in order to resolve a RangeError [ERR_BUFFER_OUT_OF_BOUNDS]: "length" is outside of buffer bounds error that occurs during job creation. The error originates from the msgpackr library, which is used by Bull for data serialization. 
Upgrading to msgpackr version 1.1.2 includes a fix that addresses this issue.

ref https://github.com/OptimalBits/bull/issues/2782