### PR TITLE
docs: remove outdated TODO comment from finished() method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -284,8 +284,6 @@ declare namespace Bull {
 
     /**
      * Returns a promise that resolves to the returned data when the job has been finished.
-     * TODO: Add a watchdog to check if the job has finished periodically.
-     * since pubsub does not give any guarantees.
      */
     finished(): Promise<any>;
 


### PR DESCRIPTION
The watchdog functionality mentioned in the TODO has already been implemented in lib/job.js. The setInterval-based watchdog checks job completion status periodically using FINISHED_WATCHDOG constant.