### PR TITLE
chore: fix typo "occured" -> "occurred" in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -989,7 +989,7 @@ declare namespace Bull {
     on(event: string, callback: (...args: any[]) => void): this;
 
     /**
-     * An error occured
+     * An error occurred
      */
     on(event: 'error', callback: ErrorEventCallback): this;
 


### PR DESCRIPTION
Fixes a single-character typo in the comment block describing the `error` event handler at index.d.ts:992. Comment-only typo fix, no functional change.